### PR TITLE
IC-1307 add end of service report entities and persistence tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import org.hibernate.annotations.Fetch
+import org.hibernate.annotations.FetchMode
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.CollectionTable
+import javax.persistence.ElementCollection
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+import javax.validation.constraints.NotNull
+
+@Entity
+@Table(name = "end_of_service_report")
+data class EndOfServiceReport(
+  @Id val id: UUID,
+
+  @NotNull val createdAt: OffsetDateTime,
+  @NotNull @ManyToOne @Fetch(FetchMode.JOIN) val createdBy: AuthUser,
+
+  var submittedAt: OffsetDateTime? = null,
+  @ManyToOne @Fetch(FetchMode.JOIN) var submittedBy: AuthUser? = null,
+
+  var furtherInformation: String? = null,
+
+  // Outcomes
+  @ElementCollection
+  @CollectionTable(name = "end_of_service_report_outcome", joinColumns = [JoinColumn(name = "end_of_service_report_id")])
+  @NotNull val outcomes: MutableList<EndOfServiceReportOutcome> = mutableListOf(),
+
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReportOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReportOutcome.kt
@@ -1,17 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
+import org.hibernate.annotations.Fetch
+import org.hibernate.annotations.FetchMode
 import javax.persistence.Embeddable
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
-import javax.persistence.FetchType
 import javax.persistence.ManyToOne
 import javax.validation.constraints.NotNull
 
 @Embeddable
 data class EndOfServiceReportOutcome(
-  @NotNull @ManyToOne(fetch = FetchType.LAZY) val desiredOutcome: DesiredOutcome,
+  @NotNull @ManyToOne @Fetch(FetchMode.JOIN) val desiredOutcome: DesiredOutcome,
   @Enumerated(EnumType.STRING)
-  val achievementLevel: AchievementLevel,
+  @NotNull val achievementLevel: AchievementLevel,
   val progressionComments: String? = null,
   val additionalTaskComments: String? = null
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReportOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReportOutcome.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import javax.persistence.Embeddable
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.ManyToOne
+import javax.validation.constraints.NotNull
+
+@Embeddable
+data class EndOfServiceReportOutcome(
+  @NotNull @ManyToOne(fetch = FetchType.LAZY) val desiredOutcome: DesiredOutcome,
+  @Enumerated(EnumType.STRING)
+  val achievementLevel: AchievementLevel,
+  val progressionComments: String? = null,
+  val additionalTaskComments: String? = null
+)
+
+enum class AchievementLevel {
+  ACHIEVED, PARTIALLY_ACHIEVED, NOT_ACHIEVED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -70,4 +70,6 @@ data class Referral(
   @NotNull @ManyToOne @Fetch(FetchMode.JOIN) val createdBy: AuthUser,
   @NotNull val createdAt: OffsetDateTime,
   @Id val id: UUID,
+
+  @OneToOne @Fetch(JOIN) var endOfServiceReport: EndOfServiceReport? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/EndOfServiceReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/EndOfServiceReportRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import java.util.UUID
+
+interface EndOfServiceReportRepository : JpaRepository<EndOfServiceReport, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDT
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
@@ -71,7 +72,8 @@ class ReferralService(
     crn: String,
     interventionId: UUID,
     overrideID: UUID? = null,
-    overrideCreatedAt: OffsetDateTime? = null
+    overrideCreatedAt: OffsetDateTime? = null,
+    endOfServiceReport: EndOfServiceReport? = null,
   ): Referral {
     return referralRepository.save(
       Referral(
@@ -79,7 +81,8 @@ class ReferralService(
         createdAt = overrideCreatedAt ?: OffsetDateTime.now(),
         createdBy = authUserRepository.save(user),
         serviceUserCRN = crn,
-        intervention = interventionRepository.getOne(interventionId)
+        intervention = interventionRepository.getOne(interventionId),
+        endOfServiceReport = endOfServiceReport
       )
     )
   }

--- a/src/main/resources/db/migration/V1_30__end_of_service_report.sql
+++ b/src/main/resources/db/migration/V1_30__end_of_service_report.sql
@@ -1,0 +1,28 @@
+create table end_of_service_report (
+    id uuid not null,
+    created_at timestamp with time zone not null,
+    created_by_id text not null,
+    submitted_at timestamp with time zone,
+    submitted_by_id text,
+    further_information text,
+
+	constraint pk_end_of_service_report primary key (id),
+    constraint fk_created_by_id foreign key (created_by_id) references auth_user,
+    constraint fk_submitted_by_id foreign key (submitted_by_id) references auth_user
+);
+
+create table end_of_service_report_outcome (
+    end_of_service_report_id uuid not null,
+    desired_outcome_id uuid not null,
+    achievement_level text not null,
+    progression_comments text,
+    additional_task_comments text,
+
+    constraint fk_end_of_service_report_id foreign key (end_of_service_report_id) references end_of_service_report,
+    constraint fk_desired_outcome_id foreign key (desired_outcome_id) references desired_outcome
+);
+
+
+alter table referral
+    add column end_of_service_report_id uuid,
+    add constraint fk_end_of_service_report_id foreign key (end_of_service_report_id) references end_of_service_report;

--- a/src/main/resources/db/migration/V1_32__end_of_service_report.sql
+++ b/src/main/resources/db/migration/V1_32__end_of_service_report.sql
@@ -24,5 +24,5 @@ create table end_of_service_report_outcome (
 
 
 alter table referral
-    add column end_of_service_report_id uuid,
+    add column end_of_service_report_id uuid unique,
     add constraint fk_end_of_service_report_id foreign key (end_of_service_report_id) references end_of_service_report;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -41,7 +41,7 @@ internal class ReferralControllerTest {
 
   @Test
   fun `createDraftReferral handles EntityNotFound exceptions from InterventionsService`() {
-    whenever(referralService.createDraftReferral(any(), any(), any(), anyOrNull(), anyOrNull())).thenThrow(EntityNotFoundException::class.java)
+    whenever(referralService.createDraftReferral(any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())).thenThrow(EntityNotFoundException::class.java)
     assertThrows<ServerWebInputException> {
       referralController.createDraftReferral(CreateReferralRequestDTO("CRN20", UUID.randomUUID()), tokenFactory.create())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -68,6 +68,7 @@ class SampleData {
       assignedTo: AuthUser? = null,
       assignedAt: OffsetDateTime = OffsetDateTime.now(),
       actionPlan: ActionPlan? = null,
+      endOfServiceReport: EndOfServiceReport? = null
     ): Referral {
       return Referral(
         serviceUserCRN = crn,
@@ -87,6 +88,7 @@ class SampleData {
           )
         ),
         actionPlan = actionPlan,
+        endOfServiceReport = endOfServiceReport,
       )
     }
 
@@ -127,6 +129,39 @@ class SampleData {
         allowsFemale = true,
         npsRegion = npsRegion,
         pccRegion = pccRegion
+      )
+    }
+    fun sampleEndOfServiceReport(
+      id: UUID? = null,
+      createdAt: OffsetDateTime = OffsetDateTime.now(),
+      createdBy: AuthUser = AuthUser("CRN123", "auth", "user"),
+      submittedAt: OffsetDateTime? = null,
+      submittedBy: AuthUser? = null,
+      furtherInformation: String? = null,
+      outcomes: List<EndOfServiceReportOutcome> = listOf(sampleEndOfServiceReportOutcome())
+    ): EndOfServiceReport {
+      return EndOfServiceReport(
+        id = id ?: UUID.randomUUID(),
+        createdAt = createdAt,
+        createdBy = createdBy,
+        submittedAt = submittedAt,
+        submittedBy = submittedBy,
+        furtherInformation = furtherInformation,
+        outcomes = outcomes.toMutableList()
+      )
+    }
+
+    fun sampleEndOfServiceReportOutcome(
+      desiredOutcome: DesiredOutcome? = null,
+      achievementLevel: AchievementLevel = AchievementLevel.ACHIEVED,
+      progressionComments: String? = null,
+      additionalTaskComments: String? = null
+    ): EndOfServiceReportOutcome {
+      return EndOfServiceReportOutcome(
+        desiredOutcome = desiredOutcome ?: sampleDesiredOutcome(),
+        achievementLevel = achievementLevel,
+        progressionComments = progressionComments,
+        additionalTaskComments = additionalTaskComments,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/EndOfServiceReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/EndOfServiceReportRepositoryTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+
+@RepositoryTest
+class EndOfServiceReportRepositoryTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val endOfServiceReportRepository: EndOfServiceReportRepository,
+) {
+  private val authUserFactory = AuthUserFactory(entityManager)
+
+  @Test
+  fun `can retrieve an end of service report`() {
+    val endOfServiceReport = buildAndPersistEndOfServiceReport()
+    val outcome = endOfServiceReport.outcomes.first()
+
+    val savedEndOfServiceReport = endOfServiceReportRepository.findById(endOfServiceReport.id)
+    val savedOutcome = savedEndOfServiceReport.get().outcomes.first()
+
+    assertThat(savedEndOfServiceReport.get().createdAt).isEqualTo(endOfServiceReport.createdAt)
+    assertThat(savedEndOfServiceReport.get().createdBy).isEqualTo(endOfServiceReport.createdBy)
+    assertThat(savedEndOfServiceReport.get().submittedAt).isEqualTo(endOfServiceReport.submittedAt)
+    assertThat(savedEndOfServiceReport.get().submittedBy).isEqualTo(endOfServiceReport.submittedBy)
+    assertThat(savedEndOfServiceReport.get().furtherInformation).isEqualTo(endOfServiceReport.furtherInformation)
+    assertThat(savedEndOfServiceReport.get().outcomes.size).isEqualTo(1)
+
+    assertThat(savedOutcome.desiredOutcome).isEqualTo(outcome.desiredOutcome)
+    assertThat(savedOutcome.achievementLevel).isEqualTo(outcome.achievementLevel)
+    assertThat(savedOutcome.progressionComments).isEqualTo(outcome.progressionComments)
+    assertThat(savedOutcome.additionalTaskComments).isEqualTo(outcome.additionalTaskComments)
+  }
+
+  private fun buildAndPersistEndOfServiceReport(): EndOfServiceReport {
+    val user = authUserFactory.create(id = "referral_repository_test_user_id")
+
+    val referral = SampleData.sampleReferral("X123456", "Harmony Living", createdBy = user)
+    SampleData.persistReferral(entityManager, referral)
+
+    val serviceCategory = SampleData.sampleServiceCategory()
+    entityManager.persist(serviceCategory)
+
+    val desiredOutcome = SampleData.sampleDesiredOutcome(description = "Removing Barriers", serviceCategoryId = serviceCategory.id)
+    entityManager.persist(desiredOutcome)
+
+    val endOfServiceReport = SampleData.sampleEndOfServiceReport(
+      createdBy = user,
+      outcomes = listOf(SampleData.sampleEndOfServiceReportOutcome(desiredOutcome = desiredOutcome))
+    )
+
+    endOfServiceReportRepository.save(endOfServiceReport)
+    entityManager.flush()
+    return endOfServiceReport
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImplTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/InterventionFilterRepositoryImplTest.kt
@@ -17,6 +17,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
   val interventionFilterRepositoryImpl: InterventionFilterRepository,
   val interventionRepository: InterventionRepository,
   val referralRepository: ReferralRepository,
+  val actionPlanRepository: ActionPlanRepository,
 ) {
 
   private val interventionFactory = InterventionFactory(entityManager)
@@ -26,6 +27,7 @@ class InterventionFilterRepositoryImplTest @Autowired constructor(
 
   @BeforeEach
   fun setup() {
+    actionPlanRepository.deleteAll()
     referralRepository.deleteAll()
     interventionRepository.deleteAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceTest.kt
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData.Companion.persistIntervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData.Companion.sampleContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData.Companion.sampleIntervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.PCCRegionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
@@ -23,6 +24,7 @@ class InterventionServiceTest @Autowired constructor(
   val pccRegionRepository: PCCRegionRepository,
   val interventionRepository: InterventionRepository,
   val referralRepository: ReferralRepository,
+  val actionPlanRepository: ActionPlanRepository,
 ) {
   private val interventionService = InterventionService(pccRegionRepository, interventionRepository)
   private val serviceCategoryFactory = ServiceCategoryFactory(entityManager)
@@ -32,6 +34,7 @@ class InterventionServiceTest @Autowired constructor(
 
   @BeforeEach
   fun setup() {
+    actionPlanRepository.deleteAll()
     referralRepository.deleteAll()
     interventionRepository.deleteAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/EndOfServiceReportFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/EndOfServiceReportFactory.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AchievementLevel
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReportOutcome
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class EndOfServiceReportFactory(em: TestEntityManager? = null) : EntityFactory(em) {
+  private val authUserFactory = AuthUserFactory(em)
+
+  fun create(
+    id: UUID? = null,
+    createdAt: OffsetDateTime? = null,
+    createdBy: AuthUser? = null,
+    submittedAt: OffsetDateTime? = null,
+    submittedBy: AuthUser? = null,
+    furtherInformation: String? = null,
+    outcomes: List<EndOfServiceReportOutcome>? = null,
+    desiredOutcome: DesiredOutcome,
+    achievementLevel: AchievementLevel? = null,
+    progressionComments: String? = null,
+    additionalTaskComments: String? = null,
+  ): EndOfServiceReport {
+    return save(
+      EndOfServiceReport(
+        id = id ?: UUID.randomUUID(),
+        createdAt = createdAt ?: OffsetDateTime.now(),
+        createdBy = createdBy ?: authUserFactory.create(),
+        submittedAt = submittedAt ?: OffsetDateTime.now(),
+        submittedBy = submittedBy ?: authUserFactory.create(),
+        furtherInformation = furtherInformation,
+        outcomes = outcomes?.toMutableList() ?: mutableListOf(
+          EndOfServiceReportOutcome(
+            desiredOutcome = desiredOutcome,
+            achievementLevel = achievementLevel ?: AchievementLevel.ACHIEVED,
+            progressionComments = progressionComments,
+            additionalTaskComments = additionalTaskComments,
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Adds the database changes required to add end of service report data.

## What is the intent behind these changes?

Allow end of service report data to be persisted in the database.
