### PR TITLE
Re-enable (non-blocking) Pact tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
   build_test_and_deploy:
     jobs:
       - validate
-#      - pact_check_and_publish
+      - pact_check_and_publish
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:
@@ -136,7 +136,6 @@ workflows:
                 - main
           requires:
             - validate
-#            - pact_check_and_publish
             - build_and_publish_docker
             - helm_lint
             - vulnerability_scan_and_monitor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
           command: |
             PACT_PROVIDER_VERSION="$CIRCLE_SHA1" \
               PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
+              PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="main,last-implemented" \
               ./gradlew pactTestPublish
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
             PACT_PROVIDER_VERSION="$CIRCLE_SHA1" \
               PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
               PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="main,last-implemented" \
+              PACT_PUBLISH_RESULTS="true" \
               ./gradlew pactTestPublish
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ jobs:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
+      - store_test_results:
+          path: build/test-results
+      - store_artifacts:
+          path: build/reports/tests
 
   vulnerability_scan:
     executor: hmpps/java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
 
   pact_check_and_publish:
     environment:
-      PACT_BROKER_HOST: "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
-      PACT_BROKER_USERNAME: "interventions"
+      PACTBROKER_HOST: "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACTBROKER_AUTH_USERNAME: "interventions"
     executor: hmpps/java
     docker:
       - image: cimg/openjdk:11.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,7 @@ tasks {
 
     systemProperty("pact.provider.tag", System.getenv("PACT_PROVIDER_TAG"))
     systemProperty("pact.provider.version", System.getenv("PACT_PROVIDER_VERSION"))
-
     systemProperty("pact.verifier.publishResults", "true")
-    systemProperty("pactbroker.host", System.getenv("PACT_BROKER_HOST"))
-    systemProperty("pactbroker.auth.username", System.getenv("PACT_BROKER_USERNAME"))
-    systemProperty("pactbroker.auth.password", System.getenv("PACT_BROKER_PASSWORD"))
 
     useJUnitPlatform()
     filter {
@@ -40,6 +36,6 @@ dependencies {
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql")
 
-  testImplementation("au.com.dius.pact.provider:junit5:4.1.11")
+  testImplementation("au.com.dius.pact.provider:junit5spring:4.1.14")
   testImplementation("com.h2database:h2:1.4.200")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,12 @@ configurations {
 }
 
 tasks {
+  test {
+    useJUnitPlatform() {
+      excludeTags("pact")
+    }
+  }
+
   register<Test>("pactTestPublish") {
     description = "Run and publish Pact provider tests"
     group = "verification"
@@ -17,9 +23,8 @@ tasks {
     systemProperty("pact.provider.version", System.getenv("PACT_PROVIDER_VERSION"))
     systemProperty("pact.verifier.publishResults", "true")
 
-    useJUnitPlatform()
-    filter {
-      includeTestsMatching("PactTest")
+    useJUnitPlatform() {
+      includeTags("pact")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks {
 
     systemProperty("pact.provider.tag", System.getenv("PACT_PROVIDER_TAG"))
     systemProperty("pact.provider.version", System.getenv("PACT_PROVIDER_VERSION"))
-    systemProperty("pact.verifier.publishResults", "true")
+    systemProperty("pact.verifier.publishResults", System.getenv("PACT_PUBLISH_RESULTS") ?: "false")
 
     useJUnitPlatform() {
       includeTags("pact")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -1,30 +1,27 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration
 
 import au.com.dius.pact.provider.junit5.PactVerificationContext
-import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
-import au.com.dius.pact.provider.junitsupport.loader.VersionSelector
+import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @Disabled
+@ExtendWith(SpringExtension::class)
 @Provider("Interventions Service")
-@PactBroker(
-  host = "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk",
-  scheme = "https",
-  consumerVersionSelectors = [VersionSelector(tag = "last-implemented")],
-)
+@PactBroker
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test", "local")
 class PactTest {
 
   @TestTemplate
-  @ExtendWith(PactVerificationInvocationContextProvider::class)
+  @ExtendWith(PactVerificationSpringProvider::class)
   fun pactVerificationTestTemplate(context: PactVerificationContext) {
     context.verifyInteraction()
   }
@@ -42,8 +39,10 @@ class PactTest {
   }
 
   @State("a service category with ID 428ee70f-3001-4399-95a6-ad25eaaede16 exists")
-  fun `use service category 428ee70f from the seed`() {}
+  fun `use service category 428ee70f from the seed`() {
+  }
 
   @State("There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected")
-  fun `use referral d496e4a7 from the seed`() {}
+  fun `use referral d496e4a7 from the seed`() {
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -5,19 +5,19 @@ import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@Disabled
 @ExtendWith(SpringExtension::class)
 @Provider("Interventions Service")
 @PactBroker
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test", "local")
+@Tag("pact")
 class PactTest {
 
   @TestTemplate

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,3 +8,9 @@ server:
 management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
+
+pactbroker:
+  host: pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk
+  scheme: https
+  consumerversionselectors:
+    tags: last-implemented


### PR DESCRIPTION
## What does this pull request do?

Re-enables Pact tests that

- do not block deployments and development
- runnable locally (use `./gradlew pactTestPublish`)
- can be tested against arbitrary tags (use `PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS ` env var)
- can be viewed in CircleCI (e.g. [here](https://1201-312544431-gh.circle-artifacts.com/0/build/reports/tests/pactTestPublish/classes/uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.PactTest.html))

This **will** fail the `ci/circleci: pact_check_and_publish` job on CI but that will no longer block the deployment. This is **normal** for now.

## Where should the reviewer start?

Please review commit-by-commit, there's context there for each step.

## What is the intent behind these changes?

To make the tests run against `main` on CI so we're aware how far away we are from mainline contracts.