### PR TITLE
Remove unused H2 database dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
   runtimeOnly("org.postgresql:postgresql")
 
   testImplementation("au.com.dius.pact.provider:junit5spring:4.2.0")
-  testImplementation("com.h2database:h2:1.4.200")
   testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
   testImplementation("uk.org.lidalia:slf4j-test:1.2.0")


### PR DESCRIPTION
## What does this pull request do?

Remove unused H2 database dependency: we now always use a real PostgreSQL database for tests

## What is the intent behind these changes?

To reduce importing dependencies which we don't use
