### PR TITLE
Remove last-implemented tag from pact job config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: false
   pact_consumer_tags:
     type: string
-    default: main,last-implemented
+    default: main
 
 orbs:
   hmpps: ministryofjustice/hmpps@2.1.0


### PR DESCRIPTION
## What does this pull request do?

Remove `last-implemented` consumer tag from the pact job's default configuration.

This relates to https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/848/workflows/c1a5cd0f-4872-4f77-97f4-05a320542dcd/jobs/3049 validating a really old UI contract version:

> Pact between Interventions UI (d826533b45cb056bf3c4c811d6c16cc82f385dfc) and Interventions Service

That [commit](https://github.com/ministryofjustice/hmpps-interventions-ui/commit/d826533b45cb056bf3c4c811d6c16cc82f385dfc) is from 18 December 2020, which must have been pulled in by this old tag.

## What is the intent behind these changes?

To stop validating really old contracts.