### PR TITLE
IC-1106: Generate unique reference numbers for referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -10,6 +10,7 @@ interface ReferralRepository : CrudRepository<Referral, UUID> {
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?
   fun findBySentAtIsNotNull(): List<Referral>
   fun findByInterventionDynamicFrameworkContractServiceProviderIdAndSentAtIsNotNull(id: AuthGroupID): List<Referral>
+  fun existsByReferenceNumber(reference: String): Boolean
 
   // queries for draft referrals
   fun findByIdAndSentAtIsNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.springframework.stereotype.Component
+
+@Component
+class ReferralReferenceGenerator {
+  fun generate(): String {
+    return "HDJ2123F"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
@@ -3,11 +3,24 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import org.springframework.stereotype.Component
 
 @Component
-class ReferralReferenceGenerator {
-  private val prefixChars = ('A'..'Z').toList()
-  private val numbers = ('0'..'9').toList()
+class ReferralReferenceGenerator(
+  private val prefixChars: List<Char> = ('A'..'Z').toList(),
+  private val numbers: List<Char> = ('0'..'9').toList(),
+) {
+  private val ambiguousPairs = listOf(
+    Pair("0", "O"),
+    Pair("1", "I"),
+    Pair("5", "S"),
+    Pair("8", "B"),
+  )
 
   fun generate(categoryName: String): String {
+    return generateSequence { newReference(categoryName) }
+      .filterNot { ambiguous(it) }
+      .first()
+  }
+
+  private fun newReference(categoryName: String): String {
     return buildString {
       append(prefix())
       append(numbers())
@@ -17,4 +30,8 @@ class ReferralReferenceGenerator {
 
   private fun prefix(): String = buildString { while (length < 2) append(prefixChars.random()) }
   private fun numbers(): String = buildString { while (length < 4) append(numbers.random()) }
+
+  private fun ambiguous(candidate: String): Boolean {
+    return ambiguousPairs.any { pair -> candidate.contains(pair.first) && candidate.contains(pair.second) }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
@@ -4,7 +4,17 @@ import org.springframework.stereotype.Component
 
 @Component
 class ReferralReferenceGenerator {
-  fun generate(): String {
-    return "HDJ2123F"
+  private val prefixChars = ('A'..'Z').toList()
+  private val numbers = ('0'..'9').toList()
+
+  fun generate(categoryName: String): String {
+    return buildString {
+      append(prefix())
+      append(numbers())
+      append(categoryName.take(2))
+    }.toUpperCase()
   }
+
+  private fun prefix(): String = buildString { while (length < 2) append(prefixChars.random()) }
+  private fun numbers(): String = buildString { while (length < 4) append(numbers.random()) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGenerator.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class ReferralReferenceGenerator(
-  private val prefixChars: List<Char> = ('A'..'Z').toList(),
+  private val prefixChars: List<Char> = ('A'..'Z').toList().filterNot { it in listOf('I', 'O') },
   private val numbers: List<Char> = ('0'..'9').toList(),
 ) {
   private val ambiguousPairs = listOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
@@ -194,6 +195,14 @@ class ReferralService(
 
   private fun generateReferenceNumber(category: ServiceCategory): String? {
     return generateSequence { referenceGenerator.generate(category.name) }
-      .find { candidate -> !referralRepository.existsByReferenceNumber(candidate) }
+      .find { candidate ->
+        referralRepository.existsByReferenceNumber(candidate)
+          .also { exists -> if (exists) log.warn("Clash found for referral number: $candidate") }
+          .not()
+      }
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(ReferralService::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -42,7 +42,9 @@ class ReferralService(
   fun sendDraftReferral(referral: Referral, user: AuthUser): Referral {
     referral.sentAt = OffsetDateTime.now()
     referral.sentBy = authUserRepository.save(user)
-    referral.referenceNumber = referenceGenerator.generate()
+
+    val categoryName = referral.intervention.dynamicFrameworkContract.serviceCategory.name
+    referral.referenceNumber = referenceGenerator.generate(categoryName)
 
     val sentReferral = referralRepository.save(referral)
     eventPublisher.referralSentEvent(sentReferral)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -23,7 +23,8 @@ class ReferralService(
   val referralRepository: ReferralRepository,
   val authUserRepository: AuthUserRepository,
   val interventionRepository: InterventionRepository,
-  val eventPublisher: ReferralEventPublisher
+  val eventPublisher: ReferralEventPublisher,
+  val referenceGenerator: ReferralReferenceGenerator,
 ) {
   fun getSentReferral(id: UUID): Referral? {
     return referralRepository.findByIdAndSentAtIsNotNull(id)
@@ -41,9 +42,7 @@ class ReferralService(
   fun sendDraftReferral(referral: Referral, user: AuthUser): Referral {
     referral.sentAt = OffsetDateTime.now()
     referral.sentBy = authUserRepository.save(user)
-
-    // fixme: hardcoded for now
-    referral.referenceNumber = "HDJ2123F"
+    referral.referenceNumber = referenceGenerator.generate()
 
     val sentReferral = referralRepository.save(referral)
     eventPublisher.referralSentEvent(sentReferral)

--- a/src/main/resources/db/migration/V1_25__add_index_for_referral_reference_number.sql
+++ b/src/main/resources/db/migration/V1_25__add_index_for_referral_reference_number.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON referral (reference_number);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGeneratorTest.kt
@@ -7,9 +7,16 @@ class ReferralReferenceGeneratorTest {
   private val generator = ReferralReferenceGenerator()
 
   @Test
-  fun `generates the same reference number every time`() {
-    for (i in 1..5) {
-      assertThat(generator.generate()).isEqualTo("HDJ2123F")
+  fun `generates 2-letter 4-digit 2-letter references`() {
+    repeat(5) {
+      assertThat(generator.generate("name")).matches("[A-Z]{2}[0-9]{4}[A-Z]{2}")
     }
+  }
+
+  @Test
+  fun `reference postfix is the capitalised first two (unicode) letters of the given category`() {
+    assertThat(generator.generate("Category")).endsWith("CA")
+    assertThat(generator.generate("accommodation")).endsWith("AC")
+    assertThat(generator.generate("űrlény")).endsWith("ŰR")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGeneratorTest.kt
@@ -14,6 +14,30 @@ class ReferralReferenceGeneratorTest {
   }
 
   @Test
+  fun `references must avoid similar looking letters and numbers`() {
+    data class Example(val prefixChars: String, val numbers: String, val doesNotContain: String)
+
+    val examples = listOf(
+      Example("O", "07", "0"),
+      Example("I", "17", "1"),
+      Example("S", "57", "5"),
+      Example("B", "87", "8"),
+      Example("OX", "0", "O"),
+      Example("IX", "1", "I"),
+      Example("SX", "5", "S"),
+      Example("BX", "8", "B"),
+    )
+
+    examples.forEach { ex ->
+      val g = ReferralReferenceGenerator(prefixChars = ex.prefixChars.toList(), numbers = ex.numbers.toList())
+      assertThat(g.generate("name")).doesNotContain(
+        ex.doesNotContain,
+        "Characters in ${ex.prefixChars} and ${ex.numbers} are similar, avoid '${ex.doesNotContain}' to remain unambiguous"
+      )
+    }
+  }
+
+  @Test
   fun `reference postfix is the capitalised first two (unicode) letters of the given category`() {
     assertThat(generator.generate("Category")).endsWith("CA")
     assertThat(generator.generate("accommodation")).endsWith("AC")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralReferenceGeneratorTest.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ReferralReferenceGeneratorTest {
+  private val generator = ReferralReferenceGenerator()
+
+  @Test
+  fun `generates the same reference number every time`() {
+    for (i in 1..5) {
+      assertThat(generator.generate()).isEqualTo("HDJ2123F")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -3,12 +3,12 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
@@ -305,7 +305,7 @@ class ReferralServiceTest @Autowired constructor(
     val draft1 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
     val draft2 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
 
-    Mockito.`when`(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.serviceCategory.name))
+    whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.serviceCategory.name))
       .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
 
     val sent1 = referralService.sendDraftReferral(draft1, user)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -35,11 +35,13 @@ class ReferralServiceTest @Autowired constructor(
 ) {
 
   private val referralEventPublisher: ReferralEventPublisher = mock()
+  private val referenceGenerator: ReferralReferenceGenerator = ReferralReferenceGenerator()
   private val referralService = ReferralService(
     referralRepository,
     authUserRepository,
     interventionRepository,
-    referralEventPublisher
+    referralEventPublisher,
+    referenceGenerator,
   )
 
   // reset before each test


### PR DESCRIPTION
## What does this pull request do?

Changes the hardcoded reference number of `HDJ2123F` to be dynamically generated using the following rules:

- two random letters
- four random numbers
- two letters, generated from the service category name
- avoid ambiguous pairs: `0/O`, `1/I`, `5/S`, `8/B`
- generate unique reference numbers 

### Main decisions

- to avoid migration problems and to prioritise sending the referral over reference number integrity, uniqueness is **not** enforced on a database level (it's not as important as successful sending), however, an index now exists for efficient uniqueness checks
- 🔬 to avoid database concerns in the generator, the responsibility of checking uniqueness was put into `ReferralService` in bb8a23b952b260042504011f2772df417d5e0a3d
- 👀 for observability, reference number clashes are logged as warnings in 7bf16ae8cb93ea128f2ab8431ecd0faa37682fd1
- 🦺 for safety, avoid unbounded retries in a11fb9e6572e5d659b5aa84a72552750c2655f84

## How should I review?

Please review commit-by-commit.

If this is too much, we can remove/split the ambiguity, unique checks, logs, etc. commits for a slimmer version.

## What is the intent behind these changes?

Generate human-readable, unambiguous reference numbers, similar to https://psychologymarc.medium.com/why-are-uk-postcodes-so-memorable-b0457e2e8a0d.