### PR TITLE
fix mismatch between date of birth fields between api and frontend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceUserDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceUserDTO.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
-import java.util.Date
+import java.time.LocalDate
 
 data class ServiceUserDTO(
   var crn: String? = null,
   var title: String? = null,
   var firstName: String? = null,
   var lastName: String? = null,
-  var dob: Date? = null,
+  var dateOfBirth: LocalDate? = null,
   var gender: String? = null,
   var ethnicity: String? = null,
   var preferredLanguage: String? = null,
@@ -23,7 +23,7 @@ data class ServiceUserDTO(
         dto.title = serviceUserData.title
         dto.firstName = serviceUserData.firstName
         dto.lastName = serviceUserData.lastName
-        dto.dob = serviceUserData.dob
+        dto.dateOfBirth = serviceUserData.dateOfBirth
         dto.gender = serviceUserData.gender
         dto.ethnicity = serviceUserData.ethnicity
         dto.preferredLanguage = serviceUserData.preferredLanguage

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceUserData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceUserData.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 import com.vladmihalcea.hibernate.type.array.ListArrayType
 import org.hibernate.annotations.Type
 import org.hibernate.annotations.TypeDef
-import java.util.Date
+import java.time.LocalDate
 import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -20,7 +20,7 @@ data class ServiceUserData(
   var title: String? = null,
   var firstName: String? = null,
   var lastName: String? = null,
-  @Column(name = "dob", columnDefinition = "DATE") var dob: Date? = null,
+  @Column(name = "dob") var dateOfBirth: LocalDate? = null,
   var gender: String? = null,
   var ethnicity: String? = null,
   var preferredLanguage: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/service/ReferralService.kt
@@ -158,7 +158,7 @@ class ReferralService(val repository: ReferralRepository, val authUserRepository
         title = it.title,
         firstName = it.firstName,
         lastName = it.lastName,
-        dob = it.dob,
+        dateOfBirth = it.dateOfBirth,
         gender = it.gender,
         ethnicity = it.ethnicity,
         preferredLanguage = it.preferredLanguage,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceUserDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceUserDTOTest.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
+import java.time.LocalDate
+
+@JsonTest
+class ServiceUserDTOTest(@Autowired private val json: JacksonTester<ServiceUserDTO>) {
+  @Test
+  fun `test deserialization of service user details`() {
+    val serviceUser = json.parseObject(
+      """
+          {
+            "crn": "CRN11",
+            "title": "Accepted",
+            "firstName": "KEN",
+            "lastName": "BARLOW",
+            "dateOfBirth": "2059-08-09",
+            "gender": "Accepted",
+            "ethnicity": "Accepted",
+            "preferredLanguage": "Accepted",
+            "religionOrBelief": "Accepted",
+            "disabilities": [
+              "prosthetic left leg",
+              "blindness"
+            ]
+          }
+      """
+    )
+    Assertions.assertThat(serviceUser.dateOfBirth).isEqualTo(LocalDate.of(2059, 8, 9))
+    Assertions.assertThat(serviceUser.disabilities).isEqualTo(listOf("prosthetic left leg", "blindness"))
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

fix mismatch between date of birth fields between api and frontend. there are two parts to this.
1) fix the name of the field
2) change to data type to the newer java8+ LocalDate type which automatically handles the date parsing and backing data type

## What is the intent behind these changes?

front end compatibility
