### PR TITLE
add ability to filter Get /interventions by gender. AllowsFemale & Al…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
@@ -23,8 +23,12 @@ class InterventionController(
   }
 
   @GetMapping("/interventions")
-  fun getInterventions(@RequestParam(name = "pccRegionIds", required = false) pccRegionIds: List<String>?): List<InterventionDTO> {
+  fun getInterventions(
+    @RequestParam(name = "pccRegionIds", required = false) pccRegionIds: List<String>?,
+    @RequestParam(name = "allowsFemale", required = false) allowsFemale: Boolean?,
+    @RequestParam(name = "allowsMale", required = false) allowsMale: Boolean?,
+  ): List<InterventionDTO> {
 
-    return interventionService.getInterventions(pccRegionIds.orEmpty())
+    return interventionService.getInterventions(pccRegionIds.orEmpty(), allowsFemale, allowsMale)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepository.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 
 interface InterventionFilterRepository {
-  fun findByCriteria(locations: List<String>): List<Intervention>
+  fun findByCriteria(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?): List<Intervention>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
@@ -28,8 +28,8 @@ class InterventionService(
     }
   }
 
-  fun getInterventions(pccRegionIds: List<String>): List<InterventionDTO> {
-    return interventionRepository.findByCriteria(pccRegionIds).map {
+  fun getInterventions(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?): List<InterventionDTO> {
+    return interventionRepository.findByCriteria(pccRegionIds, allowsFemale, allowsMale).map {
       InterventionDTO.from(it, getPCCRegions(it))
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
@@ -16,11 +16,11 @@ internal class InterventionControllerTest {
   fun `getInterventions returns interventions based on filtering`() {
     val locations = emptyList<String>()
     val interventionDTOs = emptyList<InterventionDTO>()
-    whenever(interventionService.getInterventions(locations)).thenReturn(interventionDTOs)
+    whenever(interventionService.getInterventions(locations, allowsFemale = true, allowsMale = true)).thenReturn(interventionDTOs)
 
-    val responseDTOs = interventionController.getInterventions(locations)
+    val responseDTOs = interventionController.getInterventions(locations, allowsFemale = true, allowsMale = true)
 
-    verify(interventionService).getInterventions(locations)
+    verify(interventionService).getInterventions(locations, allowsFemale = true, allowsMale = true)
     assertSame(interventionDTOs, responseDTOs)
   }
 
@@ -28,11 +28,11 @@ internal class InterventionControllerTest {
   fun `getInterventions returns interventions unfiltered when no parameters supplied`() {
     val locations: List<String>? = null
     val interventionDTOs = emptyList<InterventionDTO>()
-    whenever(interventionService.getInterventions(emptyList())).thenReturn(interventionDTOs)
+    whenever(interventionService.getInterventions(emptyList(), null, null)).thenReturn(interventionDTOs)
 
-    val responseDTOs = interventionController.getInterventions(locations)
+    val responseDTOs = interventionController.getInterventions(locations, null, null)
 
-    verify(interventionService).getInterventions(emptyList())
+    verify(interventionService).getInterventions(emptyList(), null, null)
     assertSame(interventionDTOs, responseDTOs)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImplTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImplTest.kt
@@ -35,7 +35,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()), title = "test Title")
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf())
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, null)
     assertThat(found.size).isEqualTo(3)
   }
 
@@ -44,7 +44,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create(id = 'H', name = "name")))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("devon-and-cornwall"))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("devon-and-cornwall"), null, null)
 
     assertThat(found.size).isEqualTo(2)
     found.forEach {
@@ -57,7 +57,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create(id = "testID", name = "testName")))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), null, null)
 
     assertThat(found.size).isEqualTo(2)
     found.forEach {
@@ -70,11 +70,89 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create(id = "testID", name = "testName")))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), null, null)
 
     assertThat(found.size).isEqualTo(2)
     found.forEach {
       assert(it.dynamicFrameworkContract.pccRegion?.id.equals("avon-and-somerset") || it.dynamicFrameworkContract.npsRegion?.id?.equals('G')!!)
     }
+  }
+
+  @Test
+  fun `get interventions filtering by allowsFemale is true`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), true, null)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
+  }
+
+  @Test
+  fun `get interventions filtering by allowsFemale is false`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), false, null)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsFemale).isFalse
+  }
+
+  @Test
+  fun `get interventions filtering by allowsMale is true`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, true)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsMale).isTrue
+  }
+
+  @Test
+  fun `get interventions filtering by allowsMale is false`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, false)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsMale).isFalse
+  }
+
+  @Test
+  fun `get interventions filtering by both allowsMale is true and allowsFemale is true`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), allowsFemale = true, allowsMale = true)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
+    assertThat(found[0].dynamicFrameworkContract.allowsMale).isTrue
+  }
+
+  @Test
+  fun `get interventions filtering by both allowsMale is false and allowsFemale is true`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), allowsFemale = true, allowsMale = false)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
+    assertThat(found[0].dynamicFrameworkContract.allowsMale).isFalse
+  }
+
+  @Test
+  fun `get interventions filtering by location, allowsMale and allowsFemale`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create(id = "testID", name = "testName")))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false, pccRegion = pccRegionFactory.create()))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), allowsFemale = true, allowsMale = false)
+
+    assertThat(found.size).isEqualTo(1)
+    assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
+    assertThat(found[0].dynamicFrameworkContract.allowsMale).isFalse
+    assertThat(found[0].dynamicFrameworkContract.pccRegion?.id).isEqualTo("avon-and-somerset")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceUnitTest.kt
@@ -27,11 +27,11 @@ class InterventionServiceUnitTest {
   fun `finds interventions using search criteria`() {
     val locations = emptyList<String>()
     val interventions = emptyList<Intervention>()
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
 
-    interventionService.getInterventions(locations)
+    interventionService.getInterventions(locations, null, null)
 
-    verify(interventionRepository).findByCriteria(locations)
+    verify(interventionRepository).findByCriteria(locations, null, null)
   }
 
   @Test
@@ -40,9 +40,9 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = sampleNPSRegion(), pccRegion = samplePCCRegion())
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
 
-    interventionService.getInterventions(locations)
+    interventionService.getInterventions(locations, null, null)
 
     verifyZeroInteractions(pccRegionRepository)
   }
@@ -55,10 +55,10 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    interventionService.getInterventions(locations)
+    interventionService.getInterventions(locations, null, null)
 
     verify(pccRegionRepository).findAllByNpsRegionId(npsRegion.id)
   }
@@ -71,10 +71,40 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    val interventionDTOs = interventionService.getInterventions(locations)
+    val interventionDTOs = interventionService.getInterventions(locations, null, null)
+
+    assertEquals(interventionDTOs.size, interventions.size)
+  }
+
+  @Test
+  fun `should return an intervention with allowsFemale parameter`() {
+    val npsRegion = sampleNPSRegion()
+    val pccRegion = samplePCCRegion()
+    val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
+    val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
+    val interventions = listOf(intervention)
+    whenever(interventionRepository.findByCriteria(listOf(), true, null)).thenReturn(interventions)
+    whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
+
+    val interventionDTOs = interventionService.getInterventions(listOf(), true, null)
+
+    assertEquals(interventionDTOs.size, interventions.size)
+  }
+
+  @Test
+  fun `should return an intervention with allowsMale parameter`() {
+    val npsRegion = sampleNPSRegion()
+    val pccRegion = samplePCCRegion()
+    val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
+    val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
+    val interventions = listOf(intervention)
+    whenever(interventionRepository.findByCriteria(listOf(), null, true)).thenReturn(interventions)
+    whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
+
+    val interventionDTOs = interventionService.getInterventions(listOf(), null, true)
 
     assertEquals(interventionDTOs.size, interventions.size)
   }


### PR DESCRIPTION
…lowsMale

## What does this pull request do?

Provides the ability to pass 'allowsMale' & 'allowsFemale' boolean parameters into the GET /interventions endpoint. This will allows the search results to filter on these parameters. This will also work in combination with a location filter.

## What is the intent behind these changes?

To allow the filtering of intervention search results, as per IC-1026
