### PR TITLE
Point to corrected swagger URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HMPPS Interventions Service
 
-[![API docs](https://img.shields.io/badge/API_docs-view-85EA2D.svg?logo=swagger)](https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/swagger-ui.html)
+[![API docs](https://img.shields.io/badge/API_docs-view-85EA2D.svg?logo=swagger)](https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/swagger-ui.html)
 
 Business/domain API to **find, arrange and monitor an intervention** for service users (offenders).
 


### PR DESCRIPTION
## What does this pull request do?

Corrects the API docs URL to point to:

![image](https://user-images.githubusercontent.com/1526295/107641559-af1ac600-6c6b-11eb-8613-6f2fcc8be2de.png)

## What is the intent behind these changes?

Make the link work