### PR TITLE
add 'on conflict' to handle duplicate user case

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,4 +17,3 @@ logging:
 spring:
   flyway:
     locations: classpath:db/migration,classpath:db/local
-    clean-on-validation-error: true # DO NOT *EVER* SET THIS IN PRODUCTION

--- a/src/main/resources/db/migration/V1_13_1__created_by_auth_user.sql
+++ b/src/main/resources/db/migration/V1_13_1__created_by_auth_user.sql
@@ -6,8 +6,8 @@ alter table referral
 -- create any auth user entities that exist in the referral table but not the auth_user table.
 insert into auth_user (id, auth_source)
     select created_by_userid, created_by_user_auth_source
-    from referral r
-    where not exists (select from auth_user where id = r.created_by_userid);
+    from referral
+    on conflict do nothing;
 
 -- copy over all 'created_by_userid' values to the 'created_by_id' column. these columns hold the same value.
 update referral


### PR DESCRIPTION
## What does this pull request do?

add 'on conflict' to handle duplicate user case.

also remove 'clean on validation' from local config so we avoid situations like this in the future.

## What is the intent behind these changes?

get the latest migrations applied and unblock deploy.
