### PR TITLE
Ignore base image cve ' CVE-2020-29573/SNYK-DEBIAN10-GLIBC-1048698' until February

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,11 +3,14 @@ version: v1.14.1
 
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-DEBIAN10-GLIBC-1048698:
+     - '*':
+         reason: base image vuln with no upgrade path; will reassess in 2 months
+         expiry: 2021-02-01T00:00:00.000Z
   SNYK-DEBIAN10-GLIBC-1048309:
     - '*':
         reason: base image vuln with no upgrade path; will reassess in 2 months
         expiry: 2021-02-01T00:00:00.000Z
-
   SNYK-DEBIAN10-SYSTEMD-345386:
     - '*':
         reason: base image vuln with no upgrade path; will reassess in 2 months


### PR DESCRIPTION
## What does this pull request do?

Ignores a new CVE found by snyk. there is no upgrade available.

## What is the intent behind these changes?

Provide a successful build
