### PR TITLE
Remove filtering IPs on the ingress

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    {{ if .Values.ingress.enable_whitelist }}nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.whitelist | quote }}{{ end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
 spec:
   tls:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,7 +10,6 @@ image:
 
 ingress:
   enabled: true
-  enable_whitelist: true
   hosts:
     - host: hmpps-interventions-service-dev.hmpps.service.justice.gov.uk
       cert_secret: hmpps-interventions-service-cert
@@ -18,11 +17,3 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
-
-whitelist:
-  office: "217.33.148.210/32"
-  health-kick: "35.177.252.195/32"
-  mojvpn: "81.134.202.29/32"
-  cloudplatform-live1-1: "35.178.209.113/32"
-  cloudplatform-live1-2: "3.8.51.207/32"
-  cloudplatform-live1-3: "35.177.252.54/32"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,7 +10,6 @@ image:
 
 ingress:
   enabled: true
-  enable_whitelist: true
   hosts:
     - host: hmpps-interventions-service-preprod.hmpps.service.justice.gov.uk
       cert_secret: hmpps-interventions-service-cert
@@ -18,11 +17,3 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
-
-whitelist:
-  office: "217.33.148.210/32"
-  health-kick: "35.177.252.195/32"
-  mojvpn: "81.134.202.29/32"
-  cloudplatform-live1-1: "35.178.209.113/32"
-  cloudplatform-live1-2: "3.8.51.207/32"
-  cloudplatform-live1-3: "35.177.252.54/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,7 +10,6 @@ image:
 
 ingress:
   enabled: true
-  enable_whitelist: true
   hosts:
     - host: hmpps-interventions-service.hmpps.service.justice.gov.uk
       cert_secret: hmpps-interventions-service-cert
@@ -18,11 +17,3 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
-
-whitelist:
-  office: "217.33.148.210/32"
-  health-kick: "35.177.252.195/32"
-  mojvpn: "81.134.202.29/32"
-  cloudplatform-live1-1: "35.178.209.113/32"
-  cloudplatform-live1-2: "3.8.51.207/32"
-  cloudplatform-live1-3: "35.177.252.54/32"


### PR DESCRIPTION
## What does this pull request do?

Removes IP access list controls from **all** environments.

## What is the intent behind these changes?

Current guidance:

> IP addresses access control lists (and/or techniques such as HTTP basic authentication) should be used to restrict access to non-production systems you do not wish general users to access.

Source: https://ministryofjustice.github.io/security-guidance/authentication/#ip-address-for-non-production-systems

We will

- have production open to the internet,
- have pre-production have the same security measures,
- have no sensitive data on development,
- will use authentication and authorisation on all environments.

Given the above, we don't have a strong use case to restrict access.