### PR TITLE
IC-653 Improve logging configuration for production environments.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,10 @@ tasks {
 }
 
 dependencies {
+  // logging
+  implementation("net.logstash.logback:logstash-logback-encoder:6.6")
+  implementation("ch.qos.logback:logback-classic:1.2.3")
+
   // openapi
   implementation("org.springdoc:springdoc-openapi-ui:1.5.5")
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -32,15 +32,7 @@ postgres:
   username: postgres
   password: password
 
-logging:
-  level:
-    org:
-      springframework:
-        security: DEBUG
-
 spring:
-  jpa:
-    show-sql: true
   security:
     oauth2:
       client:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProfile name="local">
+        <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                <charset>utf8</charset>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="stdout" />
+        </root>
+        <logger name="org.hibernate.SQL" level="debug" additivity="false">
+            <appender-ref ref="stdout" />
+        </logger>
+    </springProfile>
+
+    <springProfile name="!local">
+        <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <timestamp/>
+                    <message/>
+                    <loggerName/>
+                    <threadName/>
+                    <logLevel/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
+
+        <root level="warn">
+            <appender-ref ref="stdout" />
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## What does this pull request do?

Add logback configuration which splits the logging config into local/prod
sections. local config behaves the same as normal, coloured output pretty printed at DEBUG level.
the non locl config formats messages as json at WARN level.

## What is the intent behind these changes?

structured log messages in production environments.
