### PR TITLE
allow updating service category id in patch referral endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -18,6 +18,11 @@ class ReferralService(val repository: ReferralRepository) {
   }
 
   fun updateDraftReferral(referral: Referral, update: DraftReferralDTO): Referral {
+    update.serviceCategoryId?.let {
+      // fixme: error if service category is already set
+      referral.serviceCategoryID = it
+    }
+
     update.completionDeadline?.let {
       // fixme: error if completion deadline is after sentence end date
       referral.completionDeadline = it


### PR DESCRIPTION
## What does this pull request do?

allows the service category id to be updated on the draft referral.

## What is the intent behind these changes?

allow API consumers to set the service category ID to get the dev environment working