### PR TITLE
split latest migration in two to fix deploy

### DIFF
--- a/src/main/resources/db/migration/V1_8_0__created_by_update.sql
+++ b/src/main/resources/db/migration/V1_8_0__created_by_update.sql
@@ -8,7 +8,3 @@ update referral
 update referral
     set created_by_user_auth_source = 'unknown'
     where created_by_user_auth_source = null;
-
-alter table referral
-    alter column created_by_userid set not null,
-    alter column created_by_user_auth_source set not null;

--- a/src/main/resources/db/migration/V1_8_1__created_by_not_null.sql
+++ b/src/main/resources/db/migration/V1_8_1__created_by_not_null.sql
@@ -1,0 +1,3 @@
+alter table referral
+    alter column created_by_userid set not null,
+    alter column created_by_user_auth_source set not null;


### PR DESCRIPTION
## What does this pull request do?

split latest migration in two to seperate the data changes from the `not null` change.

## What is the intent behind these changes?

upblock the deploy.
