### PR TITLE
add helm env vars for hmpps auth baseurl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
 
   postgres:
-    image: postgres:13
+    image: postgres:13-alpine
     container_name: postgres
     ports:
       - "5432:5432"

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -13,7 +13,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "logstash"
 
-  - name: HMPPS_AUTH_BASEURL
-    value: "{{ .Values.env.HMPPS_AUTH_BASEURL }}"
+  - name: HMPPSAUTH_BASEURL
+    value: "{{ .Values.env.HMPPSAUTH_BASEURL }}"
 
 {{- end -}}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,3 +16,4 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
+  HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,3 +16,4 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
+  HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,3 +16,4 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
+  HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,4 @@
-hmpps-auth:
+hmppsauth:
   baseurl: http://localhost:8090/auth
 
 postgres:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,8 +15,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${hmpps-auth.baseurl}/issuer
-          jwk-set-uri: ${hmpps-auth.baseurl}/.well-known/jwks.json
+          issuer-uri: ${hmppsauth.baseurl}/issuer
+          jwk-set-uri: ${hmppsauth.baseurl}/.well-known/jwks.json
   datasource:
     url: jdbc:postgresql://${postgres.uri}/${postgres.db}
     username: ${postgres.username}


### PR DESCRIPTION
## What does this pull request do?

adds required env vars for hmpps auth config

## What is the intent behind these changes?

fix the deploy

----

At startup, we were getting a `CrashLoopBackOff` on the pods, with this log:

```
2020-11-30 15:54:28.512 ERROR 1 --- [           main] o.s.boot.SpringApplication               : Application run failed |

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'springSecurityFilterChain' defined in class path resource [org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [javax.servlet.Filter]: Factory method 'springSecurityFilterChain' threw exception; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'jwtDecoderByJwkKeySetUri' defined in class path resource [org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration$JwtDecoderConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.security.oauth2.jwt.JwtDecoder]: Factory method 'jwtDecoderByJwkKeySetUri' threw exception; nested exception is java.lang.IllegalArgumentException: Invalid JWK Set URL "/.well-known/jwks.json" : no protocol: /.well-known/jwks.json
<snip>
Caused by: java.net.MalformedURLException: no protocol: /.well-known/jwks.json
```