### PR TITLE
Allow updates to a referral's complexity level 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -57,11 +57,11 @@ class ReferralController(
       return ResponseEntity.badRequest().body("malformed id")
     }
 
-    return referralService.updateDraftReferral(uuid, partialUpdate)
-      ?.let {
-        ResponseEntity.ok(DraftReferral(it))
-      }
-      ?: ResponseEntity.notFound().build()
+    val referralToUpdate = referralService.getDraftReferral(uuid)
+      ?: return ResponseEntity.notFound().build()
+
+    val updatedReferral = referralService.updateDraftReferral(referralToUpdate, partialUpdate)
+    return ResponseEntity.ok(DraftReferral(updatedReferral))
   }
 
   @GetMapping("/draft-referrals")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.service.ServiceCategoryService
@@ -22,7 +22,7 @@ class ReferralController(
 ) {
 
   @PostMapping("/draft-referral")
-  fun createDraftReferral(): ResponseEntity<DraftReferral> {
+  fun createDraftReferral(): ResponseEntity<DraftReferralDTO> {
 
     val referral = referralService.createDraftReferral()
     val location = ServletUriComponentsBuilder
@@ -33,7 +33,7 @@ class ReferralController(
 
     return ResponseEntity
       .created(location)
-      .body(DraftReferral(referral))
+      .body(DraftReferralDTO.from(referral))
   }
 
   @GetMapping("/draft-referral/{id}")
@@ -45,12 +45,12 @@ class ReferralController(
     }
 
     return referralService.getDraftReferral(uuid)
-      ?.let { ResponseEntity.ok(DraftReferral(it)) }
+      ?.let { ResponseEntity.ok(DraftReferralDTO.from(it)) }
       ?: ResponseEntity.notFound().build()
   }
 
   @PatchMapping("/draft-referral/{id}")
-  fun patchDraftReferralByID(@PathVariable id: String, @RequestBody partialUpdate: DraftReferral): ResponseEntity<Any> {
+  fun patchDraftReferralByID(@PathVariable id: String, @RequestBody partialUpdate: DraftReferralDTO): ResponseEntity<Any> {
     val uuid = try {
       UUID.fromString(id)
     } catch (e: IllegalArgumentException) {
@@ -61,11 +61,11 @@ class ReferralController(
       ?: return ResponseEntity.notFound().build()
 
     val updatedReferral = referralService.updateDraftReferral(referralToUpdate, partialUpdate)
-    return ResponseEntity.ok(DraftReferral(updatedReferral))
+    return ResponseEntity.ok(DraftReferralDTO.from(updatedReferral))
   }
 
   @GetMapping("/draft-referrals")
-  fun getDraftReferralsCreatedByUserID(@RequestParam userID: String): List<DraftReferral> {
+  fun getDraftReferralsCreatedByUserID(@RequestParam userID: String): List<DraftReferralDTO> {
     return referralService.getDraftReferralsCreatedByUserID(userID)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -9,6 +9,8 @@ data class DraftReferralDTO(
   val id: UUID? = null,
   val created: OffsetDateTime? = null,
   val completionDeadline: LocalDate? = null,
+  val serviceCategoryId: UUID? = null,
+  val complexityLevelId: UUID? = null,
 ) {
   companion object {
     fun from(referral: Referral): DraftReferralDTO {
@@ -16,6 +18,8 @@ data class DraftReferralDTO(
         referral.id!!,
         referral.created!!,
         referral.completionDeadline,
+        referral.serviceCategoryID,
+        referral.complexityLevelID,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -5,14 +5,18 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-data class DraftReferral(
+data class DraftReferralDTO(
   val id: UUID? = null,
   val created: OffsetDateTime? = null,
-  val completionDeadline: LocalDate? = null
+  val completionDeadline: LocalDate? = null,
 ) {
-  constructor(referral: Referral) : this(
-    referral.id!!,
-    referral.created!!,
-    referral.completionDeadline,
-  )
+  companion object {
+    fun from(referral: Referral): DraftReferralDTO {
+      return DraftReferralDTO(
+        referral.id!!,
+        referral.created!!,
+        referral.completionDeadline,
+      )
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -14,6 +14,8 @@ import javax.persistence.Table
 @Entity
 @Table(indexes = arrayOf(Index(columnList = "created_by_userid")))
 data class Referral(
+  var complexityLevelID: UUID? = null,
+  var serviceCategoryID: UUID? = null,
   @Column(name = "created_by_userid") var createdByUserID: String? = null,
   var completionDeadline: LocalDate? = null,
   @CreationTimestamp var created: OffsetDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -9,7 +9,6 @@ import java.util.UUID
 
 @Service
 class ReferralService(val repository: ReferralRepository) {
-
   fun createDraftReferral(): Referral {
     return repository.save(Referral())
   }
@@ -18,14 +17,11 @@ class ReferralService(val repository: ReferralRepository) {
     return repository.findByIdOrNull(id)
   }
 
-  fun updateDraftReferral(id: UUID, update: DraftReferral): Referral? {
-    val ref = getDraftReferral(id) ?: return null
-
+  fun updateDraftReferral(referral: Referral, update: DraftReferral): Referral {
     update.completionDeadline?.let {
-      ref.completionDeadline = update.completionDeadline
-      return repository.save(ref)
+      referral.completionDeadline = it
     }
-    return ref
+    return repository.save(referral)
   }
 
   fun getDraftReferralsCreatedByUserID(userID: String): List<DraftReferral> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -19,7 +19,14 @@ class ReferralService(val repository: ReferralRepository) {
 
   fun updateDraftReferral(referral: Referral, update: DraftReferralDTO): Referral {
     update.completionDeadline?.let {
+      // fixme: error if completion deadline is after sentence end date
       referral.completionDeadline = it
+    }
+
+    update.complexityLevelId?.let {
+      // fixme: error if service category not set for referral
+      //        error if complexity level not valid for service category
+      referral.complexityLevelID = it
     }
 
     return repository.save(referral)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.util.UUID
@@ -17,14 +17,15 @@ class ReferralService(val repository: ReferralRepository) {
     return repository.findByIdOrNull(id)
   }
 
-  fun updateDraftReferral(referral: Referral, update: DraftReferral): Referral {
+  fun updateDraftReferral(referral: Referral, update: DraftReferralDTO): Referral {
     update.completionDeadline?.let {
       referral.completionDeadline = it
     }
+
     return repository.save(referral)
   }
 
-  fun getDraftReferralsCreatedByUserID(userID: String): List<DraftReferral> {
-    return repository.findByCreatedByUserID(userID).map { DraftReferral(it) }
+  fun getDraftReferralsCreatedByUserID(userID: String): List<DraftReferralDTO> {
+    return repository.findByCreatedByUserID(userID).map { DraftReferralDTO.from(it) }
   }
 }

--- a/src/main/resources/db/local/V99_0__draft_referrals.sql
+++ b/src/main/resources/db/local/V99_0__draft_referrals.sql
@@ -1,3 +1,4 @@
-insert into referral (id, created, completion_deadline, created_by_userid)
-values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00', '2021-02-14', '2500128586'),
-       ('dfb64747-f658-40e0-a827-87b4b0bdcfed', '2020-12-07 20:45:21.986389+00', '2021-03-01', '8751622134');
+insert into referral (id, created, completion_deadline, created_by_userid, service_categoryid)
+values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00', '2021-02-14', '2500128586', null),
+       ('dfb64747-f658-40e0-a827-87b4b0bdcfed', '2020-12-07 20:45:21.986389+00', '2021-03-01', '8751622134', null),
+       ('d496e4a7-7cc1-44ea-ba67-c295084f1962', '2020-12-24 09:32:32.871623+00', '2021-01-30', '2500128586', '428ee70f-3001-4399-95a6-ad25eaaede16');

--- a/src/main/resources/db/migration/V1_4__more_referral_fields.sql
+++ b/src/main/resources/db/migration/V1_4__more_referral_fields.sql
@@ -1,0 +1,3 @@
+alter table referral
+    add column service_categoryid uuid,
+    add column complexity_levelid uuid;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
@@ -12,11 +12,11 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @JsonTest
-class DraftReferralTest(@Autowired private val json: JacksonTester<DraftReferral>) {
+class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftReferralDTO>) {
   @Test
   fun `empty input cannot create draft referral`() {
     assertThrows<RuntimeException> {
-      DraftReferral(Referral())
+      DraftReferralDTO.from(Referral())
     }
   }
 
@@ -25,7 +25,7 @@ class DraftReferralTest(@Autowired private val json: JacksonTester<DraftReferral
     val createdDate = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
 
     assertThrows<RuntimeException> {
-      DraftReferral(Referral(created = createdDate))
+      DraftReferralDTO.from(Referral(created = createdDate))
     }
   }
 
@@ -34,7 +34,7 @@ class DraftReferralTest(@Autowired private val json: JacksonTester<DraftReferral
     val id = UUID.fromString("70d3a47c-d539-4f76-8fc9-1c50e34aea29")
 
     assertThrows<RuntimeException> {
-      DraftReferral(Referral(id = id))
+      DraftReferralDTO.from(Referral(id = id))
     }
   }
 
@@ -44,7 +44,7 @@ class DraftReferralTest(@Autowired private val json: JacksonTester<DraftReferral
       id = UUID.fromString("3B9ED289-8412-41A9-8291-45E33E60276C"),
       created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
     )
-    val out = json.write(DraftReferral(referral))
+    val out = json.write(DraftReferralDTO.from(referral))
     assertThat(out).isEqualToJson(
       """
       {"id": "3b9ed289-8412-41a9-8291-45e33e60276c", "created": "2020-12-04T10:42:43Z"}
@@ -59,7 +59,7 @@ class DraftReferralTest(@Autowired private val json: JacksonTester<DraftReferral
       created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
       completionDeadline = LocalDate.of(2021, 2, 12)
     )
-    val out = json.write(DraftReferral(referral))
+    val out = json.write(DraftReferralDTO.from(referral))
     assertThat(out).isEqualToJson(
       """
       {"id": "3b9ed289-8412-41a9-8291-45e33e60276c", "created": "2020-12-04T10:42:43Z", "completionDeadline": "2021-02-12"}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -42,9 +42,6 @@ class PactTest {
   @State("a service category with ID 428ee70f-3001-4399-95a6-ad25eaaede16 exists")
   fun `use service category 428ee70f from the seed`() {}
 
-//  @State("there is an existing draft referral with ID of 1219a064-709b-4b6c-a11e-10b8cb3966f6")
-//  fun `use ...`() {}
-//
-//  @State("there is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected")
-//  fun `use ...`() {}
+  @State("There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected")
+  fun `use referral d496e4a7 from the seed`() {}
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.time.LocalDate
@@ -29,7 +29,7 @@ class ReferralServiceTest @Autowired constructor(
     entityManager.persist(referral)
     entityManager.flush()
 
-    val draftReferral = DraftReferral(
+    val draftReferral = DraftReferralDTO(
       id = UUID.fromString("ce364949-7301-497b-894d-130f34a98bff"),
       created = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
     )
@@ -45,7 +45,7 @@ class ReferralServiceTest @Autowired constructor(
     entityManager.persist(referral)
     entityManager.flush()
 
-    val draftReferral = DraftReferral(completionDeadline = null)
+    val draftReferral = DraftReferralDTO(completionDeadline = null)
 
     val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.completionDeadline).isEqualTo(LocalDate.of(2021, 6, 26))
@@ -57,7 +57,7 @@ class ReferralServiceTest @Autowired constructor(
     entityManager.persist(referral)
     entityManager.flush()
 
-    val draftReferral = DraftReferral(completionDeadline = LocalDate.of(2020, 12, 1))
+    val draftReferral = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 12, 1))
 
     val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.completionDeadline).isEqualTo(LocalDate.of(2020, 12, 1))
@@ -69,7 +69,7 @@ class ReferralServiceTest @Autowired constructor(
     entityManager.persist(referral)
     entityManager.flush()
 
-    val draftReferral = DraftReferral(completionDeadline = LocalDate.of(2020, 12, 1))
+    val draftReferral = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 12, 1))
 
     val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.completionDeadline).isEqualTo(LocalDate.of(2020, 12, 1))
@@ -81,7 +81,7 @@ class ReferralServiceTest @Autowired constructor(
     entityManager.persist(referral)
     entityManager.flush()
 
-    val draftReferral = DraftReferral(completionDeadline = LocalDate.of(2020, 12, 1))
+    val draftReferral = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 12, 1))
     referralService.updateDraftReferral(referral, draftReferral)
 
     val savedDraftReferral = referralService.getDraftReferral(referral.id!!)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
@@ -34,7 +34,7 @@ class ReferralServiceTest @Autowired constructor(
       created = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
     )
 
-    val updated = referralService.updateDraftReferral(referral.id!!, draftReferral)
+    val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.id).isEqualTo(referral.id!!)
     assertThat(updated.created).isEqualTo(referral.created)
   }
@@ -47,7 +47,7 @@ class ReferralServiceTest @Autowired constructor(
 
     val draftReferral = DraftReferral(completionDeadline = null)
 
-    val updated = referralService.updateDraftReferral(referral.id!!, draftReferral)
+    val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.completionDeadline).isEqualTo(LocalDate.of(2021, 6, 26))
   }
 
@@ -59,7 +59,7 @@ class ReferralServiceTest @Autowired constructor(
 
     val draftReferral = DraftReferral(completionDeadline = LocalDate.of(2020, 12, 1))
 
-    val updated = referralService.updateDraftReferral(referral.id!!, draftReferral)
+    val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.completionDeadline).isEqualTo(LocalDate.of(2020, 12, 1))
   }
 
@@ -71,7 +71,7 @@ class ReferralServiceTest @Autowired constructor(
 
     val draftReferral = DraftReferral(completionDeadline = LocalDate.of(2020, 12, 1))
 
-    val updated = referralService.updateDraftReferral(referral.id!!, draftReferral)
+    val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.completionDeadline).isEqualTo(LocalDate.of(2020, 12, 1))
   }
 
@@ -82,7 +82,7 @@ class ReferralServiceTest @Autowired constructor(
     entityManager.flush()
 
     val draftReferral = DraftReferral(completionDeadline = LocalDate.of(2020, 12, 1))
-    referralService.updateDraftReferral(referral.id!!, draftReferral)
+    referralService.updateDraftReferral(referral, draftReferral)
 
     val savedDraftReferral = referralService.getDraftReferral(referral.id!!)
     assertThat(savedDraftReferral!!.id).isEqualTo(referral.id)


### PR DESCRIPTION
## What does this pull request do?

- some refactoring - please review commit by commit.
- adds fields for service category and complexity level to the referral entity and DTO.
- allows updating complexity level in the PATCH /draft-referral/{id} endpoint

## What is the intent behind these changes?

continue to get the API more up to date with the front end consumer
