### PR TITLE
Remove retrieving AWS secrets during deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
+          retrieve_secrets: "none"
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

Remove retrieving AWS secrets during deployment

## What is the intent behind these changes?

We do not need that functionality yet.

Configured via [hmpps-circleci-orb](https://github.com/ministryofjustice/hmpps-circleci-orb/blob/aa63b0b076d564ba1b4e933fdda7f75065dfa75f/src/jobs/deploy_env.yml#L41).