### PR TITLE
Change resource server config to always require auth tokens, but relax verification for testing 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -16,24 +16,13 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 
 @Configuration
 @EnableWebSecurity
-@Profile("test")
-class BasicResourceServerConfiguration : WebSecurityConfigurerAdapter() {
+class ResourceServerConfiguration : WebSecurityConfigurerAdapter() {
+  // todo: add custom token validator which calls token verification service
   override fun configure(http: HttpSecurity) {
     http
       .sessionManagement()
       .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
       .and().csrf().disable()
-  }
-}
-
-@Configuration
-@EnableWebSecurity
-@Profile("!test")
-class ResourceServerConfiguration : BasicResourceServerConfiguration() {
-  // todo: add custom token validator which calls token verification service
-  override fun configure(http: HttpSecurity) {
-    super.configure(http)
-    http
       .authorizeRequests {
         it.antMatchers("/health/**", "/info", "/test/**").permitAll()
         it.anyRequest().authenticated()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
+import com.nimbusds.jwt.JWTParser
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -7,6 +8,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.MappedJwtClaimSetConverter
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
 
@@ -48,5 +52,27 @@ class ResourceServerConfiguration : BasicResourceServerConfiguration() {
     val jwtAuthenticationConverter = JwtAuthenticationConverter()
     jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(grantedAuthoritiesConverter)
     return jwtAuthenticationConverter
+  }
+
+  @Bean
+  @Profile("test")
+  fun testJwtDecoder(): JwtDecoder {
+    return TestJwtDecoder()
+  }
+}
+
+internal class TestJwtDecoder : JwtDecoder {
+  private val claimSetConverter = MappedJwtClaimSetConverter.withDefaults(emptyMap())
+
+  override fun decode(token: String): Jwt? {
+    // extract headers and claims, but do not attempt to verify signature
+    val jwt = JWTParser.parse(token)
+    val headers = LinkedHashMap<String, Any>(jwt.header.toJSONObject())
+    val claims = claimSetConverter.convert(jwt.getJWTClaimsSet().claims)
+
+    return Jwt.withTokenValue(token)
+      .headers { it.putAll(headers) }
+      .claims { it.putAll(claims) }
+      .build()
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Change resource server config to always require auth tokens, but relaxes token verification for testing 

also reverts 76d02d7

## What is the intent behind these changes?

allow us to test endpoints that require tokens (e.g. endpoints that need to know the user accessing them) with pact
