### PR TITLE
fix latest migration to unblock deploy

### DIFF
--- a/src/main/resources/db/migration/V1_8__created_by_update.sql
+++ b/src/main/resources/db/migration/V1_8__created_by_update.sql
@@ -1,10 +1,14 @@
 alter table referral
-    add column created_by_user_auth_source varchar(255) not null;
+    add column created_by_user_auth_source varchar(255);
 
 update referral
-        set created_by_userid = 'unknown',
-        created_by_user_auth_source = 'unknown'
+    set created_by_userid = 'unknown'
     where created_by_userid = null;
 
+update referral
+    set created_by_user_auth_source = 'unknown'
+    where created_by_user_auth_source = null;
+
 alter table referral
-    alter column created_by_userid set not null;
+    alter column created_by_userid set not null,
+    alter column created_by_user_auth_source set not null;


### PR DESCRIPTION
## What does this pull request do?

sets the `created_by_user_auth_source` to not null after it has been populated.

## What is the intent behind these changes?

unblock the broken deploy
