### PR TITLE
IC-914 show referral notification in delius

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,10 @@ repositories {
 }
 
 configurations {
-  testImplementation { exclude(group = "org.junit.vintage") }
+  testImplementation {
+    exclude(group = "org.junit.vintage")
+    exclude("ch.qos.logback")
+  }
 }
 
 tasks {
@@ -41,6 +44,7 @@ dependencies {
   // security
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -52,4 +56,5 @@ dependencies {
 
   testImplementation("au.com.dius.pact.provider:junit5spring:4.1.14")
   testImplementation("com.h2database:h2:1.4.200")
+  testImplementation("uk.org.lidalia:slf4j-test:1.0.1")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfiguration(
+  @Value("\${community-api.baseurl}") private val communityApiBaseUrl: String,
+  private val webClientBuilder: WebClient.Builder
+) {
+  @Bean
+  fun communityApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+    oauth2Client.setDefaultClientRegistrationId("community-api")
+    return webClientBuilder
+      .baseUrl(communityApiBaseUrl)
+      .apply(oauth2Client.oauth2Configuration())
+      .exchangeStrategies(
+        ExchangeStrategies.builder()
+          .codecs { configurer ->
+            configurer.defaultCodecs()
+              .maxInMemorySize(-1)
+          }
+          .build()
+      )
+      .build()
+  }
+
+  @Bean
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository?,
+    clientService: OAuth2AuthorizedClientService?
+  ): OAuth2AuthorizedClientManager? {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
+      .clientCredentials()
+      .build()
+    val authorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(
+      clientRegistrationRepository,
+      clientService
+    )
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+    return authorizedClientManager
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import java.time.LocalDate
+
+@Service
+class CommunityAPIService(
+  @Value("\${community-api.temporaryReferralRequest.probationAreaCode}") private val probationAreaCode: String,
+  @Value("\${community-api.temporaryReferralRequest.referralType}") private val referralType: String,
+  @Value("\${community-api.temporaryReferralRequest.staffCode}") private val staffCode: String,
+  @Value("\${community-api.temporaryReferralRequest.teamCode}") private val teamCode: String,
+  @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
+  @Value("\${interventions-ui.locations.sent-referral}") private val interventionsUISentReferralLocation: String,
+  @Value("\${community-api.locations.sent-referral}") private val communityAPISentReferralLocation: String,
+  private val communityApiWebClient: WebClient,
+) : ApplicationListener<ReferralEvent> {
+
+  override fun onApplicationEvent(event: ReferralEvent) {
+    when (event.type) {
+      ReferralEventType.SENT -> {
+        val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
+          .path(interventionsUISentReferralLocation)
+          .buildAndExpand(event.referral.id)
+          .toString()
+
+        val body = ReferRequest(
+          probationAreaCode,
+          referralType,
+          staffCode,
+          teamCode,
+          url,
+          event.referral.sentAt!!.toLocalDate()
+        )
+
+        val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPISentReferralLocation)
+          .buildAndExpand(event.referral.serviceUserCRN)
+          .toString()
+
+        communityApiWebClient.post().uri(communityApiSentReferralPath)
+          .body(Mono.just(body), ReferRequest::class.java)
+          .retrieve()
+          .bodyToMono(Unit::class.java)
+          .onErrorResume { e ->
+            log.error("Call to community api to update contact log failed:", e)
+            Mono.empty()
+          }
+          .subscribe()
+      }
+    }
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(CommunityAPIService::class.java)
+  }
+}
+
+data class ReferRequest(
+  val probationAreaCode: String? = null,
+  val referralType: String? = null,
+  val staffCode: String? = null,
+  val teamCode: String? = null,
+  val notes: String? = null,
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val date: LocalDate? = null
+)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,16 @@ notify:
 interventions-ui:
   baseurl: http://localhost:3000
 
+community-api:
+  baseUrl: http://localhost:8081
+#  Temporarily stored in config until it is decided where these values will come from. TeamCode may come from the community api
+#  in the future. The rest may be hard coded as generic values.
+  temporaryReferralRequest:
+    probationAreaCode: A00
+    referralType: C385
+    staffCode: ASPUATU
+    teamCode: ASPUAT
+
 aws:
   sns:
     enabled: false
@@ -31,3 +41,10 @@ logging:
 spring:
   flyway:
     locations: classpath:db/migration,classpath:db/local
+  security:
+    oauth2:
+      client:
+        registration:
+          community-api:
+            client-id: interventions
+            client-secret: clientsecret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,15 @@ spring:
       WRITE_DATES_AS_TIMESTAMPS: false
   security:
     oauth2:
+      client:
+        provider:
+          hmppsauth:
+            token-uri: ${hmppsauth.baseurl}/oauth/token
+        registration:
+          community-api:
+            provider: hmppsauth
+            authorization-grant-type: client_credentials
+            scope: read
       resourceserver:
         jwt:
           issuer-uri: ${hmppsauth.baseurl}/issuer
@@ -67,6 +76,10 @@ notify:
 interventions-ui:
   locations:
     sent-referral: "/referrals/{id}/confirmation"
+
+community-api:
+  locations:
+    sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
 
 aws:
   sns:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIServiceTest.kt
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.org.lidalia.slf4jtest.TestLogger
+import uk.org.lidalia.slf4jtest.TestLoggerFactory
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+class CommunityAPIServiceTest {
+
+  private val exchangeFunction = mock<ExchangeFunction>()
+  private lateinit var communityAPIService: CommunityAPIService
+
+  @Test
+  fun `got service successfully`() {
+    val communityApiWebClient = WebClient.builder()
+      .exchangeFunction(exchangeFunction)
+      .build()
+
+    communityAPIService = CommunityAPIService(
+      "A00",
+      "C385",
+      "ASPUATU",
+      "ASPUAT",
+      "http://testUrl",
+      "secure/offenders/crn/{id}/referral/sent",
+      "secure/offenders/crn/{id}/referral/sent",
+      communityApiWebClient
+    )
+
+    whenever(exchangeFunction.exchange(any()))
+      .thenReturn(Mono.empty())
+
+    communityAPIService.onApplicationEvent(referralSentEvent)
+
+    verify(exchangeFunction, times(1)).exchange(any())
+
+    val requestCaptor = argumentCaptor<ClientRequest>()
+    verify(exchangeFunction).exchange(requestCaptor.capture())
+    val requestDetails = requestCaptor.firstValue
+
+    assertThat("secure/offenders/crn/X123456/referral/sent").isEqualTo(requestDetails.url().toString())
+  }
+
+  @Test
+  fun `error was logged on exception`() {
+    val logger: TestLogger = TestLoggerFactory.getTestLogger(CommunityAPIService::class.java)
+
+    val communityApiWebClient = WebClient.builder()
+      .exchangeFunction(exchangeFunction)
+      .build()
+
+    communityAPIService = CommunityAPIService(
+      "A00",
+      "C385",
+      "ASPUATU",
+      "ASPUAT",
+      "http://testUrl",
+      "/referral/{id}/sent",
+      "/referral/{id}/sent",
+      communityApiWebClient
+    )
+
+    whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException::class.java)
+    communityAPIService.onApplicationEvent(referralSentEvent)
+    assertThat(logger.loggingEvents.size == 1)
+    assertThat(logger.loggingEvents[0].level.name).isEqualTo("ERROR")
+    assertThat(logger.loggingEvents[0].message).isEqualTo("Call to community api to update contact log failed:")
+  }
+
+  private val referralSentEvent = ReferralEvent(
+    "source",
+    ReferralEventType.SENT,
+    SampleData.sampleReferral(
+      id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
+      referenceNumber = "HAS71263",
+      crn = "X123456",
+      serviceProviderName = "Harmony Living",
+      sentAt = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 0, ZoneOffset.of("+00:00"))
+    ),
+  )
+}


### PR DESCRIPTION
## What does this pull request do?

When a referral event is triggered, a post request will be sent to community api to insert a row into delius db - contact table with some details of the referral. 

## What is the intent behind these changes?

To update the delius contact log with the referral sent notification
