### PR TITLE
IC-1107 endpoint to get list of sent referrals with optional 'service provider id' query param

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService
@@ -55,6 +56,13 @@ class ReferralController(
     return referralService.getSentReferral(uuid)
       ?.let { SentReferralDTO.from(it) }
       ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$uuid]")
+  }
+
+  @GetMapping("/sent-referrals")
+  fun getSentReferrals(@RequestParam(required = false) serviceProviderID: AuthGroupID?): List<SentReferralDTO> {
+    return serviceProviderID?.let {
+      referralService.getSentReferralsForServiceProviderID(it)
+    } ?: referralService.getAllSentReferrals()
   }
 
   @PostMapping("/draft-referral")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
 import org.springframework.data.repository.CrudRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.util.UUID
 
 interface ReferralRepository : CrudRepository<Referral, UUID> {
   // queries for sent referrals
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?
+  fun findBySentAtIsNotNull(): List<Referral>
+  fun findByInterventionDynamicFrameworkContractServiceProviderIdAndSentAtIsNotNull(id: AuthGroupID): List<Referral>
 
   // queries for draft referrals
   fun findByIdAndSentAtIsNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -5,7 +5,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
@@ -25,6 +27,15 @@ class ReferralService(
 ) {
   fun getSentReferral(id: UUID): Referral? {
     return referralRepository.findByIdAndSentAtIsNotNull(id)
+  }
+
+  fun getAllSentReferrals(): List<SentReferralDTO> {
+    return referralRepository.findBySentAtIsNotNull().map { SentReferralDTO.from(it) }
+  }
+
+  fun getSentReferralsForServiceProviderID(serviceProviderID: AuthGroupID): List<SentReferralDTO> {
+    return referralRepository.findByInterventionDynamicFrameworkContractServiceProviderIdAndSentAtIsNotNull(serviceProviderID)
+      .map { SentReferralDTO.from(it) }
   }
 
   fun sendDraftReferral(referral: Referral, user: AuthUser): Referral {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -24,5 +25,14 @@ internal class ReferralControllerTest {
     assertThrows<ServerWebInputException> {
       referralController.createDraftReferral(CreateReferralRequestDTO("CRN20", UUID.randomUUID()), createJwtAuthenticationToken())
     }
+  }
+
+  @Test
+  fun `getSentReferrals takes an optional query param to filter by service provider ID`() {
+    referralController.getSentReferrals(null)
+    verify(referralService).getAllSentReferrals()
+
+    referralController.getSentReferrals("HARMONY_LIVING")
+    verify(referralService).getSentReferralsForServiceProviderID("HARMONY_LIVING")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -67,4 +67,7 @@ class PactTest {
 
   @State("a service provider with ID 674b47a0-39bf-4514-82ae-61885b9c0cb4 exists")
   fun `not implement yet - service provider`() {}
+
+  @State("there are some existing sent referrals")
+  fun `use referrals from seed data`() {}
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -33,13 +33,15 @@ class SampleData {
       serviceProviderName: String,
       id: UUID? = null,
       referenceNumber: String? = null,
-      completionDeadline: LocalDate? = null
+      completionDeadline: LocalDate? = null,
+      sentAt: OffsetDateTime? = null,
     ): Referral {
       return Referral(
         serviceUserCRN = crn,
         id = id,
         completionDeadline = completionDeadline,
         referenceNumber = referenceNumber,
+        sentAt = sentAt,
         intervention = sampleIntervention(
           dynamicFrameworkContract = sampleContract(
             serviceCategory = sampleServiceCategory(desiredOutcomes = emptyList()),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -302,4 +302,39 @@ class ReferralServiceTest @Autowired constructor(
     }
     assertThat(referralService.getDraftReferralsCreatedByUserID("multi_user_id")).hasSize(3)
   }
+
+  @Test
+  fun `get all sent referrals returns referrals for multiple service providers`() {
+    listOf("PROVIDER1", "PROVIDER2").forEach {
+      SampleData.persistReferral(
+        entityManager,
+        SampleData.sampleReferral(
+          "X123456",
+          it,
+          sentAt = OffsetDateTime.now(),
+          referenceNumber = "REF123"
+        )
+      )
+    }
+
+    assertThat(referralService.getAllSentReferrals().size).isEqualTo(2)
+  }
+
+  @Test
+  fun `get sent referrals by provider id returns filtered referrals`() {
+    listOf("PROVIDER1", "PROVIDER2").forEach {
+      SampleData.persistReferral(
+        entityManager,
+        SampleData.sampleReferral(
+          "X123456",
+          it,
+          sentAt = OffsetDateTime.now(),
+          referenceNumber = "REF123"
+        )
+      )
+    }
+
+    assertThat(referralService.getSentReferralsForServiceProviderID("PROVIDER2").size).isEqualTo(1)
+    assertThat(referralService.getSentReferralsForServiceProviderID("PROVIDER3").size).isEqualTo(0)
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds a `GET /sent-referrals` endpoint which accepts an optional `serviceProviderID` query param to allow retrieving sent referrals for a particular service provider.

## What is the intent behind these changes?

1. power the new SP dashboard screen
2. enable future filtering of referrals by SP
