### PR TITLE
some commits which bring the api more in line with the front end contracts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -98,18 +98,12 @@ class ReferralService(val repository: ReferralRepository) {
 
     update.needsInterpreter?.let {
       referral.needsInterpreter = it
-    }
-
-    update.interpreterLanguage?.let {
-      referral.interpreterLanguage = it
+      referral.interpreterLanguage = if (it) update.interpreterLanguage else null
     }
 
     update.hasAdditionalResponsibilities?.let {
       referral.hasAdditionalResponsibilities = it
-    }
-
-    update.whenUnavailable?.let {
-      referral.whenUnavailable = it
+      referral.whenUnavailable = if (it) update.whenUnavailable else null
     }
 
     update.additionalRiskInformation?.let {
@@ -118,10 +112,7 @@ class ReferralService(val repository: ReferralRepository) {
 
     update.usingRarDays?.let {
       referral.usingRarDays = it
-    }
-
-    update.maximumRarDays?.let {
-      referral.maximumRarDays = it
+      referral.maximumRarDays = if (it) update.maximumRarDays else null
     }
 
     return repository.save(referral)

--- a/src/main/resources/db/local/V99_0__draft_referrals.sql
+++ b/src/main/resources/db/local/V99_0__draft_referrals.sql
@@ -1,4 +1,5 @@
 insert into referral (id, created_at, completion_deadline, created_by_userid, created_by_user_auth_source, service_categoryid)
 values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00', '2021-02-14', '2500128586', 'delius', null),
        ('dfb64747-f658-40e0-a827-87b4b0bdcfed', '2020-12-07 20:45:21.986389+00', '2021-03-01', '8751622134', 'delius', null),
-       ('d496e4a7-7cc1-44ea-ba67-c295084f1962', '2020-12-24 09:32:32.871623+00', '2021-01-30', '2500128586', 'delius', '428ee70f-3001-4399-95a6-ad25eaaede16');
+       ('d496e4a7-7cc1-44ea-ba67-c295084f1962', '2020-12-24 09:32:32.871623+00', '2021-01-30', '2500128586', 'delius', '428ee70f-3001-4399-95a6-ad25eaaede16'),
+       ('1219a064-709b-4b6c-a11e-10b8cb3966f6', '2021-01-12 14:46:21.987234+00', null, '2500128586', 'delius', '428ee70f-3001-4399-95a6-ad25eaaede16');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -53,7 +53,7 @@ class PactTest {
   @State("There is an existing draft referral with ID of 1219a064-709b-4b6c-a11e-10b8cb3966f6, and it has had a service user selected")
   fun `tmp2`() {}
 
-  @State("a referral for user with ID 2500128586 exists")
+  @State("a single referral for user with ID 8751622134 exists")
   fun `tmp3`() {}
 
   @State("a referral does not exist for user with ID 123344556")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 
-//@Disabled
+@Disabled
 @Provider("Interventions Service")
 @PactBroker(
   host = "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk",
   scheme = "https",
-  consumerVersionSelectors = [VersionSelector(tag = "main")],
+  consumerVersionSelectors = [VersionSelector(tag = "last-implemented")],
 )
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test", "local")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -38,8 +38,7 @@ class PactTest {
   }
 
   @State("a draft referral with ID dfb64747-f658-40e0-a827-87b4b0bdcfed exists")
-  fun `use referral dfb64747 from the seed`() {
-  }
+  fun `use referral dfb64747 from the seed`() {}
 
   @State("a service category with ID 428ee70f-3001-4399-95a6-ad25eaaede16 exists")
   fun `use service category 428ee70f from the seed`() {}
@@ -47,15 +46,18 @@ class PactTest {
   @State("There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected")
   fun `use referral d496e4a7 from the seed`() {}
 
+  @State("There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service provider selected")
+  fun `use referral d496e4a7 from the seed, since it also has a service provider`() {}
+
   @State("There is an existing draft referral with ID of 037cc90b-beaa-4a32-9ab7-7f79136e1d27, and it has had desired outcomes selected")
-  fun `tmp`() {}
+  fun `not implemented yet`() {}
 
   @State("There is an existing draft referral with ID of 1219a064-709b-4b6c-a11e-10b8cb3966f6, and it has had a service user selected")
-  fun `tmp2`() {}
+  fun `use referral 1219a064 from the seed`() {}
 
   @State("a single referral for user with ID 8751622134 exists")
-  fun `tmp3`() {}
+  fun `user referral dfb64747 from the seed`() {}
 
   @State("a referral does not exist for user with ID 123344556")
-  fun `tmp4`() {}
+  fun `no referral required for this state`() {}
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 
-@Disabled
+//@Disabled
 @Provider("Interventions Service")
 @PactBroker(
   host = "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk",
   scheme = "https",
-  consumerVersionSelectors = [VersionSelector(tag = "last-implemented")],
+  consumerVersionSelectors = [VersionSelector(tag = "main")],
 )
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test", "local")
@@ -46,4 +46,16 @@ class PactTest {
 
   @State("There is an existing draft referral with ID of d496e4a7-7cc1-44ea-ba67-c295084f1962, and it has had a service category selected")
   fun `use referral d496e4a7 from the seed`() {}
+
+  @State("There is an existing draft referral with ID of 037cc90b-beaa-4a32-9ab7-7f79136e1d27, and it has had desired outcomes selected")
+  fun `tmp`() {}
+
+  @State("There is an existing draft referral with ID of 1219a064-709b-4b6c-a11e-10b8cb3966f6, and it has had a service user selected")
+  fun `tmp2`() {}
+
+  @State("a referral for user with ID 2500128586 exists")
+  fun `tmp3`() {}
+
+  @State("a referral does not exist for user with ID 123344556")
+  fun `tmp4`() {}
 }


### PR DESCRIPTION
## What does this pull request do?

several small commits:
- add required pact states so we get proper test failures and not just "state missing" errors
- behaviour change to unset conditional fields when their boolean radio button is set to false

## What is the intent behind these changes?

working towards getting latest contract tests green
