### PR TITLE
Change code owners to interventions-service team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @ministryofjustice/hmpps-interventions
+* @ministryofjustice/interventions-service
 src/main/resources/db/migration/ @ministryofjustice/interventions-data-engineers


### PR DESCRIPTION
## What does this pull request do?

Changes the code owners to the interventions-service team, which only contains backend developers.

## What is the intent behind these changes?

To stop frontend-only developers from being bothered by automatic review requests for this repo.