### PR TITLE
require service user CRN on draft referral creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Build and test:
 ```
 
 Run:
+
+First, add the following line to your `/etc/hosts` file to allow hmpps-auth interoperability with other docker services:
+
+```127.0.0.1 hmpps-auth```
+
+Then run: 
+
 ```
 docker-compose pull
 docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       - hmpps
     container_name: hmpps-auth
     ports:
-      - "8090:8080"
+      - "8090:8090"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8090/auth/health"]
     environment:
-      - SERVER_PORT=8080
+      - SERVER_PORT=8090
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebInputException
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryDTO
@@ -26,7 +27,6 @@ class ReferralController(
   private val referralService: ReferralService,
   private val serviceCategoryService: ServiceCategoryService
 ) {
-
   @PostMapping("/draft-referral/{id}/send")
   fun sendDraftReferral(@PathVariable id: String, authentication: JwtAuthenticationToken): ResponseEntity<SentReferralDTO> {
     val uuid = parseID(id)
@@ -57,9 +57,10 @@ class ReferralController(
   }
 
   @PostMapping("/draft-referral")
-  fun createDraftReferral(authentication: JwtAuthenticationToken): ResponseEntity<DraftReferralDTO> {
+  fun createDraftReferral(@RequestBody createReferralRequestDTO: CreateReferralRequestDTO, authentication: JwtAuthenticationToken): ResponseEntity<DraftReferralDTO> {
     val user = parseAuthUserToken(authentication)
-    val referral = referralService.createDraftReferral(user)
+
+    val referral = referralService.createDraftReferral(user, createReferralRequestDTO.serviceUserCrn)
     val location = ServletUriComponentsBuilder
       .fromCurrentRequest()
       .path("/{id}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/CreateReferralRequestDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/CreateReferralRequestDTO.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+data class CreateReferralRequestDTO(
+  val serviceUserCrn: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -28,9 +28,8 @@ class ReferralService(val repository: ReferralRepository) {
     return repository.save(referral)
   }
 
-  fun createDraftReferral(user: AuthUser): Referral {
-    val dummyCRN = "X320741"
-    return repository.save(Referral(serviceUserCRN = dummyCRN, createdBy = user))
+  fun createDraftReferral(user: AuthUser, crn: String): Referral {
+    return repository.save(Referral(serviceUserCRN = crn, createdBy = user))
   }
 
   fun getDraftReferral(id: UUID): Referral? {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 hmppsauth:
-  baseurl: http://localhost:8090/auth
+  baseurl: http://hmpps-auth:8090/auth
 
 postgres:
   uri: localhost:5432

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
@@ -99,13 +99,14 @@ class ReferralServiceTest @Autowired constructor(
   @Test
   fun `create and persist draft referral`() {
     val authUser = AuthUser("user_id", "auth_source")
-    val draftReferral = referralService.createDraftReferral(authUser)
+    val draftReferral = referralService.createDraftReferral(authUser, "X123456")
     entityManager.flush()
 
     val savedDraftReferral = referralService.getDraftReferral(draftReferral.id!!)
     assertThat(savedDraftReferral!!.id).isNotNull
     assertThat(savedDraftReferral.createdAt).isNotNull
     assertThat(savedDraftReferral.createdBy).isEqualTo(authUser)
+    assertThat(savedDraftReferral.serviceUserCRN).isEqualTo("X123456")
   }
 
   @Test
@@ -337,7 +338,7 @@ class ReferralServiceTest @Autowired constructor(
   @Test
   fun `once a draft referral is sent it's id is no longer is a valid draft referral`() {
     val user = AuthUser("user_id", "auth_source")
-    val draftReferral = referralService.createDraftReferral(user)
+    val draftReferral = referralService.createDraftReferral(user, "X123456")
 
     assertThat(referralService.getDraftReferral(draftReferral.id!!)).isNotNull()
 


### PR DESCRIPTION
## What does this pull request do?

requires a service user CRN to create new draft referrals.

## What is the intent behind these changes?

update the API to match with the current front end designs for starting the referral process.
