### PR TITLE
IC-1308 add endpoint to create an empty end of service report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/EndOfServiceReportController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/EndOfServiceReportController.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers.JwtAuthUserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EndOfServiceReportDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.EndOfServiceReportService
+import java.util.UUID
+
+@RestController
+class EndOfServiceReportController(
+  val jwtAuthUserMapper: JwtAuthUserMapper,
+  val locationMapper: LocationMapper,
+  val endOfServiceReportService: EndOfServiceReportService,
+) {
+
+  @PostMapping("/referral/{id}/end-of-service-report")
+  fun createEndOfServiceReport(
+    @PathVariable id: UUID,
+    authentication: JwtAuthenticationToken
+  ): ResponseEntity<EndOfServiceReportDTO> {
+
+    val createdByUser = jwtAuthUserMapper.map(authentication)
+    val endOfServiceReport = endOfServiceReportService.createEndOfServiceReport(id, createdByUser)
+
+    val endOfServiceReportDTO = EndOfServiceReportDTO.from(endOfServiceReport)
+    val location = locationMapper.mapToCurrentRequestBasePath("/{id}", endOfServiceReportDTO.id)
+    return ResponseEntity.created(location.toUri()).body(endOfServiceReportDTO)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndOfServiceReportDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndOfServiceReportDTO.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AchievementLevel
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReportOutcome
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class EndOfServiceReportDTO(
+  val id: UUID,
+  val createdAt: OffsetDateTime,
+  val createdBy: AuthUserDTO,
+  val submittedAt: OffsetDateTime? = null,
+  val submittedBy: AuthUserDTO? = null,
+  val furtherInformation: String? = null,
+  val outcomes: List<EndOfServiceReportOutcomeDTO> = emptyList(),
+) {
+  companion object {
+    fun from(endOfServiceReport: EndOfServiceReport): EndOfServiceReportDTO {
+      return EndOfServiceReportDTO(
+        id = endOfServiceReport.id,
+        createdAt = endOfServiceReport.createdAt,
+        createdBy = AuthUserDTO.from(endOfServiceReport.createdBy),
+        submittedAt = endOfServiceReport.submittedAt,
+        submittedBy = endOfServiceReport.submittedBy?.let { AuthUserDTO.from(it) },
+        furtherInformation = endOfServiceReport.furtherInformation,
+        outcomes = endOfServiceReport.outcomes.map { EndOfServiceReportOutcomeDTO.from(it) },
+      )
+    }
+  }
+}
+data class EndOfServiceReportOutcomeDTO(
+  val desiredOutcome: DesiredOutcomeDTO,
+  val achievementLevel: AchievementLevel,
+  val progressionComments: String? = null,
+  val additionalTaskComments: String? = null
+) {
+  companion object {
+    fun from(endOfServiceReportOutcome: EndOfServiceReportOutcome): EndOfServiceReportOutcomeDTO {
+      return EndOfServiceReportOutcomeDTO(
+        desiredOutcome = DesiredOutcomeDTO.from(endOfServiceReportOutcome.desiredOutcome),
+        achievementLevel = endOfServiceReportOutcome.achievementLevel,
+        progressionComments = endOfServiceReportOutcome.progressionComments,
+        additionalTaskComments = endOfServiceReportOutcome.additionalTaskComments
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -12,6 +12,7 @@ class SentReferralDTO(
   val assignedTo: AuthUserDTO?,
   val referral: DraftReferralDTO,
   val actionPlanId: UUID?,
+  val endOfServiceReport: EndOfServiceReportDTO?,
 ) {
   companion object {
     fun from(referral: Referral): SentReferralDTO {
@@ -22,7 +23,8 @@ class SentReferralDTO(
         referenceNumber = referral.referenceNumber!!,
         assignedTo = referral.assignedTo?.let { AuthUserDTO.from(it) },
         referral = DraftReferralDTO.from(referral),
-        actionPlanId = referral.actionPlan?.id
+        actionPlanId = referral.actionPlan?.id,
+        endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) }
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.EntityNotFoundException
+
+@Service
+class EndOfServiceReportService(
+  val authUserRepository: AuthUserRepository,
+  val referralRepository: ReferralRepository,
+  val endOfServiceReportRepository: EndOfServiceReportRepository,
+) {
+
+  fun createEndOfServiceReport(
+    referralId: UUID,
+    createdByUser: AuthUser
+  ): EndOfServiceReport {
+    val referral = getReferral(referralId)
+
+    val endOfServiceReport = EndOfServiceReport(
+      id = UUID.randomUUID(),
+      createdBy = authUserRepository.save(createdByUser),
+      createdAt = OffsetDateTime.now(),
+    )
+
+    val savedEndOfServiceReport = endOfServiceReportRepository.save(endOfServiceReport)
+    referral.endOfServiceReport = endOfServiceReport
+    referralRepository.save(referral)
+
+    return savedEndOfServiceReport
+  }
+
+  private fun getReferral(referralId: UUID): Referral {
+    return referralRepository.findById(referralId).orElseThrow {
+      throw EntityNotFoundException("referral not found [id=$referralId]")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/EndOfServiceReportControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/EndOfServiceReportControllerTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.web.util.UriComponentsBuilder
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers.JwtAuthUserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EndOfServiceReportDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.EndOfServiceReportService
+import java.net.URI
+import java.util.UUID
+
+class EndOfServiceReportControllerTest {
+  private val jwtAuthUserMapper = mock<JwtAuthUserMapper>()
+  private val endOfServiceReportService = mock<EndOfServiceReportService>()
+  private val locationMapper = mock<LocationMapper>()
+
+  private val endOfServiceReportController = EndOfServiceReportController(jwtAuthUserMapper, locationMapper, endOfServiceReportService)
+
+  @Test
+  fun `create end of service report successfully`() {
+    val referralId = UUID.randomUUID()
+    val jwtAuthenticationToken = JwtAuthenticationToken(mock())
+    val authUser = AuthUser("CRN123", "auth", "user")
+    val endOfServiceReport = SampleData.sampleEndOfServiceReport()
+    val endOfServiceReportDTO = EndOfServiceReportDTO.from(endOfServiceReport)
+    val uriComponents = UriComponentsBuilder.fromUri(URI.create("/1234")).build()
+
+    whenever(jwtAuthUserMapper.map(jwtAuthenticationToken)).thenReturn(authUser)
+    whenever(endOfServiceReportService.createEndOfServiceReport(referralId, authUser)).thenReturn(endOfServiceReport)
+    whenever(locationMapper.mapToCurrentRequestBasePath("/{id}", endOfServiceReportDTO.id)).thenReturn(uriComponents)
+
+    val endOfServiceReportResponse = endOfServiceReportController.createEndOfServiceReport(referralId, jwtAuthenticationToken)
+    assertThat(endOfServiceReportResponse.let { it.body }).isEqualTo(endOfServiceReportDTO)
+    assertThat(endOfServiceReportResponse.let { it.headers["location"] }).isEqualTo(listOf("/1234"))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTOTest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 
 internal class ActionPlanAppointmentsDTOTest {
@@ -19,7 +19,7 @@ internal class ActionPlanAppointmentsDTOTest {
     assertThat(appointmentDTO.appointmentTime).isEqualTo(actionPlanAppointment.appointmentTime)
     assertThat(appointmentDTO.durationInMinutes).isEqualTo(actionPlanAppointment.durationInMinutes)
     assertThat(appointmentDTO.createdAt).isEqualTo(actionPlanAppointment.createdAt)
-    assertThat(appointmentDTO.createdBy).isEqualTo(actionPlanAppointment.createdBy)
+    assertThat(appointmentDTO.createdBy.userId).isEqualTo(actionPlanAppointment.createdBy.id)
   }
 
   @Test
@@ -36,6 +36,6 @@ internal class ActionPlanAppointmentsDTOTest {
     assertThat(appointmentsDTO.first().appointmentTime).isEqualTo(actionPlanAppointment.appointmentTime)
     assertThat(appointmentsDTO.first().durationInMinutes).isEqualTo(actionPlanAppointment.durationInMinutes)
     assertThat(appointmentsDTO.first().createdAt).isEqualTo(actionPlanAppointment.createdAt)
-    assertThat(appointmentsDTO.first().createdBy).isEqualTo(actionPlanAppointment.createdBy)
+    assertThat(appointmentsDTO.first().createdBy.userId).isEqualTo(actionPlanAppointment.createdBy.id)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import java.util.Optional.empty
+import java.util.Optional.of
+import java.util.UUID
+import javax.persistence.EntityNotFoundException
+
+class EndOfServiceReportServiceTest {
+
+  private val authUserRepository: AuthUserRepository = mock()
+  private val referralRepository: ReferralRepository = mock()
+  private val endOfServiceReportRepository: EndOfServiceReportRepository = mock()
+
+  private val endOfServiceReportService = EndOfServiceReportService(authUserRepository, referralRepository, endOfServiceReportRepository)
+
+  @Test
+  fun `create end of service report`() {
+    val authUser = AuthUser("CRN123", "auth", "user")
+    val endOfServiceReport = SampleData.sampleEndOfServiceReport(outcomes = mutableListOf())
+    val referral = SampleData.sampleReferral(endOfServiceReport = endOfServiceReport, crn = "CRN123", serviceProviderName = "Service Provider")
+
+    whenever(authUserRepository.save(authUser)).thenReturn(authUser)
+    whenever(referralRepository.findById(referral.id)).thenReturn(of(referral))
+    whenever(endOfServiceReportRepository.save(any())).thenReturn(endOfServiceReport)
+    whenever(referralRepository.save(any())).thenReturn(referral)
+
+    val savedEndOfServiceReport = endOfServiceReportService.createEndOfServiceReport(referral.id, authUser)
+
+    assertThat(savedEndOfServiceReport).isNotNull
+  }
+
+  @Test
+  fun `referral not found when creating end of service report`() {
+    val authUser = AuthUser("CRN123", "auth", "user")
+    val referralId = UUID.randomUUID()
+    whenever(referralRepository.findById(referralId)).thenReturn(empty())
+
+    val exception = Assertions.assertThrows(EntityNotFoundException::class.java) {
+      endOfServiceReportService.createEndOfServiceReport(referralId, authUser)
+    }
+    assertThat(exception.message).isEqualTo("referral not found [id=$referralId]")
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Adds an endpoint that allows an empty eosr to be created against a referral.
Fix broken action plan test.

## What is the intent behind these changes?

Provides a referral with an empty eosr that can later be populated.
