### PR TITLE
Convert Pact build to be triggerable via CI API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+parameters:
+  only_pacts:
+    type: boolean
+    default: false
+  pact_consumer_tags:
+    type: string
+    default: main,last-implemented
+
 orbs:
   hmpps: ministryofjustice/hmpps@2.1.0
   snyk: snyk/snyk@0.0.12
@@ -37,6 +45,9 @@ jobs:
           path: build/reports/tests
 
   pact_check_and_publish:
+    parameters:
+      consumer_tags:
+        type: string
     environment:
       PACTBROKER_HOST: "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACTBROKER_AUTH_USERNAME: "interventions"
@@ -58,7 +69,7 @@ jobs:
           command: |
             PACT_PROVIDER_VERSION="$CIRCLE_SHA1" \
               PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
-              PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="main,last-implemented" \
+              PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="<< parameters.consumer_tags >>" \
               PACT_PUBLISH_RESULTS="true" \
               ./gradlew pactTestPublish
       - save_cache:
@@ -95,10 +106,15 @@ jobs:
 
 workflows:
   version: 2
+  pact:
+    jobs:
+      - pact_check_and_publish:
+          consumer_tags: << pipeline.parameters.pact_consumer_tags >>
+
   build_test_and_deploy:
+    unless: << pipeline.parameters.only_pacts >>
     jobs:
       - validate
-      - pact_check_and_publish
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:


### PR DESCRIPTION
## What does this pull request do?

Prepare the `pact_check_and_publish` job to be triggered from the Pact Broker via webhooks when contracts change by introducing pipeline parameters.

## What is the intent behind these changes?

The CircleCI v2 API supports triggering pipelines on a GitHub project.

However, it only supports branch/tag arguments and pipeline parameters:
there is no built-in support for selecting a specific workflow or job.

Instead, we need to use **pipeline parameters**.

These can be passed down from the triggering API call and we need to
implement a branching logic based on it.

Tested the below code with the following API call:
```
$ curl -X POST \
  'https://circleci.com/api/v2/project/github/ministryofjustice/hmpps-interventions-service/pipeline'
  -H "Circle-Token: $CIRCLECI_INTERVENTIONS_TOKEN" \
  -H "Content-Type: application/json" \
  -d @payload.json
```

payload.json:
```
{
  "branch": "trigger-pact-builds",
  "parameters": {
    "only_pacts": true,
    "pact_consumer_tags": "last-implemented"
  }
}
```

Which ran @ https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/335/workflows/46587e0f-bac5-4c8d-8981-54eb3be38ae0.

## Caveat

📝 There's an annoying bit is that any build ran this way will register the pass/failure against the commit SHA in the `branch` -- if we'd run against `main` the latest commit's pact check would flip-flop on new builds.