### PR TITLE
IC-1386: Add manual deployment to user research environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,21 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+      - approve_research:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_research
+          env: "research"
+          retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: "interventions-dev-notifications"
+          requires:
+            - approve_research
+          context:
+            - hmpps-common-vars
+            - hmpps-interventions-service-research
       - approve_preprod:
           type: approval
           requires:

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -1,0 +1,22 @@
+replicaCount: 2
+
+image:
+  repository: quay.io/hmpps/hmpps-interventions-service
+  tag: latest
+  port: 8080
+
+ingress:
+  enabled: true
+  hosts:
+    - host: hmpps-interventions-service-research.apps.live-1.cloud-platform.service.justice.gov.uk
+  path: /
+
+env:
+  JAVA_OPTS: "-Xmx512m"
+  HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+  INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
+  COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_PROVIDERCODE: "CRS"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_REFERRALTYPE: "CRS01"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_STAFFCODE: "CRSUATU"
+  COMMUNITYAPI_CONTACTNOTIFICATIONCONTEXT_TEAMCODE: "CRSUAT"


### PR DESCRIPTION
## What does this pull request do?

Adds a manual deployment "gate" to CircleCI.

There will be a new "approve_research" and "deploy_research" button, similar to the preprod ones:

![image](https://user-images.githubusercontent.com/1526295/111987541-42ff6d80-8b07-11eb-9273-ff5fab96d617.png)


## What is the intent behind these changes?

To enable user research.