### PR TITLE
remove unneeded 'CascadeType' annotations 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -24,12 +24,11 @@ import javax.validation.constraints.NotNull
 @Table(indexes = arrayOf(Index(columnList = "created_by_id")))
 data class Referral(
   var sentAt: OffsetDateTime? = null,
-  @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST]) var sentBy: AuthUser? = null,
+  @ManyToOne(fetch = FetchType.LAZY) var sentBy: AuthUser? = null,
   var referenceNumber: String? = null,
 
   // draft referral fields
-  @OneToOne(mappedBy = "referral", cascade = arrayOf(CascadeType.ALL)) @PrimaryKeyJoinColumn
-  var serviceUserData: ServiceUserData? = null,
+  @OneToOne(mappedBy = "referral", cascade = arrayOf(CascadeType.ALL)) @PrimaryKeyJoinColumn var serviceUserData: ServiceUserData? = null,
   var additionalRiskInformation: String? = null,
   var furtherInformation: String? = null,
   var additionalNeedsInformation: String? = null,
@@ -42,7 +41,7 @@ data class Referral(
   var serviceCategoryID: UUID? = null,
   var usingRarDays: Boolean? = null,
   var maximumRarDays: Int? = null,
-  @NotNull @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST]) var createdBy: AuthUser? = null,
+  @NotNull @ManyToOne(fetch = FetchType.LAZY) var createdBy: AuthUser? = null,
   @ElementCollection
   @CollectionTable(
     name = "referral_desired_outcome",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -31,14 +31,10 @@ class ReferralRepositoryTest @Autowired constructor(
   @Test
   fun `removing a referral does not remove associated auth_user`() {
     val user = AuthUser("user_id", "auth_source")
+    entityManager.persist(user)
     val referral = Referral(serviceUserCRN = "X123456", createdBy = user)
     entityManager.persist(referral)
     entityManager.flush()
-
-    // check the user has been persisted by the cascade setting
-    val users = authUserRepository.findAll() as List<AuthUser>
-    Assertions.assertThat(users.size).isEqualTo(1)
-    Assertions.assertThat(users[0]).isEqualTo(user)
 
     // check that when the referral is deleted, the user is not
     entityManager.remove(referral)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralServiceTest.kt
@@ -129,12 +129,9 @@ class ReferralServiceTest @Autowired constructor(
   fun `find by userID returns list of draft referrals`() {
     val user1 = AuthUser("123", "delius")
     val user2 = AuthUser("456", "delius")
-    val referrals = listOf(
-      Referral(serviceUserCRN = "X123456", createdBy = user1),
-      Referral(serviceUserCRN = "X123456", createdBy = user1),
-      Referral(serviceUserCRN = "X123456", createdBy = user2),
-    )
-    referrals.forEach { entityManager.persist(it) }
+    referralService.createDraftReferral(user1, "X123456")
+    referralService.createDraftReferral(user1, "X123456")
+    referralService.createDraftReferral(user2, "X123456")
     entityManager.flush()
 
     val single = referralService.getDraftReferralsCreatedByUserID("456")


### PR DESCRIPTION
this is related to 97d8aa2a90ba850acd87cccdc8ccfadef37d8f2f - these should probably have been taken out then

## What does this pull request do?

remove unneeded 'CascadeType' annotations 

## What is the intent behind these changes?

code clean up
