### PR TITLE
add minimal skeleton code for referral creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,12 @@ jobs:
       monitor:
         type: boolean
         default: false
+      snyk-scan:
+        type: boolean
+      snyk-fail-build:
+        type: boolean
+      snyk-args:
+        type: string
     steps:
       - checkout
       - snyk/scan:
@@ -50,7 +56,9 @@ jobs:
           monitor-on-build: << parameters.monitor >>
           organization: "digital-probation-services"
           severity-threshold: "high" # note: this does not affect snyk 'monitor' commands
-          fail-on-issues: true
+          fail-on-issues: << parameters.snyk-fail-build >>
+          additional-arguments: << parameters.snyk-args >>
+
 
 workflows:
   version: 2
@@ -72,11 +80,13 @@ workflows:
       - vulnerability_scan:
           name: vulnerability_scan_and_monitor
           monitor: true
+          <<: *snyk_options
           filters:
             branches:
               only:
                 - main
       - vulnerability_scan:
+          <<: *snyk_options
           filters:
             branches:
               ignore:
@@ -115,6 +125,7 @@ workflows:
       - vulnerability_scan:
           name: vulnerability_scan_and_monitor
           monitor: true
+          <<: *snyk_options
       - hmpps/build_docker:
           publish: false
           <<: *snyk_options

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,14 @@ _snyk_options: &snyk_options
 jobs:
   validate:
     executor: hmpps/java
+    docker:
+      - image: cimg/openjdk:11.0
+        environment:
+          POSTGRES_DB: circle_test
+
+      - image: circleci/postgres:13-ram
+        environment:
+          POSTGRES_PASSWORD: password
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.1.1"
   kotlin("plugin.spring") version "1.4.10"
+  id("org.jetbrains.kotlin.plugin.jpa") version "1.4.20"
 }
 
 configurations {
@@ -17,4 +18,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.hibernate:hibernate-core:5.4.24.Final")
   runtimeOnly("org.postgresql:postgresql")
+
+  testImplementation("com.h2database:h2:1.4.200")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=password
     volumes:
-      - ./src/main/resources/db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro
+      - ./src/main/resources/db/init:/docker-entrypoint-initdb.d:ro
 
 networks:
   hmpps:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import java.util.UUID
+
+@RestController
+class ReferralController(private val repository: ReferralRepository) {
+  @PostMapping("/draft-referral")
+  fun createDraftReferral(): ResponseEntity<Referral> {
+    val referral = Referral()
+    repository.save(referral)
+
+    val location = ServletUriComponentsBuilder
+      .fromCurrentRequest()
+      .path("/{id}")
+      .buildAndExpand(referral.id)
+      .toUri()
+
+    return ResponseEntity
+      .created(location)
+      .body(referral)
+  }
+
+  @GetMapping("/draft-referral/{id}")
+  fun getDraftReferralByID(@PathVariable id: String): ResponseEntity<Any> {
+    val uuid = try {
+      UUID.fromString(id)
+    } catch (e: IllegalArgumentException) {
+      return ResponseEntity.badRequest().body("malformed id")
+    }
+
+    return repository.findByIdOrNull(uuid)
+      ?.let { ResponseEntity.ok(it) }
+      ?: ResponseEntity.notFound().build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import org.hibernate.annotations.CreationTimestamp
+import java.util.Date
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+
+@Entity
+data class Referral(
+  @CreationTimestamp var created: Date? = null,
+  @Id @GeneratedValue var id: UUID? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.repository.CrudRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import java.util.UUID
+
+interface ReferralRepository : CrudRepository<Referral, UUID>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
           issuer-uri: ${hmppsauth.baseurl}/issuer
           jwk-set-uri: ${hmppsauth.baseurl}/.well-known/jwks.json
   datasource:
+    driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${postgres.uri}/${postgres.db}
     username: ${postgres.username}
     password: ${postgres.password}

--- a/src/main/resources/db/docker-entrypoint-initdb.d/init-db.sh
+++ b/src/main/resources/db/docker-entrypoint-initdb.d/init-db.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    CREATE DATABASE interventions;
-EOSQL

--- a/src/main/resources/db/init/init-db.sql
+++ b/src/main/resources/db/init/init-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE interventions;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/health/HealthCheckTest.kt
@@ -9,9 +9,9 @@ import java.util.function.Consumer
 
 class HealthCheckTest : IntegrationTestBase() {
   @Test
-  fun `Health info reports ok`() {
+  fun `Health page reports ok`() {
     webTestClient.get()
-      .uri("/health/healthInfo")
+      .uri("/health")
       .exchange()
       .expectStatus().isOk
       .expectBody()
@@ -61,12 +61,12 @@ class HealthCheckTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `db reports down (db not currently running for integration tests)`() {
+  fun `db reports ok`() {
     webTestClient.get()
       .uri("/health/db")
       .exchange()
-      .expectStatus().isEqualTo(503)
+      .expectStatus().isOk
       .expectBody()
-      .jsonPath("status").isEqualTo("DOWN")
+      .jsonPath("status").isEqualTo("UP")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+
+@DataJpaTest
+class ReferralRepositoryTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val referralRepository: ReferralRepository
+) {
+
+  @Test
+  fun `when findByIdOrNull then return referral`() {
+    val referrals = listOf(Referral(), Referral())
+    referrals.forEach { entityManager.persist(it) }
+    entityManager.flush()
+
+    val found = referralRepository.findByIdOrNull(referrals[0].id!!)
+    Assertions.assertThat(found).isEqualTo(referrals[0])
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

adds an endpoint for referral creation and a test for the repository interface.

adding the h2 test dependency caused a vulberability scan failure, which alerted me to the fact that snyk configuration is not getting loaded for certain build jobs. so that is fixed in this PR too. 

## What is the intent behind these changes?

get the referral endpoint work off the ground by putting the JPA scaffolding in place 
