### PR TITLE
Add 'completionDeadline' field to DraftReferralDTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferral.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import java.time.format.DateTimeFormatter
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
 
 data class DraftReferral(
-  val id: String? = null,
-  val created: String? = null,
+  val id: UUID? = null,
+  val created: OffsetDateTime? = null,
+  val completionDeadline: LocalDate? = null
 ) {
   constructor(referral: Referral) : this(
-    referral.id!!.toString(),
-    DateTimeFormatter.ISO_INSTANT.format(referral.created!!.toInstant()),
+    referral.id!!,
+    referral.created!!,
+    referral.completionDeadline,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralTest.kt
@@ -1,17 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class DraftReferralTest : IntegrationTestBase() {
-
+@JsonTest
+class DraftReferralTest(@Autowired private val json: JacksonTester<DraftReferral>) {
   @Test
   fun `empty input cannot create draft referral`() {
     assertThrows<RuntimeException> {
@@ -38,35 +39,41 @@ class DraftReferralTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `create draft referral dto from referral`() {
-    val createdDate = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
-    val id = UUID.fromString("70d3a47c-d539-4f76-8fc9-1c50e34aea29")
-    val draftReferral = DraftReferral(Referral(id = id, created = createdDate))
-
-    assertThat(draftReferral.id).isEqualTo("70d3a47c-d539-4f76-8fc9-1c50e34aea29")
-    assertThat(draftReferral.created).isEqualTo("2020-12-04T10:42:43Z")
+  fun `test serialization of newly created referral`() {
+    val referral = Referral(
+      id = UUID.fromString("3B9ED289-8412-41A9-8291-45E33E60276C"),
+      created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+    )
+    val out = json.write(DraftReferral(referral))
+    assertThat(out).isEqualToJson(
+      """
+      {"id": "3b9ed289-8412-41a9-8291-45e33e60276c", "created": "2020-12-04T10:42:43Z"}
+    """
+    )
   }
 
   @Test
-  fun `determine json for draft referral dto`() {
-    val uuid = "70d3a47c-d539-4f76-8fc9-1c50e34aea29"
-    val draftReferralJson =
-      """{
-        "id":"$uuid",
-        "created":"2020-12-04T10:42:43Z"
-      }"""
-
-    val mapper = jacksonObjectMapper()
-
-    val draftReferral = DraftReferral(
-      Referral(
-        id = UUID.fromString(uuid),
-        created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
-        completionDeadline = LocalDate.parse("2021-10-05")
-      )
+  fun `test serialization of referral with completionDeadline`() {
+    val referral = Referral(
+      id = UUID.fromString("3B9ED289-8412-41A9-8291-45E33E60276C"),
+      created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+      completionDeadline = LocalDate.of(2021, 2, 12)
     )
-    val serializedDraftReferral = mapper.writeValueAsString(draftReferral)
+    val out = json.write(DraftReferral(referral))
+    assertThat(out).isEqualToJson(
+      """
+      {"id": "3b9ed289-8412-41a9-8291-45e33e60276c", "created": "2020-12-04T10:42:43Z", "completionDeadline": "2021-02-12"}
+    """
+    )
+  }
 
-    assertThat(serializedDraftReferral).isEqualToIgnoringWhitespace(draftReferralJson)
+  @Test
+  fun `test deserialization of partial referral`() {
+    val draftReferral = json.parseObject(
+      """
+      {"completionDeadline": "2021-02-10"}
+    """
+    )
+    assertThat(draftReferral.completionDeadline).isEqualTo(LocalDate.of(2021, 2, 10))
   }
 }


### PR DESCRIPTION

## What does this pull request do?

add completion deadline to the draft referral DTO + a couple of small changes Karen and i discussed to improve the structure:

This change also makes a subtle change to how the DTO is constructed,
allowing the serialization of the fields to take place only when the DTO
is converted to JSON for a response.

This change also includes a test which checks the DTO can be used to
deserialize partial referral updates.

## What is the intent behind these changes?

support for completion deadline field. 
