### PR TITLE
🔐 Upgrade gradle-spring-boot for security

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.1.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.1"
   kotlin("plugin.spring") version "1.4.10"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.4.20"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.1"
-  kotlin("plugin.spring") version "1.4.10"
-  id("org.jetbrains.kotlin.plugin.jpa") version "1.4.20"
+  kotlin("plugin.spring") version "1.4.31"
+  id("org.jetbrains.kotlin.plugin.jpa") version "1.4.31"
 }
 
 repositories {
@@ -39,11 +39,11 @@ tasks {
 
 dependencies {
   // openapi
-  implementation("org.springdoc:springdoc-openapi-ui:1.5.3")
+  implementation("org.springdoc:springdoc-openapi-ui:1.5.5")
 
   // notifications
   implementation("uk.gov.service.notify:notifications-java-client:3.17.0-RELEASE")
-  implementation("software.amazon.awssdk:sns:2.15.71")
+  implementation("software.amazon.awssdk:sns:2.16.9")
 
   // security
   implementation("org.springframework.boot:spring-boot-starter-webflux")
@@ -53,14 +53,14 @@ dependencies {
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
-  implementation("org.hibernate:hibernate-core:5.4.24.Final")
-  implementation("com.vladmihalcea:hibernate-types-52:2.10.2")
+  implementation("org.hibernate:hibernate-core:5.4.28.Final")
+  implementation("com.vladmihalcea:hibernate-types-52:2.10.3")
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql")
 
-  testImplementation("au.com.dius.pact.provider:junit5spring:4.1.14")
+  testImplementation("au.com.dius.pact.provider:junit5spring:4.2.0")
   testImplementation("com.h2database:h2:1.4.200")
-  testImplementation("com.squareup.okhttp3:okhttp:4.9.0")
-  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
-  testImplementation("uk.org.lidalia:slf4j-test:1.0.1")
+  testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
+  testImplementation("uk.org.lidalia:slf4j-test:1.2.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,8 @@ configurations {
 
 tasks {
   test {
-    useJUnitPlatform() {
-      excludeTags("pact")
+    useJUnitPlatform {
+      exclude("**/*PactTest*")
     }
   }
 
@@ -31,8 +31,8 @@ tasks {
     systemProperty("pact.provider.version", System.getenv("PACT_PROVIDER_VERSION"))
     systemProperty("pact.verifier.publishResults", System.getenv("PACT_PUBLISH_RESULTS") ?: "false")
 
-    useJUnitPlatform() {
-      includeTags("pact")
+    useJUnitPlatform {
+      include("**/*PactTest*")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -6,7 +6,6 @@ import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,7 +22,6 @@ import java.util.UUID
 
 @PactBroker
 @Provider("Interventions Service")
-@Tag("pact")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test", "local", "seed")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,3 @@
-spring:
-  profiles:
-    include: stdout
-
 server:
   shutdown: immediate
 


### PR DESCRIPTION
## What does this pull request do?

Fixes https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25329

By transitively upgrading to a version of Spring Boot that pulls in `tomcat-embed-core:9.0.43`

Full path:
```
|    +--- org.springframework.boot:spring-boot-starter-tomcat:2.4.3
|    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.43
```

## What is the intent behind these changes?

`ci/circleci: vulnerability_scan` is 🚫, unblock deployment.

Reference: https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/1122/workflows/fe583f85-b669-4363-9333-f8f3c859bf53/jobs/3849