### PR TITLE
Move shared ownership to DB migration folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @ministryofjustice/hmpps-interventions
-src/main/resources/db/ @ministryofjustice/interventions-data-engineers
+src/main/resources/db/migration/ @ministryofjustice/interventions-data-engineers


### PR DESCRIPTION
## What does this pull request do?

Move shared code ownership from "All files in the DB folder" to DB migration folder only.

## What is the intent behind these changes?

#29 required data engineering code review for a seed migration change.

The `.../db/local` and `.../db/*` file changes do not require collaboration with data engineering -- we only have to make sure the schema changes are agreed on.