### PR TITLE
allow intervention ID to be specified on creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 import java.time.LocalDate
 import java.util.UUID
 import javax.persistence.Entity
-import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -11,7 +10,7 @@ import javax.validation.constraints.NotNull
 
 @Entity
 data class DynamicFrameworkContract(
-  @NotNull @Id @GeneratedValue val id: UUID? = null,
+  @Id val id: UUID,
 
   @NotNull @ManyToOne @JoinColumn(name = "service_category_id")
   val serviceCategory: ServiceCategory,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -101,6 +101,7 @@ class SampleData {
     }
 
     fun sampleContract(
+      id: UUID? = null,
       startDate: LocalDate = LocalDate.of(2020, 12, 1),
       endDate: LocalDate = LocalDate.of(2021, 12, 1),
       serviceCategory: ServiceCategory,
@@ -109,6 +110,7 @@ class SampleData {
       pccRegion: PCCRegion? = null,
     ): DynamicFrameworkContract {
       return DynamicFrameworkContract(
+        id = id ?: UUID.randomUUID(),
         serviceCategory = serviceCategory,
         serviceProvider = serviceProvider,
         startDate = startDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/InterventionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/InterventionFactory.kt
@@ -3,6 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.NPSRegion
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PCCRegion
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceCategory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -18,21 +22,24 @@ class InterventionFactory(em: TestEntityManager) : EntityFactory(em) {
     createdAt: OffsetDateTime? = null,
     title: String = "Sheffield Housing Services",
     description: String = "Inclusive housing for South Yorkshire",
+    serviceCategory: ServiceCategory? = null,
+    serviceProvider: ServiceProvider? = null,
+    npsRegion: NPSRegion = npsRegionFactory.create(),
+    pccRegion: PCCRegion? = pccRegionFactory.create(npsRegion = npsRegion),
   ): Intervention {
-    // for now we aren't allowing any of the contract details to be configured
     val contract = save(
       DynamicFrameworkContract(
         id = UUID.randomUUID(),
-        serviceCategory = serviceCategoryFactory.create(),
-        serviceProvider = serviceProviderFactory.create(),
+        serviceCategory = serviceCategory ?: serviceCategoryFactory.create(),
+        serviceProvider = serviceProvider ?: serviceProviderFactory.create(),
         startDate = LocalDate.of(2021, 6, 1),
         endDate = LocalDate.of(2026, 6, 1),
         minimumAge = 18,
         maximumAge = null,
         allowsMale = true,
         allowsFemale = true,
-        npsRegion = npsRegionFactory.create(),
-        pccRegion = pccRegionFactory.create(),
+        npsRegion = npsRegion,
+        pccRegion = pccRegion,
       )
     )
 


### PR DESCRIPTION
## What does this pull request do?

removed 'GeneratedValue' from intervention entity to match new pattern used elsewhere.

## What is the intent behind these changes?

allow creation of interventions with known IDs.
