### PR TITLE
create user entities before adding their ids to the new referral column to prevent violating FK constraint

### DIFF
--- a/src/main/resources/db/migration/V1_13_1__created_by_auth_user.sql
+++ b/src/main/resources/db/migration/V1_13_1__created_by_auth_user.sql
@@ -3,18 +3,18 @@ alter table referral
     add column created_by_id text,
     add constraint fk_created_by_id foreign key (created_by_id) references auth_user;
 
--- copy over all 'created_by_userid' values to the 'created_by_id' column. these columns hold the same value.
-update referral
-set created_by_id = created_by_userid;
-
-alter table referral
-    alter column created_by_id set not null;
-
 -- create any auth user entities that exist in the referral table but not the auth_user table.
 insert into auth_user (id, auth_source)
     select created_by_userid, created_by_user_auth_source
     from referral r
     where not exists (select from auth_user where id = r.created_by_userid);
+
+-- copy over all 'created_by_userid' values to the 'created_by_id' column. these columns hold the same value.
+update referral
+    set created_by_id = created_by_userid;
+
+alter table referral
+    alter column created_by_id set not null;
 
 -- drop the index on the old 'created_by_userid' column and add it to the new 'created_by_id' column.
 drop index IX_referral_created_by_userid;


### PR DESCRIPTION
## What does this pull request do?

create user entities before adding their ids to the new referral column to prevent violating FK constraint

## What is the intent behind these changes?

fix broken migration and unblock deploy
