### PR TITLE
ignore base image vulns with no upgrade path for 2 months

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ orbs:
   hmpps: ministryofjustice/hmpps@1.1.3
   snyk: snyk/snyk@0.0.12
 
+_snyk_options: &snyk_options
+  snyk-scan: true
+  snyk-fail-build: true
+  snyk-args: --policy-path=.snyk --configuration-matching='^((?!test).)*$'
+
 jobs:
   validate:
     executor: hmpps/java
@@ -51,7 +56,7 @@ workflows:
           name: helm_lint
       - hmpps/build_docker:
           name: build_and_publish_docker
-          snyk-scan: false # fixme!
+          <<: *snyk_options
           filters:
             branches:
               only:
@@ -71,7 +76,7 @@ workflows:
       - hmpps/build_docker:
           name: build_docker
           publish: false
-          snyk-scan: false # fixme!
+          <<: *snyk_options
           filters:
             branches:
               ignore:
@@ -104,4 +109,4 @@ workflows:
           monitor: true
       - hmpps/build_docker:
           publish: false
-          snyk-scan: true
+          <<: *snyk_options

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,47 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-DEBIAN10-SYSTEMD-345386:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-SYSTEMD-345391:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-SYSTEMD-346788:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-LIBSSH2-452460:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-LIBIDN2-474100:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-GNUTLS28-609778:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-GLIBC-559488:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-GLIBC-559493:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-GCC8-347558:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+  SNYK-DEBIAN10-GCC8-469413:
+    - '*':
+        reason: base image vuln with no upgrade path; will reassess in 2 months
+        expiry: 2021-02-01T00:00:00.000Z
+
+patch: {}


### PR DESCRIPTION
## What does this pull request do?

ignore the 10 high severity CVEs which are currently found in the docker base image. the ignore config expires in 2 months so we can reasses the image then.

## What is the intent behind these changes?

unblock the deploy. ensure we look at the image again before release by setting expiry dates.
