### PR TITLE
IC-710: Add error codes decision record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # HMPPS Interventions Service
 
-This is the HMPPS Interventions Service
+Business/domain API to **find, arrange and monitor an intervention** for service users (offenders).
 
 ## Quickstart
 
 ### Requirements
 
-- Docker 
+- Docker
 - Java
 
 Build and test:
@@ -20,7 +20,7 @@ First, add the following line to your `/etc/hosts` file to allow hmpps-auth inte
 
 ```127.0.0.1 hmpps-auth```
 
-Then run: 
+Then run:
 
 ```
 docker-compose pull
@@ -31,6 +31,9 @@ SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
 ## Architecture
 
 To see where this service fits in the broader interventions (and probation) architecture, you can browse the HMPPS C4 models [here](https://structurizr.com/share/56937/diagrams#interventions-container).
+
+- [Decisions specific to this application](doc/adr)
+- [Decisions relevant to the "interventions" domain](https://github.com/ministryofjustice/hmpps-interventions-docs)
 
 ## Code Style
 

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-11-24
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/adr/0002-represent-validation-errors-at-field-level.md
+++ b/doc/adr/0002-represent-validation-errors-at-field-level.md
@@ -1,0 +1,39 @@
+# 2. Represent validation errors at field level
+
+Date: 2020-12-10
+
+## Status
+
+Accepted
+
+## Context
+
+For any user interface or client relying on our API, we need to define how we represent what was wrong with
+invalid client requests.
+
+## Decision
+
+We will use field-level error validation.
+
+We will use meaningful codes per field.
+
+Example:
+```json
+{
+  "status": 400,
+  "error": "validation error",
+  "message": "draft referral update invalid",
+  "validationErrors": [
+    {
+      "field": "serviceUser.crn",
+      "error": "FIELD_CANNOT_BE_CHANGED"
+    }
+  ]
+}
+```
+
+## Consequences
+
+All validation errors have to have corresponding codes assigned to them.
+
+We have to document the expected error conditions in the OpenAPI specification.


### PR DESCRIPTION
## What does this pull request do?

Document how we represent error codes.

## What is the intent behind these changes?

To document decisions. Took me a while :)

I intend to go through https://dsdmoj.atlassian.net/browse/IC-709 (Decisions epic) and document all of them.

The changeset also includes the new, agreed name of the service and links to other ADRs.