### PR TITLE
add snyk dependency scanning to build and nightly pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,6 @@ orbs:
   hmpps: ministryofjustice/hmpps@1.1.3
   snyk: snyk/snyk@0.0.12
 
-_snyk_options: &snyk_options
-  organization: "digital-probation-services"
-  severity-threshold: "high" # note: this does not affect snyk 'monitor' commands
-  fail-on-issues: true
-
 jobs:
   validate:
     executor: hmpps/java
@@ -40,7 +35,9 @@ jobs:
       - snyk/scan:
           project: '${CIRCLE_PROJECT_REPONAME}'
           monitor-on-build: << parameters.monitor >>
-          <<: *snyk_options
+          organization: "digital-probation-services"
+          severity-threshold: "high" # note: this does not affect snyk 'monitor' commands
+          fail-on-issues: true
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 
 orbs:
-  owasp: entur/owasp@0.0.13
   hmpps: ministryofjustice/hmpps@1.1.3
+  snyk: snyk/snyk@0.0.12
+
+_snyk_options: &snyk_options
+  organization: "digital-probation-services"
+  severity-threshold: "high" # note: this does not affect snyk 'monitor' commands
+  fail-on-issues: true
 
 jobs:
   validate:
@@ -24,9 +29,22 @@ jobs:
       - store_artifacts:
           path: build/reports/tests
 
+  vulnerability_scan:
+    executor: hmpps/java
+    parameters:
+      monitor:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - snyk/scan:
+          project: '${CIRCLE_PROJECT_REPONAME}'
+          monitor-on-build: << parameters.monitor >>
+          <<: *snyk_options
+
 workflows:
   version: 2
-  build-test-and-deploy:
+  build_test_and_deploy:
     jobs:
       - validate:
           filters:
@@ -40,6 +58,18 @@ workflows:
           filters:
             branches:
               only:
+                - main
+      - vulnerability_scan:
+          name: vulnerability_scan_and_monitor
+          monitor: true
+          filters:
+            branches:
+              only:
+                - main
+      - vulnerability_scan:
+          filters:
+            branches:
+              ignore:
                 - main
       - hmpps/build_docker:
           name: build_docker
@@ -62,7 +92,7 @@ workflows:
             - build_and_publish_docker
             - helm_lint
 
-  scheduled:
+  nightly:
     triggers:
       - schedule:
           cron: "0 7 * * 1-5"
@@ -71,5 +101,9 @@ workflows:
               only:
                 - main
     jobs:
-      - owasp/gradle_owasp_dependency_check:
-          executor: hmpps/java
+      - vulnerability_scan:
+          name: vulnerability_scan_and_monitor
+          monitor: true
+      - hmpps/build_docker:
+          publish: false
+          snyk-scan: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ workflows:
             - validate
             - build_and_publish_docker
             - helm_lint
+            - vulnerability_scan_and_monitor
 
   nightly:
     triggers:


### PR DESCRIPTION
## What does this pull request do?

adds snyk scanning to build and nightly pipelines:

- scans on PRs provide results and fail builds if any known high severity CVEs are found. 
- scans on `main` also fail builds on high severity CVEs, but also post the results to the snyk platform for monitoring
- nightly scans run on the docker image and app dependencies 

## What is the intent behind these changes?

be aware of CVEs before they end up in production. block deploys with known high severity CVEs. 
