### PR TITLE
rename 'created' field in referral entity to 'createdAt' to make it's meaning clearer to the API consumer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 
 data class DraftReferralDTO(
   val id: UUID? = null,
-  val created: OffsetDateTime? = null,
+  val createdAt: OffsetDateTime? = null,
   val createdByUserId: String? = null,
   val completionDeadline: LocalDate? = null,
   val serviceCategoryId: UUID? = null,
@@ -27,7 +27,7 @@ data class DraftReferralDTO(
     fun from(referral: Referral): DraftReferralDTO {
       return DraftReferralDTO(
         id = referral.id!!,
-        created = referral.created!!,
+        createdAt = referral.createdAt!!,
         createdByUserId = referral.createdByUserID!!,
         completionDeadline = referral.completionDeadline,
         serviceCategoryId = referral.serviceCategoryID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -30,6 +30,6 @@ data class Referral(
   @NotNull var createdByUserAuthSource: String? = null,
   @Column(name = "created_by_userid") @NotNull var createdByUserID: String? = null,
   var completionDeadline: LocalDate? = null,
-  @CreationTimestamp var created: OffsetDateTime? = null,
+  @CreationTimestamp var createdAt: OffsetDateTime? = null,
   @Id @GeneratedValue var id: UUID? = null,
 )

--- a/src/main/resources/db/local/V99_0__draft_referrals.sql
+++ b/src/main/resources/db/local/V99_0__draft_referrals.sql
@@ -1,4 +1,4 @@
-insert into referral (id, created, completion_deadline, created_by_userid, created_by_user_auth_source, service_categoryid)
+insert into referral (id, created_at, completion_deadline, created_by_userid, created_by_user_auth_source, service_categoryid)
 values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00', '2021-02-14', '2500128586', 'delius', null),
        ('dfb64747-f658-40e0-a827-87b4b0bdcfed', '2020-12-07 20:45:21.986389+00', '2021-03-01', '8751622134', 'delius', null),
        ('d496e4a7-7cc1-44ea-ba67-c295084f1962', '2020-12-24 09:32:32.871623+00', '2021-01-30', '2500128586', 'delius', '428ee70f-3001-4399-95a6-ad25eaaede16');

--- a/src/main/resources/db/migration/V1_10__created_at_update.sql
+++ b/src/main/resources/db/migration/V1_10__created_at_update.sql
@@ -1,0 +1,2 @@
+alter table referral
+    rename column created to created_at;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
@@ -25,7 +25,7 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
     val createdDate = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
 
     assertThrows<RuntimeException> {
-      DraftReferralDTO.from(Referral(created = createdDate))
+      DraftReferralDTO.from(Referral(createdAt = createdDate))
     }
   }
 
@@ -42,7 +42,7 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
   fun `test serialization of newly created referral`() {
     val referral = Referral(
       id = UUID.fromString("3B9ED289-8412-41A9-8291-45E33E60276C"),
-      created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+      createdAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
       createdByUserID = "123456",
       createdByUserAuthSource = "delius",
     )
@@ -51,7 +51,7 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
       """
       {
         "id": "3b9ed289-8412-41a9-8291-45e33e60276c", 
-        "created": "2020-12-04T10:42:43Z",
+        "createdAt": "2020-12-04T10:42:43Z",
         "createdByUserId": "123456"
       }
     """
@@ -62,7 +62,7 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
   fun `test serialization of referral with completionDeadline`() {
     val referral = Referral(
       id = UUID.fromString("3B9ED289-8412-41A9-8291-45E33E60276C"),
-      created = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+      createdAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
       createdByUserID = "123456",
       createdByUserAuthSource = "delius",
       completionDeadline = LocalDate.of(2021, 2, 12)
@@ -72,7 +72,7 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
       """
       {
         "id": "3b9ed289-8412-41a9-8291-45e33e60276c", 
-        "created": "2020-12-04T10:42:43Z",
+        "createdAt": "2020-12-04T10:42:43Z",
         "createdByUserId": "123456",
         "completionDeadline": "2021-02-12"
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
@@ -33,12 +33,12 @@ class ReferralServiceTest @Autowired constructor(
 
     val draftReferral = DraftReferralDTO(
       id = UUID.fromString("ce364949-7301-497b-894d-130f34a98bff"),
-      created = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
+      createdAt = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
     )
 
     val updated = referralService.updateDraftReferral(referral, draftReferral)
     assertThat(updated!!.id).isEqualTo(referral.id!!)
-    assertThat(updated.created).isEqualTo(referral.created)
+    assertThat(updated.createdAt).isEqualTo(referral.createdAt)
   }
 
   @Test
@@ -91,7 +91,7 @@ class ReferralServiceTest @Autowired constructor(
 
     val savedDraftReferral = referralService.getDraftReferral(referral.id!!)
     assertThat(savedDraftReferral!!.id).isEqualTo(referral.id)
-    assertThat(savedDraftReferral.created).isEqualTo(referral.created)
+    assertThat(savedDraftReferral.createdAt).isEqualTo(referral.createdAt)
     assertThat(savedDraftReferral.completionDeadline).isEqualTo(draftReferral.completionDeadline)
   }
 
@@ -102,7 +102,7 @@ class ReferralServiceTest @Autowired constructor(
 
     val savedDraftReferral = referralService.getDraftReferral(draftReferral.id!!)
     assertThat(savedDraftReferral!!.id).isNotNull
-    assertThat(savedDraftReferral.created).isNotNull
+    assertThat(savedDraftReferral.createdAt).isNotNull
     assertThat(savedDraftReferral.createdByUserID).isEqualTo("user_id")
     assertThat(savedDraftReferral.createdByUserAuthSource).isEqualTo("auth_source")
   }
@@ -115,7 +115,7 @@ class ReferralServiceTest @Autowired constructor(
 
     val savedDraftReferral = referralService.getDraftReferral(referral.id!!)
     assertThat(savedDraftReferral!!.id).isEqualTo(referral.id)
-    assertThat(savedDraftReferral.created).isEqualTo(referral.created)
+    assertThat(savedDraftReferral.createdAt).isEqualTo(referral.createdAt)
     assertThat(savedDraftReferral.completionDeadline).isEqualTo(referral.completionDeadline)
   }
 


### PR DESCRIPTION
## What does this pull request do?

rename 'created' field in referral entity to 'createdAt' to make it's meaning clearer to the API consumer

## What is the intent behind these changes?

there was some confusion on the backend about the meaning of `created` in the DraftReferralDTO. it sounds like a boolean value, but really it's the timestamp when the referral was created.
