### PR TITLE
🐛 Re-enable multiple referrals by the same user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -8,20 +8,21 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralD
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
-class ReferralService(val repository: ReferralRepository) {
+class ReferralService(val repository: ReferralRepository, val authUserRepository: AuthUserRepository) {
   fun getSentReferral(id: UUID): Referral? {
     return repository.findByIdAndSentAtIsNotNull(id)
   }
 
   fun sendDraftReferral(referral: Referral, user: AuthUser): Referral {
     referral.sentAt = OffsetDateTime.now()
-    referral.sentBy = user
+    referral.sentBy = authUserRepository.save(user)
 
     // fixme: hardcoded for now
     referral.referenceNumber = "HDJ2123F"
@@ -29,7 +30,7 @@ class ReferralService(val repository: ReferralRepository) {
   }
 
   fun createDraftReferral(user: AuthUser, crn: String): Referral {
-    return repository.save(Referral(serviceUserCRN = crn, createdBy = user))
+    return repository.save(Referral(serviceUserCRN = crn, createdBy = authUserRepository.save(user)))
   }
 
   fun getDraftReferral(id: UUID): Referral? {


### PR DESCRIPTION
## What does this pull request do?

Re-enables starting referrals by the same user -- currently 🐛 not working due to

```
'could not execute statement; SQL [n/a]; constraint [auth_user_pkey];
⮑ nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement'
```

## What is the intent behind these changes?

The above error happens when the same user is trying to create a new draft referral.

This is due to
- the primary key constraint on the `auth_user` table
- the `cascade = [CascadeType.PERSIST]` setting on `Referral` for the
  `createdBy` field

It seems the persistence framework cannot or did not decide whether
the `AuthUser` instance has been persisted yet or not.

I've tried a couple of things:
- overriding the repository's `save` function
- playing with other cascade types
- persisting the user directly

Decided on the last one as it's the simplest to understand solution.

With explicit `authUserRepository.save(...)` calls in the
`ReferralService`,  we can guarantee that the `Referral` object does not
have transient linked data.