### PR TITLE
IC-1061 - Filter by min and mage ages

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
@@ -23,8 +23,12 @@ class InterventionController(
   }
 
   @GetMapping("/interventions")
-  fun getInterventions(@RequestParam(name = "pccRegionIds", required = false) pccRegionIds: List<String>?): List<InterventionDTO> {
+  fun getInterventions(
+    @RequestParam(name = "pccRegionIds", required = false) pccRegionIds: List<String>?,
+    @RequestParam(name = "minimumAge", required = false) minimumAge: Int?,
+    @RequestParam(name = "maximumAge", required = false) maximumAge: Int?
+  ): List<InterventionDTO> {
 
-    return interventionService.getInterventions(pccRegionIds.orEmpty())
+    return interventionService.getInterventions(pccRegionIds.orEmpty(), minimumAge, maximumAge)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepository.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 
 interface InterventionFilterRepository {
-  fun findByCriteria(locations: List<String>): List<Intervention>
+  fun findByCriteria(pccRegionIds: List<String>, minimumAge: Int?, maximumAge: Int?): List<Intervention>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
@@ -28,8 +28,8 @@ class InterventionService(
     }
   }
 
-  fun getInterventions(pccRegionIds: List<String>): List<InterventionDTO> {
-    return interventionRepository.findByCriteria(pccRegionIds).map {
+  fun getInterventions(pccRegionIds: List<String>, minimumAge: Int?, maximumAge: Int?): List<InterventionDTO> {
+    return interventionRepository.findByCriteria(pccRegionIds, minimumAge, maximumAge).map {
       InterventionDTO.from(it, getPCCRegions(it))
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
@@ -14,25 +14,29 @@ internal class InterventionControllerTest {
 
   @Test
   fun `getInterventions returns interventions based on filtering`() {
-    val locations = emptyList<String>()
+    val pccRegionIds = emptyList<String>()
+    val minimumAge: Int? = 18
+    val maximumAge: Int? = 24
     val interventionDTOs = emptyList<InterventionDTO>()
-    whenever(interventionService.getInterventions(locations)).thenReturn(interventionDTOs)
+    whenever(interventionService.getInterventions(pccRegionIds, minimumAge, maximumAge)).thenReturn(interventionDTOs)
 
-    val responseDTOs = interventionController.getInterventions(locations)
+    val responseDTOs = interventionController.getInterventions(pccRegionIds, minimumAge, maximumAge)
 
-    verify(interventionService).getInterventions(locations)
+    verify(interventionService).getInterventions(pccRegionIds, minimumAge, maximumAge)
     assertSame(interventionDTOs, responseDTOs)
   }
 
   @Test
   fun `getInterventions returns interventions unfiltered when no parameters supplied`() {
-    val locations: List<String>? = null
+    val pccRegionIds: List<String>? = null
+    val minimumAge: Int? = null
+    val maximumAge: Int? = null
     val interventionDTOs = emptyList<InterventionDTO>()
-    whenever(interventionService.getInterventions(emptyList())).thenReturn(interventionDTOs)
+    whenever(interventionService.getInterventions(emptyList(), minimumAge, maximumAge)).thenReturn(interventionDTOs)
 
-    val responseDTOs = interventionController.getInterventions(locations)
+    val responseDTOs = interventionController.getInterventions(pccRegionIds, minimumAge, maximumAge)
 
-    verify(interventionService).getInterventions(emptyList())
+    verify(interventionService).getInterventions(emptyList(), minimumAge, maximumAge)
     assertSame(interventionDTOs, responseDTOs)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceUnitTest.kt
@@ -23,58 +23,56 @@ class InterventionServiceUnitTest {
   private val pccRegionRepository = mock<PCCRegionRepository>()
   private val interventionService = InterventionService(pccRegionRepository, interventionRepository)
 
+  private val pccRegionIds = emptyList<String>()
+  private val minimumAge: Int? = null
+  private val maximumAge: Int? = null
+  private val npsRegion = sampleNPSRegion()
+  private val pccRegion = samplePCCRegion()
+
   @Test
   fun `finds interventions using search criteria`() {
-    val locations = emptyList<String>()
     val interventions = emptyList<Intervention>()
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(pccRegionIds, minimumAge, maximumAge)).thenReturn(interventions)
 
-    interventionService.getInterventions(locations)
+    interventionService.getInterventions(pccRegionIds, minimumAge, maximumAge)
 
-    verify(interventionRepository).findByCriteria(locations)
+    verify(interventionRepository).findByCriteria(pccRegionIds, minimumAge, maximumAge)
   }
 
   @Test
   fun `should not look up regions for intervention containing contract with pcc region`() {
-    val locations = emptyList<String>()
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = sampleNPSRegion(), pccRegion = samplePCCRegion())
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(pccRegionIds, minimumAge, maximumAge)).thenReturn(interventions)
 
-    interventionService.getInterventions(locations)
+    interventionService.getInterventions(pccRegionIds, minimumAge, maximumAge)
 
     verifyZeroInteractions(pccRegionRepository)
   }
 
   @Test
   fun `looks up regions for intervention containing contract without pcc region using nps region`() {
-    val locations = emptyList<String>()
-    val npsRegion = sampleNPSRegion()
-    val pccRegion = samplePCCRegion()
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(pccRegionIds, minimumAge, maximumAge)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    interventionService.getInterventions(locations)
+    interventionService.getInterventions(pccRegionIds, minimumAge, maximumAge)
 
     verify(pccRegionRepository).findAllByNpsRegionId(npsRegion.id)
   }
 
   @Test
   fun `should return an intervention`() {
-    val locations = emptyList<String>()
-    val npsRegion = sampleNPSRegion()
-    val pccRegion = samplePCCRegion()
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(pccRegionIds, minimumAge, maximumAge)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    val interventionDTOs = interventionService.getInterventions(locations)
+    val interventionDTOs = interventionService.getInterventions(pccRegionIds, minimumAge, maximumAge)
 
     assertEquals(interventionDTOs.size, interventions.size)
   }


### PR DESCRIPTION
## What does this pull request do?

Provides the ability to pass 'minimumAge' & 'maximumAge' parameters into the GET /interventions endpoint. This will allows the search results to filter on these parameters. This will also work in combination with a location and gender filters.

## What is the intent behind these changes?

To allow the filtering of intervention search results, as per IC-1061