### PR TITLE
fix sent referral URL which is sent in email notifications

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,7 @@ notify:
 
 interventions-ui:
   locations:
-    sent-referral: "/referrals/{id}/confirmation"
+    sent-referral: "/service-provider/referrals/{id}"
 
 community-api:
   locations:


### PR DESCRIPTION
## What does this pull request do?

fix sent referral URL which is sent in email notifications

## What is the intent behind these changes?

point the recipient of the email to the correct page in the UI
