### PR TITLE
IC-926: Add manual deploy to pre-production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,20 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - moj-slack-notifications
+      - approve_preprod:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: "interventions-dev-notifications"
+          requires:
+            - approve_preprod
+          context:
+            - moj-slack-notifications
 
   nightly:
     triggers:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,3 +17,9 @@ ingress:
 env:
   JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+  INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
+  COMMUNITYAPI_BASEURL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_PROVIDERCODE: "CRS"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_REFERRALTYPE: "CRS01"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_STAFFCODE: "CRSUATU"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_TEAMCODE: "CRSUAT"


### PR DESCRIPTION
## What does this pull request do?

Adds the required CircleCI workflow to have pre-production deployments.

Currently depending on:

1. successful dev deployment
2. manual approval

Related: https://github.com/ministryofjustice/cloud-platform-environments/pull/4369
Related: https://github.com/ministryofjustice/hmpps-interventions-ui/pull/158

## What is the intent behind these changes?

To allow us to further test the application on realistic data environments, leading to quicker feedback.