### PR TITLE
IC-1113 only return sent referrals for the SP organization that the requesting user belongs to

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,5 +60,7 @@ dependencies {
 
   testImplementation("au.com.dius.pact.provider:junit5spring:4.1.14")
   testImplementation("com.h2database:h2:1.4.200")
+  testImplementation("com.squareup.okhttp3:okhttp:4.9.0")
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
   testImplementation("uk.org.lidalia:slf4j-test:1.0.1")
 }

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,7 +16,7 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
-  HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+  HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_PROBATIONAREACODE: "A00"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.server.ResponseStatusException
@@ -33,6 +34,12 @@ data class ErrorResponse(
 
 @RestControllerAdvice
 class ErrorConfiguration {
+  @ExceptionHandler(AccessDeniedException::class)
+  fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> {
+    log.info("access denied exception: {}", e.message)
+    return errorResponse(HttpStatus.FORBIDDEN, "access denied", e.message)
+  }
+
   @ExceptionHandler(ValidationError::class)
   fun handleValidationException(e: ValidationError): ResponseEntity<ErrorResponse> {
     log.info("validation exception: {}", e.message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -15,24 +15,17 @@ import org.springframework.web.reactive.function.client.WebClient
 @Configuration
 class WebClientConfiguration(
   @Value("\${community-api.baseurl}") private val communityApiBaseUrl: String,
+  @Value("\${hmppsauth.baseurl}") private val hmppsAuthBaseUrl: String,
   private val webClientBuilder: WebClient.Builder
 ) {
   @Bean
   fun communityApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
-    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
-    oauth2Client.setDefaultClientRegistrationId("community-api")
-    return webClientBuilder
-      .baseUrl(communityApiBaseUrl)
-      .apply(oauth2Client.oauth2Configuration())
-      .exchangeStrategies(
-        ExchangeStrategies.builder()
-          .codecs { configurer ->
-            configurer.defaultCodecs()
-              .maxInMemorySize(-1)
-          }
-          .build()
-      )
-      .build()
+    return createAuthorizedWebClient(authorizedClientManager, communityApiBaseUrl)
+  }
+
+  @Bean
+  fun hmppsAuthApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
+    return createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl)
   }
 
   @Bean
@@ -49,5 +42,22 @@ class WebClientConfiguration(
     )
     authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
     return authorizedClientManager
+  }
+
+  private fun createAuthorizedWebClient(clientManager: OAuth2AuthorizedClientManager, baseUrl: String): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientManager)
+    oauth2Client.setDefaultClientRegistrationId("interventions-client")
+    return webClientBuilder
+      .baseUrl(baseUrl)
+      .apply(oauth2Client.oauth2Configuration())
+      .exchangeStrategies(
+        ExchangeStrategies.builder()
+          .codecs { configurer ->
+            configurer.defaultCodecs()
+              .maxInMemorySize(-1)
+          }
+          .build()
+      )
+      .build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Flux
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+
+val AuthServiceProviderGroupPrefix = "INT_SP_"
+
+data class AuthGroup(
+  val groupCode: String,
+  val groupName: String,
+)
+
+@Service
+class HMPPSAuthService(
+  @Value("\${hmppsauth.api.locations.user-groups}") private val userGroupsLocation: String,
+  private val hmppsAuthApiWebClient: WebClient,
+) {
+  fun getServiceProviderOrganizationForUser(user: AuthUser): AuthGroupID? {
+    val url = UriComponentsBuilder.fromPath(userGroupsLocation)
+      .buildAndExpand(user.userName)
+      .toString()
+
+    val groups = hmppsAuthApiWebClient.get().uri(url)
+      .retrieve()
+      .bodyToFlux(AuthGroup::class.java)
+      .onErrorResume { e ->
+        when (e) {
+          is WebClientResponseException -> {
+            // we expect 404s for non-auth users
+            if (!e.statusCode.equals(HttpStatus.NOT_FOUND)) {
+              log.error("could not get groups for user", e)
+            }
+          }
+          else -> log.error("could not get groups for user", e)
+        }
+        Flux.empty()
+      }
+      .collectList().block()
+
+    val serviceProviderOrgs = groups
+      .filter { it.groupCode.startsWith(AuthServiceProviderGroupPrefix) }
+      .map { it.groupCode.removePrefix(AuthServiceProviderGroupPrefix) }
+
+    // in the future, we will have to handle multiple group memberships
+    // which represent SP admins managing subcontractor organizations.
+    // for now we can assume there is only one group per user.
+    return if (serviceProviderOrgs.isEmpty()) null else serviceProviderOrgs[0]
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(HMPPSAuthService::class.java)
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,7 +24,7 @@ aws:
     topic.arn: arn:aws:sns:eu-west-2:000000000000:intervention-events-local
 
 hmppsauth:
-  baseurl: http://hmpps-auth:8090/auth
+  baseurl: http://hmpps-auth:8090
 
 postgres:
   uri: localhost:5432
@@ -45,6 +45,6 @@ spring:
     oauth2:
       client:
         registration:
-          community-api:
+          interventions-client:
             client-id: interventions
             client-secret: clientsecret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,16 +16,16 @@ spring:
       client:
         provider:
           hmppsauth:
-            token-uri: ${hmppsauth.baseurl}/oauth/token
+            token-uri: ${hmppsauth.baseurl}/auth/oauth/token
         registration:
-          community-api:
+          interventions-client:
             provider: hmppsauth
             authorization-grant-type: client_credentials
             scope: read
       resourceserver:
         jwt:
-          issuer-uri: ${hmppsauth.baseurl}/issuer
-          jwk-set-uri: ${hmppsauth.baseurl}/.well-known/jwks.json
+          issuer-uri: ${hmppsauth.baseurl}/auth/issuer
+          jwk-set-uri: ${hmppsauth.baseurl}/auth/.well-known/jwks.json
   datasource:
     url: jdbc:postgresql://${postgres.uri}/${postgres.db}
     username: ${postgres.username}
@@ -80,6 +80,11 @@ interventions-ui:
 community-api:
   locations:
     sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
+
+hmppsauth:
+  api:
+    locations:
+      user-groups: "/api/authuser/{username}/groups"
 
 aws:
   sns:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIServiceTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ExchangeFunction
@@ -25,6 +26,11 @@ class CommunityAPIServiceTest {
 
   private val exchangeFunction = mock<ExchangeFunction>()
   private lateinit var communityAPIService: CommunityAPIService
+
+  @AfterEach
+  fun teardown() {
+    TestLoggerFactory.clear()
+  }
 
   @Test
   fun `got service successfully`() {
@@ -78,7 +84,7 @@ class CommunityAPIServiceTest {
 
     whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException::class.java)
     communityAPIService.onApplicationEvent(referralSentEvent)
-    assertThat(logger.loggingEvents.size == 1)
+    assertThat(logger.loggingEvents.size).isEqualTo(1)
     assertThat(logger.loggingEvents[0].level.name).isEqualTo("ERROR")
     assertThat(logger.loggingEvents[0].message).isEqualTo("Call to community api to update contact log failed:")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceTest.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.org.lidalia.slf4jtest.TestLoggerFactory
+
+class HMPPSAuthServiceTest {
+  private val mockWebServer = MockWebServer()
+  private val hmppsAuthService = HMPPSAuthService(
+    "/",
+    WebClient.create(
+      mockWebServer.url("/").toString()
+    )
+  )
+
+  @AfterEach
+  fun teardown() {
+    TestLoggerFactory.clear()
+  }
+
+  @Test
+  fun `getServiceProviderOrganizationForUser filters results and returns the first service provider org`() {
+    mockWebServer.enqueue(
+      MockResponse()
+        .setHeader("content-type", "application/json")
+        .setBody(
+          """[
+       { "groupCode": "NPS_N02", "groupName": "NPS North East" },
+       { "groupCode": "INT_SP_HARMONY_LIVING", "groupName": "Harmony Living" },
+       { "groupCode": "INT_SP_NEW_BEGINNINGS", "groupName": "New Beginnings" } 
+    ]
+          """.trimIndent()
+        )
+    )
+    val org = hmppsAuthService.getServiceProviderOrganizationForUser(AuthUser("id", "source", "username"))
+    assertThat(org).isEqualTo("HARMONY_LIVING")
+  }
+
+  @Test
+  fun `getServiceProviderOrganizationForUser returns null if there are no service provider orgs`() {
+    mockWebServer.enqueue(
+      MockResponse()
+        .setHeader("content-type", "application/json")
+        .setBody(
+          """[
+       { "groupCode": "NPS_N02", "groupName": "NPS North East" }
+    ]
+          """.trimIndent()
+        )
+    )
+    val org = hmppsAuthService.getServiceProviderOrganizationForUser(AuthUser("id", "source", "username"))
+    assertThat(org).isNull()
+  }
+
+  @Test
+  fun `getServiceProviderOrganizationForUser returns null if there are no orgs at all`() {
+    mockWebServer.enqueue(
+      MockResponse()
+        .setHeader("content-type", "application/json")
+        .setBody("[]")
+    )
+    val org = hmppsAuthService.getServiceProviderOrganizationForUser(AuthUser("id", "source", "username"))
+    assertThat(org).isNull()
+  }
+
+  @Test
+  fun `getServiceProviderOrganizationForUser returns null and logs error on http error`() {
+    TestLoggerFactory.clear()
+    val logger = TestLoggerFactory.getTestLogger(HMPPSAuthService::class.java)
+
+    mockWebServer.enqueue(MockResponse().setResponseCode(500))
+    val org = hmppsAuthService.getServiceProviderOrganizationForUser(AuthUser("id", "source", "username"))
+    assertThat(org).isNull()
+
+    assertThat(logger.allLoggingEvents.size).isEqualTo(1)
+    assertThat(logger.allLoggingEvents[0].level.name).isEqualTo("ERROR")
+  }
+
+  @Test
+  fun `getServiceProviderOrganizationForUser returns null on 404 from auth`() {
+    TestLoggerFactory.clear()
+    val logger = TestLoggerFactory.getTestLogger(HMPPSAuthService::class.java)
+
+    mockWebServer.enqueue(MockResponse().setResponseCode(404))
+    val org = hmppsAuthService.getServiceProviderOrganizationForUser(AuthUser("id", "source", "username"))
+    assertThat(org).isNull()
+
+    assertThat(logger.allLoggingEvents.size).isEqualTo(0)
+  }
+}


### PR DESCRIPTION
note: this was originally done in the front end, but see the comments here about why this PR has been raised instead. https://github.com/ministryofjustice/hmpps-interventions-ui/pull/126

## What does this pull request do?

only return sent referrals for the SP organization that the requesting user belongs to

## What is the intent behind these changes?

ensure SPs don't see referrals sent to other orgs