### PR TITLE
Allow creating files in the /app directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-interventions-service*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/AI-Agent.xml /app
+RUN chown appuser:appgroup /app
 
 USER 2000
 


### PR DESCRIPTION
## What does this pull request do?

Allow creating files in the /app directory within the docker image

## What is the intent behind these changes?

Related to:
```
 09:06:54,209 |-INFO in com.microsoft.applicationinsights.agent.shadow.ch.qos.logback.core.rolling.RollingFileAppender[FILE] - Active log file name: /app/applicationinsights.log
 09:06:54,209 |-INFO in com.microsoft.applicationinsights.agent.shadow.ch.qos.logback.core.rolling.RollingFileAppender[FILE] - File property is set to [/app/applicationinsights.log]
 09:06:54,210 |-ERROR in com.microsoft.applicationinsights.agent.shadow.ch.qos.logback.core.rolling.RollingFileAppender[FILE] - openFile(/app/applicationinsights.log,true) call failed. java.io.FileNotFoundException: /app/applicationinsights.log (Permission denied)
 	at java.io.FileNotFoundException: /app/applicationinsights.log (Permission denied)
```

Currently, the docker image has `/app` with `root:root` permissions, which prohibits the application from creating temporary files in the same directory

This change removes that restriction

🚨 **Danger**: we have a finite amount of disk space in each container, so no component should write files unbounded (files must not grow infinitely if we don't deploy/restart the app)