### PR TITLE
Fall back to default Cloud Platform ingress hosts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,8 +12,7 @@ ingress:
   enabled: true
   enable_whitelist: true
   hosts:
-    - host: hmpps-interventions-service-dev.hmpps.service.justice.gov.uk
-      cert_secret: hmpps-interventions-service-cert
+    - host: hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   path: /
 
 env:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,8 +12,7 @@ ingress:
   enabled: true
   enable_whitelist: true
   hosts:
-    - host: hmpps-interventions-service-preprod.hmpps.service.justice.gov.uk
-      cert_secret: hmpps-interventions-service-cert
+    - host: hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
   path: /
 
 env:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,8 +12,7 @@ ingress:
   enabled: true
   enable_whitelist: true
   hosts:
-    - host: hmpps-interventions-service.hmpps.service.justice.gov.uk
-      cert_secret: hmpps-interventions-service-cert
+    - host: hmpps-interventions-service-prod.apps.live-1.cloud-platform.service.justice.gov.uk
   path: /
 
 env:


### PR DESCRIPTION
## What does this pull request do?

Fall back to default Cloud Platform hosts instead of `{...}.hmpps.service.justice.gov.uk`.

## What is the intent behind these changes?

We do not have a custom domain setup in the environment yet. At this point in time, we don't really need one.