### PR TITLE
Use the new, global HMPPS domain events topic

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -73,19 +73,19 @@ env:
   - name: AWS_SNS_ACCESSKEYID
     valueFrom:
       secretKeyRef:
-        name: intervention-events-topic
+        name: hmpps-domain-events-topic
         key: access_key_id
 
   - name: AWS_SNS_SECRETACCESSKEY
     valueFrom:
       secretKeyRef:
-        name: intervention-events-topic
+        name: hmpps-domain-events-topic
         key: secret_access_key
 
   - name: AWS_SNS_TOPIC_ARN
     valueFrom:
       secretKeyRef:
-        name: intervention-events-topic
+        name: hmpps-domain-events-topic
         key: topic_arn
 
 {{- end -}}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -23,9 +23,9 @@ class SNSService(
       ReferralEventType.SENT -> {
         // fixme: what data needs to go in here
         val message = mapOf(
-          "type" to "referral-sent",
+          "eventType" to "intervention.referral.sent",
           "description" to "A referral has been sent to a Service Provider",
-          "id" to event.referral.id,
+          "referral_id" to event.referral.id,
         )
         publish(objectMapper.writeValueAsString(message))
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSServiceTest.kt
@@ -44,7 +44,7 @@ internal class SNSServiceTest {
     verify(snsClient).publish(requestCaptor.capture())
     assertThat(requestCaptor.firstValue.message()).isEqualTo(
       """
-      {"type":"referral-sent","description":"A referral has been sent to a Service Provider","id":"68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"}
+      {"eventType":"intervention.referral.sent","description":"A referral has been sent to a Service Provider","referral_id":"68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"}
       """.trimIndent()
     )
   }


### PR DESCRIPTION
## What does this pull request do?

Reconfigures the application to use the HMPPS domain events topic.
This is a new thing, we're moving towards a single domain event topic. [ADR here]( https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2811691200/Publishing+Microservice+Events)

The related infrastructure changes are in https://github.com/ministryofjustice/cloud-platform-environments/pull/4284.

## Event payload changes

Since all applications will use the domain events topic, the queue subscriptions need a way to filter for messages they are interested in.

- `type` &rarr; `eventType` as `eventType` is already used by other topics for SQS subscription filtering 
- `id` &rarr; `referral_id` to be explicit about what it means

## What is the intent behind these changes?

To follow the proposed event integration mechanism in HMPPS Digital.