### PR TITLE
Remove all current secrets

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -13,10 +13,4 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "logstash"
 
-  - name: APPLICATION_INSIGHTS_IKEY
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "app.name" . }}
-        key: APPINSIGHTS_INSTRUMENTATIONKEY
-
 {{- end -}}

--- a/helm_deploy/hmpps-interventions-service/templates/secrets.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/secrets.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "app.name" . }}
-  labels:
-    {{- include "app.labels" . | nindent 4 }}
-type: Opaque
-data:
-  APPINSIGHTS_INSTRUMENTATIONKEY: {{ .Values.secrets.APPINSIGHTS_INSTRUMENTATIONKEY | b64enc | quote }}

--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -1,3 +1,3 @@
 ---
 secrets:
-  APPINSIGHTS_INSTRUMENTATIONKEY: somesecretvalue
+  SECRET: somesecretvalue


### PR DESCRIPTION
## What does this pull request do?

Remove all secrets as we don't need any at the moment.

This, in turn, makes deployment work 🎉 

```
$ helm upgrade hmpps-interventions-service hmpps-interventions-service \
  --install --wait --reset-values --timeout 5m --history-max 10 \
  --values values-dev.yaml --set image.tag="2020-11-17.26.8541d50"
...

$ kubectl get deployment --namespace hmpps-interventions-dev
NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
hmpps-interventions-service   2/2     2            2           17m
```

## What is the intent behind these changes?

We do not currently have any secrets. The `APPINSIGHTS_INSTRUMENTATIONKEY` is not immediately required for us.