### PR TITLE
IC-664 add backing fields for more referral form data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -11,6 +11,14 @@ data class DraftReferralDTO(
   val completionDeadline: LocalDate? = null,
   val serviceCategoryId: UUID? = null,
   val complexityLevelId: UUID? = null,
+  val furtherInformation: String? = null,
+  val additionalNeedsInformation: String? = null,
+  val accessibilityNeeds: String? = null,
+  val needsInterpreter: Boolean? = null,
+  val interpreterLanguage: String? = null,
+  val hasAdditionalResponsibilities: Boolean? = null,
+  val whenUnavailable: String? = null,
+  val additionalRiskInformation: String? = null,
 ) {
   companion object {
     fun from(referral: Referral): DraftReferralDTO {
@@ -20,6 +28,14 @@ data class DraftReferralDTO(
         referral.completionDeadline,
         referral.serviceCategoryID,
         referral.complexityLevelID,
+        referral.furtherInformation,
+        referral.additionalNeedsInformation,
+        referral.accessibilityNeeds,
+        referral.needsInterpreter,
+        referral.interpreterLanguage,
+        referral.hasAdditionalResponsibilities,
+        referral.whenUnavailable,
+        referral.additionalRiskInformation,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -14,6 +14,14 @@ import javax.persistence.Table
 @Entity
 @Table(indexes = arrayOf(Index(columnList = "created_by_userid")))
 data class Referral(
+  var additionalRiskInformation: String? = null,
+  var furtherInformation: String? = null,
+  var additionalNeedsInformation: String? = null,
+  var accessibilityNeeds: String? = null,
+  var needsInterpreter: Boolean? = null,
+  var interpreterLanguage: String? = null,
+  var hasAdditionalResponsibilities: Boolean? = null,
+  var whenUnavailable: String? = null,
   var complexityLevelID: UUID? = null,
   var serviceCategoryID: UUID? = null,
   @Column(name = "created_by_userid") var createdByUserID: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -29,6 +29,40 @@ class ReferralService(val repository: ReferralRepository) {
       referral.complexityLevelID = it
     }
 
+    update.furtherInformation?.let {
+      referral.furtherInformation = it
+    }
+
+    update.additionalNeedsInformation?.let {
+      referral.additionalNeedsInformation = it
+    }
+
+    update.accessibilityNeeds?.let {
+      referral.accessibilityNeeds = it
+    }
+
+    update.needsInterpreter?.let {
+      // fixme: error if this is true and interpreterLangyage is missing
+      referral.needsInterpreter = it
+    }
+
+    update.interpreterLanguage?.let {
+      referral.interpreterLanguage = it
+    }
+
+    update.hasAdditionalResponsibilities?.let {
+      // fixme: error if this is true and whenUnavailable is missing
+      referral.hasAdditionalResponsibilities = it
+    }
+
+    update.whenUnavailable?.let {
+      referral.whenUnavailable = it
+    }
+
+    update.additionalRiskInformation?.let {
+      referral.additionalRiskInformation = it
+    }
+
     return repository.save(referral)
   }
 

--- a/src/main/resources/db/migration/V1_5__referral_further_information.sql
+++ b/src/main/resources/db/migration/V1_5__referral_further_information.sql
@@ -1,0 +1,9 @@
+alter table referral
+    add column further_information text,
+    add column accessibility_needs text,
+    add column additional_needs_information text,
+    add column needs_interpreter boolean,
+    add column interpreter_language text,
+    add column has_additional_responsibilities boolean,
+    add column when_unavailable text,
+    add column additional_risk_information text;


### PR DESCRIPTION
## What do these changes do?

adds the following fields to the referral entity and draft referral DTO:

```
  var additionalRiskInformation: String? = null,
  var furtherInformation: String? = null,
  var additionalNeedsInformation: String? = null,
  var accessibilityNeeds: String? = null,
  var needsInterpreter: Boolean? = null,
  var interpreterLanguage: String? = null,
  var hasAdditionalResponsibilities: Boolean? = null,
  var whenUnavailable: String? = null,
```

these changes are tested by the the contract tests, which are not yet running up-to-date. it's a work in progress.

## What is the intent behind these changes?

update the backend to reflect recent front end changes.
