### PR TITLE
Fix hmpps auth base url for API endpoints & tidy up error handling in hmpps auth service.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,7 +16,7 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
-  HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk"
+  HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_PROBATIONAREACODE: "A00"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,7 +24,7 @@ aws:
     topic.arn: arn:aws:sns:eu-west-2:000000000000:intervention-events-local
 
 hmppsauth:
-  baseurl: http://hmpps-auth:8090
+  baseurl: http://hmpps-auth:8090/auth
 
 postgres:
   uri: localhost:5432

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       client:
         provider:
           hmppsauth:
-            token-uri: ${hmppsauth.baseurl}/auth/oauth/token
+            token-uri: ${hmppsauth.baseurl}/oauth/token
         registration:
           interventions-client:
             provider: hmppsauth
@@ -24,8 +24,8 @@ spring:
             scope: read
       resourceserver:
         jwt:
-          issuer-uri: ${hmppsauth.baseurl}/auth/issuer
-          jwk-set-uri: ${hmppsauth.baseurl}/auth/.well-known/jwks.json
+          issuer-uri: ${hmppsauth.baseurl}/issuer
+          jwk-set-uri: ${hmppsauth.baseurl}/.well-known/jwks.json
   datasource:
     url: jdbc:postgresql://${postgres.uri}/${postgres.db}
     username: ${postgres.username}


### PR DESCRIPTION
## What does this pull request do?

Fix hmpps auth base url for API endpoints & tidy up error handling in hmpps auth service.

## What is the intent behind these changes?

fix the service provider dashboard - which currently always errors out because the user is never in a valid group
