### PR TITLE
IC-972 store SU disabilities as list of strings 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.hibernate:hibernate-core:5.4.24.Final")
+  implementation("com.vladmihalcea:hibernate-types-52:2.10.2")
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceUserDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceUserDTO.kt
@@ -13,7 +13,7 @@ data class ServiceUserDTO(
   var ethnicity: String? = null,
   var preferredLanguage: String? = null,
   var religionOrBelief: String? = null,
-  var disabilities: String? = null,
+  var disabilities: List<String>? = null,
 ) {
   companion object {
     fun from(crn: String, serviceUserData: ServiceUserData?): ServiceUserDTO {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceUserData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceUserData.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
+import com.vladmihalcea.hibernate.type.array.ListArrayType
+import org.hibernate.annotations.Type
+import org.hibernate.annotations.TypeDef
 import java.util.Date
 import java.util.UUID
 import javax.persistence.Column
@@ -12,6 +15,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "referral_service_user_data")
+@TypeDef(name = "list-array", typeClass = ListArrayType::class)
 data class ServiceUserData(
   var title: String? = null,
   var firstName: String? = null,
@@ -21,7 +25,9 @@ data class ServiceUserData(
   var ethnicity: String? = null,
   var preferredLanguage: String? = null,
   var religionOrBelief: String? = null,
-  var disabilities: String? = null,
+
+  @Type(type = "list-array") @Column(name = "disabilities", columnDefinition = "text[]")
+  var disabilities: List<String>? = null,
 
   @OneToOne @MapsId @JoinColumn(name = "referral_id") var referral: Referral? = null,
   @Id @Column(name = "referral_id") var referralID: UUID? = null,

--- a/src/main/resources/db/local/V99_0__draft_referrals.sql
+++ b/src/main/resources/db/local/V99_0__draft_referrals.sql
@@ -9,4 +9,4 @@ values ('ac386c25-52c8-41fa-9213-fcf42e24b0b5', '2020-12-07 18:02:01.599803+00',
        ('1219a064-709b-4b6c-a11e-10b8cb3966f6', '2021-01-12 14:46:21.987234+00', 'X862134', null, '2500128586', '428ee70f-3001-4399-95a6-ad25eaaede16');
 
 insert into referral_service_user_data (referral_id, disabilities, dob, ethnicity, title, first_name, last_name, preferred_language, religion_or_belief, gender)
-values ('1219a064-709b-4b6c-a11e-10b8cb3966f6', 'Autism spectrum condition', TO_DATE('1980-08-10', 'YYYY-MM-DD'), 'White British', 'Mr', 'Alex', 'River', 'English', 'None', 'Male');
+values ('1219a064-709b-4b6c-a11e-10b8cb3966f6', '{Autism spectrum condition}', TO_DATE('1980-08-10', 'YYYY-MM-DD'), 'White British', 'Mr', 'Alex', 'River', 'English', 'None', 'Male');

--- a/src/main/resources/db/migration/V1_14__disabilities_list.sql
+++ b/src/main/resources/db/migration/V1_14__disabilities_list.sql
@@ -1,0 +1,2 @@
+alter table referral_service_user_data
+    alter disabilities type text[] using array[disabilities];


### PR DESCRIPTION
## What does this pull request do?

stores disabilities as a list of strings instead of a single string. 

see this thread for more details https://github.com/ministryofjustice/hmpps-interventions-ui/pull/82#discussion_r562628835

## What is the intent behind these changes?

allow the front end to store structured data about SU disabilities instead of squashing them together in a single string.
