### PR TITLE
IC-637: Notify Slack after deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ workflows:
           name: deploy_dev
           env: "dev"
           retrieve_secrets: "none"
+          slack_notification: true
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

Notify Slack after deployments.

They will look similar to

![image](https://user-images.githubusercontent.com/1526295/101176330-3b8e8400-363e-11eb-96e8-6db56697881f.png)


## What is the intent behind these changes?

To raise awareness when deployments happen (and fail (although that does not seem to work yet)).