### PR TITLE
Add resource server config to secure api endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This is the HMPPS Interventions Service
 
 ## Quickstart
 
+### Requirements
+
+- Docker 
+- Java
+
 Build and test:
 ```
 ./gradlew build
@@ -11,7 +16,9 @@ Build and test:
 
 Run:
 ```
-./gradlew bootRun
+docker-compose pull
+docker-compose up -d
+SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
 ```
 
 ## Architecture

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
 version: "3"
 services:
-  hmpps-interventions-service:
-    build:
-      context: .
-    network_mode: "host"
-    container_name: hmpps-interventions-service
+  hmpps-auth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    networks:
+      - hmpps
+    container_name: hmpps-auth
     ports:
-      - "8081:8080"
+      - "8090:8080"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
 
 networks:
   hmpps:

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -13,4 +13,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "logstash"
 
+  - name: HMPPS_AUTH_BASEURL
+    value: "{{ .Values.env.HMPPS_AUTH_BASEURL }}"
+
 {{- end -}}

--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -1,3 +1,4 @@
 ---
 secrets:
-  SECRET: somesecretvalue
+  INTERVENTIONS_SERVICE_CLIENT_ID: clientid
+  INTERVENTIONS_SERVICE_CLIENT_SECRET: clientsecret

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+
+@Configuration
+@EnableWebSecurity
+class ResourceServerConfiguration : WebSecurityConfigurerAdapter() {
+  // todo: add custom token validator which calls token verification service
+  override fun configure(http: HttpSecurity) {
+    http
+      .sessionManagement()
+      .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+      .and().csrf().disable()
+      .authorizeRequests {
+        it.antMatchers("/health/**", "/info", "/test/**").permitAll()
+        it.anyRequest().hasAuthority("ROLE_INTERVENTIONS")
+      }
+      .oauth2ResourceServer().jwt().jwtAuthenticationConverter(jwtAuthenticationConverter())
+  }
+
+  @Bean
+  fun jwtAuthenticationConverter(): JwtAuthenticationConverter {
+    // hmpps auth tokens have roles in a custom `authorities` claim.
+    // the authorities are already prefixed with `ROLE_`.
+    val grantedAuthoritiesConverter = JwtGrantedAuthoritiesConverter()
+    grantedAuthoritiesConverter.setAuthoritiesClaimName("authorities")
+    grantedAuthoritiesConverter.setAuthorityPrefix("")
+
+    val jwtAuthenticationConverter = JwtAuthenticationConverter()
+    jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(grantedAuthoritiesConverter)
+    return jwtAuthenticationConverter
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SecureController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SecureController.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import java.time.Instant
+
+data class SecureResponse(
+  val client: String?,
+  val roles: List<String>,
+  val tokenExpiry: Instant?
+)
+
+// fixme: this class is purely here to illustrate a secure endpoint. will be removed in near future.
+@Controller
+class SecureController {
+  @GetMapping("/secure")
+  @ResponseBody
+  fun secure(authentication: JwtAuthenticationToken): SecureResponse {
+    val expiry = authentication.token.expiresAt
+    return SecureResponse(authentication.name, authentication.authorities.map { it.authority }, expiry)
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,8 @@
+hmpps-auth:
+  baseurl: http://localhost:8090/auth
+
+logging:
+  level:
+    org:
+      springframework:
+        security: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,11 +7,16 @@ spring:
     name: hmpps-interventions-service
   codec:
     max-in-memory-size: 10MB
-
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${hmpps-auth.baseurl}/issuer
+          jwk-set-uri: ${hmpps-auth.baseurl}/.well-known/jwks.json
 
 server:
   port: 8080

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
@@ -7,7 +7,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles("test", "local")
 abstract class IntegrationTestBase {
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")


### PR DESCRIPTION
## What does this pull request do?

Adds resource server configuration for creating secure endpoints. 

Adds a sample endpoint for testing in dev environment. response looks like 

```
{
    "client": "interventions",
    "roles": [
        "ROLE_INTERVENTIONS",
        "ROLE_AUTH_DELIUS_LDAP",
        "ROLE_COMMUNITY"
    ],
    "tokenExpiry": "2020-11-26T12:11:00Z"
}
```

## What is the intent behind these changes?

scaffolding to allow development of secure endpoints  
