### PR TITLE
IC-1061 filter by min max age (using gender filter branch)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
@@ -27,8 +27,10 @@ class InterventionController(
     @RequestParam(name = "pccRegionIds", required = false) pccRegionIds: List<String>?,
     @RequestParam(name = "allowsFemale", required = false) allowsFemale: Boolean?,
     @RequestParam(name = "allowsMale", required = false) allowsMale: Boolean?,
+    @RequestParam(name = "minimumAge", required = false) minimumAge: Int?,
+    @RequestParam(name = "maximumAge", required = false) maximumAge: Int?
   ): List<InterventionDTO> {
 
-    return interventionService.getInterventions(pccRegionIds.orEmpty(), allowsFemale, allowsMale)
+    return interventionService.getInterventions(pccRegionIds.orEmpty(), allowsFemale, allowsMale, minimumAge, maximumAge)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepository.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 
 interface InterventionFilterRepository {
-  fun findByCriteria(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?): List<Intervention>
+  fun findByCriteria(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?, minimumAge: Int?, maximumAge: Int?): List<Intervention>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImpl.kt
@@ -77,16 +77,16 @@ class InterventionFilterRepositoryImpl(
   private fun getMinimumAgePredicate(criteriaBuilder: CriteriaBuilder, root: Root<Intervention>, minimumAge: Int?): Predicate? {
 
     return minimumAge?.let {
-      val expression = root.get<Any>("dynamicFrameworkContract").get<Int>("minimumAge")
-      criteriaBuilder.`equal`(expression, minimumAge)
+      val expression = root.get<DynamicFrameworkContract>("dynamicFrameworkContract").get<Int>("minimumAge")
+      criteriaBuilder.equal(expression, minimumAge)
     }
   }
 
   private fun getMaximumAgePredicate(criteriaBuilder: CriteriaBuilder, root: Root<Intervention>, maximumAge: Int?): Predicate? {
 
     return maximumAge?.let {
-      val expression = root.get<Any>("dynamicFrameworkContract").get<Int>("maximumAge")
-      criteriaBuilder.`equal`(expression, maximumAge)
+      val expression = root.get<DynamicFrameworkContract>("dynamicFrameworkContract").get<Int>("maximumAge")
+      criteriaBuilder.equal(expression, maximumAge)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImpl.kt
@@ -17,11 +17,7 @@ class InterventionFilterRepositoryImpl(
   @PersistenceContext
   private lateinit var entityManager: EntityManager
 
-  override fun findByCriteria(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?): List<Intervention> {
-    return findByCriteria(pccRegionIds, allowsFemale, allowsMale, null)
-  }
-
-  private fun findByCriteria(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?, ageCategory: String?): List<Intervention> {
+  override fun findByCriteria(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?, minimumAge: Int?, maximumAge: Int?): List<Intervention> {
 
     val criteriaBuilder = entityManager.criteriaBuilder
     val criteriaQuery = criteriaBuilder.createQuery(Intervention::class.java)
@@ -30,9 +26,10 @@ class InterventionFilterRepositoryImpl(
     val regionPredicate: Predicate? = getRegionPredicate(criteriaBuilder, root, pccRegionIds)
     val allowsFemalePredicate: Predicate? = getAllowsFemalePredicate(criteriaBuilder, root, allowsFemale)
     val allowsMalePredicate: Predicate? = getAllowsMalePredicate(criteriaBuilder, root, allowsMale)
-    val ageCategoryPredicate: Predicate? = getAgeCategoryPredicate(criteriaBuilder, root, ageCategory)
+    val minimumAgePredicate: Predicate? = getMinimumAgePredicate(criteriaBuilder, root, minimumAge)
+    val maximumAgePredicate: Predicate? = getMaximumAgePredicate(criteriaBuilder, root, maximumAge)
 
-    val predicates = listOfNotNull(regionPredicate, allowsFemalePredicate, allowsMalePredicate, ageCategoryPredicate)
+    val predicates = listOfNotNull(regionPredicate, allowsFemalePredicate, allowsMalePredicate, minimumAgePredicate, maximumAgePredicate)
     val finalPredicate: Predicate = criteriaBuilder.and(*predicates.toTypedArray())
 
     criteriaQuery.where(finalPredicate)
@@ -77,12 +74,19 @@ class InterventionFilterRepositoryImpl(
     return criteriaBuilder.equal(root.get<DynamicFrameworkContract>("dynamicFrameworkContract")?.get<Boolean>("allowsMale"), allowsMale)
   }
 
-  private fun getAgeCategoryPredicate(criteriaBuilder: CriteriaBuilder?, root: Root<Intervention>?, ageCategory: String?): Predicate? {
+  private fun getMinimumAgePredicate(criteriaBuilder: CriteriaBuilder, root: Root<Intervention>, minimumAge: Int?): Predicate? {
 
-    if (ageCategory.isNullOrEmpty()) {
-      return null
+    return minimumAge?.let {
+      val expression = root.get<Any>("dynamicFrameworkContract").get<Int>("minimumAge")
+      criteriaBuilder.`equal`(expression, minimumAge)
     }
+  }
 
-    TODO("Not yet implemented")
+  private fun getMaximumAgePredicate(criteriaBuilder: CriteriaBuilder, root: Root<Intervention>, maximumAge: Int?): Predicate? {
+
+    return maximumAge?.let {
+      val expression = root.get<Any>("dynamicFrameworkContract").get<Int>("maximumAge")
+      criteriaBuilder.`equal`(expression, maximumAge)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
@@ -28,8 +28,8 @@ class InterventionService(
     }
   }
 
-  fun getInterventions(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?): List<InterventionDTO> {
-    return interventionRepository.findByCriteria(pccRegionIds, allowsFemale, allowsMale).map {
+  fun getInterventions(pccRegionIds: List<String>, allowsFemale: Boolean?, allowsMale: Boolean?, minimumAge: Int?, maximumAge: Int?): List<InterventionDTO> {
+    return interventionRepository.findByCriteria(pccRegionIds, allowsFemale, allowsMale, minimumAge, maximumAge).map {
       InterventionDTO.from(it, getPCCRegions(it))
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
@@ -16,11 +16,11 @@ internal class InterventionControllerTest {
   fun `getInterventions returns interventions based on filtering`() {
     val locations = emptyList<String>()
     val interventionDTOs = emptyList<InterventionDTO>()
-    whenever(interventionService.getInterventions(locations, allowsFemale = true, allowsMale = true)).thenReturn(interventionDTOs)
+    whenever(interventionService.getInterventions(locations, allowsFemale = true, allowsMale = true, 18, 25)).thenReturn(interventionDTOs)
 
-    val responseDTOs = interventionController.getInterventions(locations, allowsFemale = true, allowsMale = true)
+    val responseDTOs = interventionController.getInterventions(locations, allowsFemale = true, allowsMale = true, 18, 25)
 
-    verify(interventionService).getInterventions(locations, allowsFemale = true, allowsMale = true)
+    verify(interventionService).getInterventions(locations, allowsFemale = true, allowsMale = true, 18, 25)
     assertSame(interventionDTOs, responseDTOs)
   }
 
@@ -28,11 +28,11 @@ internal class InterventionControllerTest {
   fun `getInterventions returns interventions unfiltered when no parameters supplied`() {
     val locations: List<String>? = null
     val interventionDTOs = emptyList<InterventionDTO>()
-    whenever(interventionService.getInterventions(emptyList(), null, null)).thenReturn(interventionDTOs)
+    whenever(interventionService.getInterventions(emptyList(), null, null, null, null)).thenReturn(interventionDTOs)
 
-    val responseDTOs = interventionController.getInterventions(locations, null, null)
+    val responseDTOs = interventionController.getInterventions(locations, null, null, null, null)
 
-    verify(interventionService).getInterventions(emptyList(), null, null)
+    verify(interventionService).getInterventions(emptyList(), null, null, null, null)
     assertSame(interventionDTOs, responseDTOs)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImplTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImplTest.kt
@@ -35,7 +35,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()), title = "test Title")
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, null)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, null, null, null)
     assertThat(found.size).isEqualTo(3)
   }
 
@@ -44,7 +44,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create(id = 'H', name = "name")))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("devon-and-cornwall"), null, null)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("devon-and-cornwall"), null, null, null, null)
 
     assertThat(found.size).isEqualTo(2)
     found.forEach {
@@ -57,7 +57,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create(id = "testID", name = "testName")))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), null, null)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), null, null, null, null)
 
     assertThat(found.size).isEqualTo(2)
     found.forEach {
@@ -70,7 +70,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create(id = "testID", name = "testName")))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), null, null)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), null, null, null, null)
 
     assertThat(found.size).isEqualTo(2)
     found.forEach {
@@ -82,7 +82,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
   fun `get interventions filtering by allowsFemale is true`() {
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), true, null)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), true, null, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
@@ -92,7 +92,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
   fun `get interventions filtering by allowsFemale is false`() {
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), false, null)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), false, null, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsFemale).isFalse
@@ -102,7 +102,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
   fun `get interventions filtering by allowsMale is true`() {
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, true)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, true, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsMale).isTrue
@@ -112,7 +112,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
   fun `get interventions filtering by allowsMale is false`() {
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, false)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), null, false, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsMale).isFalse
@@ -123,7 +123,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), allowsFemale = true, allowsMale = true)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), allowsFemale = true, allowsMale = true, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
@@ -135,7 +135,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsFemale = false))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), allowsFemale = true, allowsMale = false)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf(), allowsFemale = true, allowsMale = false, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
@@ -148,11 +148,50 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(npsRegion = npsRegionFactory.create()))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(pccRegion = pccRegionFactory.create(id = "testID", name = "testName")))
     interventionFactory.create(contract = dynamicFrameworkContractFactory.create(allowsMale = false, pccRegion = pccRegionFactory.create()))
-    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), allowsFemale = true, allowsMale = false)
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("avon-and-somerset"), allowsFemale = true, allowsMale = false, null, null)
 
     assertThat(found.size).isEqualTo(1)
     assertThat(found[0].dynamicFrameworkContract.allowsFemale).isTrue
     assertThat(found[0].dynamicFrameworkContract.allowsMale).isFalse
     assertThat(found[0].dynamicFrameworkContract.pccRegion?.id).isEqualTo("avon-and-somerset")
+  }
+
+  @Test
+  fun `get interventions filtering by minimum age on exact match`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(minimumAge = 28))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(minimumAge = 29))
+    val found = interventionFilterRepositoryImpl.findByCriteria(emptyList(), null, null, 28, null)
+
+    assertThat(found.size).isEqualTo(1)
+    found.forEach {
+      assertThat(it.dynamicFrameworkContract.minimumAge).isEqualTo(28)
+    }
+  }
+
+  @Test
+  fun `get interventions filtering by maximum age on exact match`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(maximumAge = 28))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(maximumAge = 29))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(maximumAge = null))
+    val found = interventionFilterRepositoryImpl.findByCriteria(emptyList(), null, null, null, 29)
+
+    assertThat(found.size).isEqualTo(1)
+    found.forEach {
+      assertThat(it.dynamicFrameworkContract.maximumAge).isEqualTo(29)
+    }
+  }
+
+  @Test
+  fun `get interventions filtering by minimum and maximum age on exact match and region`() {
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(minimumAge = 18, maximumAge = 29, pccRegion = pccRegionFactory.create(id = "region1", name = "name 1")))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(minimumAge = 18, maximumAge = 29, pccRegion = pccRegionFactory.create(id = "region2", name = "name 2")))
+    interventionFactory.create(contract = dynamicFrameworkContractFactory.create(minimumAge = 18, maximumAge = 30, pccRegion = pccRegionFactory.create(id = "region3", name = "name 3")))
+    val found = interventionFilterRepositoryImpl.findByCriteria(listOf("region1", "region2"), null, null, null, 29)
+
+    assertThat(found.size).isEqualTo(2)
+    found.forEach {
+      assertThat(it.dynamicFrameworkContract.minimumAge).isEqualTo(18)
+      assertThat(it.dynamicFrameworkContract.maximumAge).isEqualTo(29)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceUnitTest.kt
@@ -27,11 +27,11 @@ class InterventionServiceUnitTest {
   fun `finds interventions using search criteria`() {
     val locations = emptyList<String>()
     val interventions = emptyList<Intervention>()
-    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null, null, null)).thenReturn(interventions)
 
-    interventionService.getInterventions(locations, null, null)
+    interventionService.getInterventions(locations, null, null, null, null)
 
-    verify(interventionRepository).findByCriteria(locations, null, null)
+    verify(interventionRepository).findByCriteria(locations, null, null, null, null)
   }
 
   @Test
@@ -40,9 +40,9 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = sampleNPSRegion(), pccRegion = samplePCCRegion())
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null, null, null)).thenReturn(interventions)
 
-    interventionService.getInterventions(locations, null, null)
+    interventionService.getInterventions(locations, null, null, null, null)
 
     verifyZeroInteractions(pccRegionRepository)
   }
@@ -55,10 +55,10 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null, null, null)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    interventionService.getInterventions(locations, null, null)
+    interventionService.getInterventions(locations, null, null, null, null)
 
     verify(pccRegionRepository).findAllByNpsRegionId(npsRegion.id)
   }
@@ -71,10 +71,10 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(locations, null, null)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(locations, null, null, null, null)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    val interventionDTOs = interventionService.getInterventions(locations, null, null)
+    val interventionDTOs = interventionService.getInterventions(locations, null, null, null, null)
 
     assertEquals(interventionDTOs.size, interventions.size)
   }
@@ -86,10 +86,10 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(listOf(), true, null)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(listOf(), true, null, null, null)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    val interventionDTOs = interventionService.getInterventions(listOf(), true, null)
+    val interventionDTOs = interventionService.getInterventions(listOf(), true, null, null, null)
 
     assertEquals(interventionDTOs.size, interventions.size)
   }
@@ -101,10 +101,40 @@ class InterventionServiceUnitTest {
     val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
     val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
     val interventions = listOf(intervention)
-    whenever(interventionRepository.findByCriteria(listOf(), null, true)).thenReturn(interventions)
+    whenever(interventionRepository.findByCriteria(listOf(), null, true, null, null)).thenReturn(interventions)
     whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
 
-    val interventionDTOs = interventionService.getInterventions(listOf(), null, true)
+    val interventionDTOs = interventionService.getInterventions(listOf(), null, true, null, null)
+
+    assertEquals(interventionDTOs.size, interventions.size)
+  }
+
+  @Test
+  fun `should return an intervention with minimum age parameter`() {
+    val npsRegion = sampleNPSRegion()
+    val pccRegion = samplePCCRegion()
+    val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
+    val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
+    val interventions = listOf(intervention)
+    whenever(interventionRepository.findByCriteria(listOf(), null, null, 18, null)).thenReturn(interventions)
+    whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
+
+    val interventionDTOs = interventionService.getInterventions(listOf(), null, null, 18, null)
+
+    assertEquals(interventionDTOs.size, interventions.size)
+  }
+
+  @Test
+  fun `should return an intervention with maximum age parameter`() {
+    val npsRegion = sampleNPSRegion()
+    val pccRegion = samplePCCRegion()
+    val contract = sampleContract(serviceCategory = sampleServiceCategory(), serviceProvider = sampleServiceProvider(), npsRegion = npsRegion)
+    val intervention = sampleIntervention(id = UUID.randomUUID(), dynamicFrameworkContract = contract)
+    val interventions = listOf(intervention)
+    whenever(interventionRepository.findByCriteria(listOf(), null, null, null, 25)).thenReturn(interventions)
+    whenever(pccRegionRepository.findAllByNpsRegionId(npsRegion.id)).thenReturn(listOf(pccRegion))
+
+    val interventionDTOs = interventionService.getInterventions(listOf(), null, null, null, 25)
 
     assertEquals(interventionDTOs.size, interventions.size)
   }


### PR DESCRIPTION
## What does this pull request do?

Provides the ability to pass 'minimumAge' & 'maximumAge' boolean parameters into the GET /interventions endpoint. This will allows the search results to filter on these parameters. This will also work in combination with a location filter.

## What is the intent behind these changes?

To allow the filtering of intervention search results, as per IC-1061