### PR TITLE
Reduce initial delay for quicker deployment time

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
@@ -43,16 +43,14 @@ spec:
             httpGet:
               path: /health/liveness
               port: {{ .Values.image.port }}
-            periodSeconds: 30
-            initialDelaySeconds: 90
-            timeoutSeconds: 20
-            failureThreshold: 10
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /health/readiness
               port: {{ .Values.image.port }}
-            periodSeconds: 20
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
-            failureThreshold: 15
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
   {{ include "deployment.envs" . | nindent 10 }}


### PR DESCRIPTION
## What does this pull request do?

Reduces the initial delay during deployment.

## What is the intent behind these changes?

To make deployments stall less, leading to quicker turnarounds and fewer minutes spent on CI.

Currently, a deploy takes less than 10 seconds:

```
$ k get pod/hmpps-interventions-service-5ff6678c86-f84r7 -ojson | \
  jq '.status | .startTime, .containerStatuses[].state.running.startedAt'
"2021-01-21T20:55:15Z"
"2021-01-21T20:55:21Z"

$ k get pod/hmpps-interventions-service-5ff6678c86-7548w -ojson | \
  jq '.status | .startTime, .containerStatuses[].state.running.startedAt'
"2021-01-21T20:55:15Z"
"2021-01-21T20:55:23Z"
```

To avoid stalling the deploy for 60 seconds (the value of the `readinessProbe.initialDelaySeconds`) we can set it to 10 seconds.

I feel the default 10 seconds value for `periodSeconds` also makes sense.

This change is similar to https://github.com/ministryofjustice/hmpps-interventions-ui/pull/41.