### PR TITLE
Downgrade PostgreSQL versions to match target env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - image: cimg/openjdk:11.0
         environment:
           POSTGRES_DB: circle_test
-      - image: circleci/postgres:13-ram
+      - image: circleci/postgres:11-alpine-ram
         environment:
           POSTGRES_PASSWORD: password
     steps:
@@ -45,7 +45,7 @@ jobs:
       - image: cimg/openjdk:11.0
         environment:
           POSTGRES_DB: circle_test
-      - image: circleci/postgres:13-ram
+      - image: circleci/postgres:11-alpine-ram
         environment:
           POSTGRES_PASSWORD: password
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
 
   postgres:
-    image: postgres:13-alpine
+    image: postgres:11-alpine
     container_name: postgres
     ports:
       - "5432:5432"


### PR DESCRIPTION
## What does this pull request do?

Use PostgreSQL 11 across everything.

## What is the intent behind these changes?

We had to provision PostgreSQL 11 on the (Kubernetes) development environment: this PR is matching all versions of Postgres to avoid surprises.

Reference: https://github.com/ministryofjustice/cloud-platform-environments/pull/3914