### PR TITLE
add 'createdByUserId' to draft referral creation 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -32,7 +32,7 @@ class ResourceServerConfiguration : BasicResourceServerConfiguration() {
     http
       .authorizeRequests {
         it.antMatchers("/health/**", "/info", "/test/**").permitAll()
-        it.anyRequest().hasAuthority("ROLE_INTERVENTIONS")
+        it.anyRequest().hasAuthority("ROLE_PROBATION")
       }
       .oauth2ResourceServer().jwt().jwtAuthenticationConverter(jwtAuthenticationConverter())
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.ResponseEntity
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,8 +19,11 @@ import java.util.UUID
 @RestController
 class ReferralController(private val repository: ReferralRepository) {
   @PostMapping("/draft-referral")
-  fun createDraftReferral(): ResponseEntity<DraftReferral> {
-    val referral = Referral()
+  fun createDraftReferral(authentication: JwtAuthenticationToken): ResponseEntity<Any> {
+    val userId = authentication.token.getClaim<String?>("user_id")
+      ?: return ResponseEntity.badRequest().body("no user_id claim in auth token")
+
+    val referral = Referral(createdByUserId = userId)
     repository.save(referral)
 
     val location = ServletUriComponentsBuilder

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -10,6 +10,7 @@ import javax.persistence.Id
 
 @Entity
 data class Referral(
+  var createdByUserId: String? = null,
   var completionDeadline: LocalDate? = null,
   @CreationTimestamp var created: OffsetDateTime? = null,
   @Id @GeneratedValue var id: UUID? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.repository.CrudRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.util.UUID
 
-interface ReferralRepository : CrudRepository<Referral, UUID>
+interface ReferralRepository : CrudRepository<Referral, UUID> {
+  fun findByCreatedByUserId(username: String): List<Referral>
+}

--- a/src/main/resources/db/local/V99_0__draft_referrals.sql
+++ b/src/main/resources/db/local/V99_0__draft_referrals.sql
@@ -1,3 +1,3 @@
-insert into referral (id, created, completion_deadline)
-values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00', '2021-02-14'),
-       ('dfb64747-f658-40e0-a827-87b4b0bdcfed', '2020-12-07 20:45:21.986389+00', '2021-03-01');
+insert into referral (id, created, completion_deadline, created_by_user_id)
+values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00', '2021-02-14', '2500128586'),
+       ('dfb64747-f658-40e0-a827-87b4b0bdcfed', '2020-12-07 20:45:21.986389+00', '2021-03-01', '8751622134');

--- a/src/main/resources/db/migration/V1_1__create_user_table.sql
+++ b/src/main/resources/db/migration/V1_1__create_user_table.sql
@@ -1,0 +1,2 @@
+alter table referral
+    add column created_by_user_id text;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -6,9 +6,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 
 @DataJpaTest
+@ActiveProfiles("test")
 class ReferralRepositoryTest @Autowired constructor(
   val entityManager: TestEntityManager,
   val referralRepository: ReferralRepository
@@ -22,5 +24,25 @@ class ReferralRepositoryTest @Autowired constructor(
 
     val found = referralRepository.findByIdOrNull(referrals[0].id!!)
     Assertions.assertThat(found).isEqualTo(referrals[0])
+  }
+
+  @Test
+  fun `when findByCreatedByUsername then return list of referrals`() {
+    val referrals = listOf(
+      Referral(createdByUserId = "123"),
+      Referral(createdByUserId = "123"),
+      Referral(createdByUserId = "456"),
+    )
+    referrals.forEach { entityManager.persist(it) }
+    entityManager.flush()
+
+    val single = referralRepository.findByCreatedByUserId("456")
+    Assertions.assertThat(single).hasSize(1)
+
+    val multiple = referralRepository.findByCreatedByUserId("123")
+    Assertions.assertThat(multiple).hasSize(2)
+
+    val none = referralRepository.findByCreatedByUserId("789")
+    Assertions.assertThat(none).hasSize(0)
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,6 +2,11 @@ spring:
   profiles:
     include: stdout
 
+  jpa:
+    hibernate:
+      show-sql: true
+      ddl-auto: create
+
 server:
   shutdown: immediate
 


### PR DESCRIPTION
## What does this pull request do?

gets the user id from from auth token for referral creation  which sets the 'createdByUserId' field in the referral entity.

also adds simple repository method to find referrals by username and a test for this.

changes the permissions from custom `ROLE_INTERVENTIONS` to `ROLE_PROBATION` to allow delius users access by default.

## What is the intent behind these changes?

allows us to track who has created referrals and allows us to search for referrals by username.
