### PR TITLE
Switch to "London (Metropolitan Police)" as the London PCC

### DIFF
--- a/src/main/resources/db/migration/V1_37__use_different_london_pcc.sql
+++ b/src/main/resources/db/migration/V1_37__use_different_london_pcc.sql
@@ -1,0 +1,9 @@
+insert into pcc_region (id, name, nps_region_id) values
+    ('metropolitan', 'London (Metropolitan Police)', 'J');
+
+update dynamic_framework_contract
+    set pcc_region_id = 'metropolitan'
+    where pcc_region_id = 'city-of-london';
+
+delete from pcc_region
+    where id = 'city-of-london';


### PR DESCRIPTION
## What does this pull request do?

Switch to Met Police PCC region for London

## What is the intent behind these changes?

To make the 'find' page more user friendly.

The Met Police PCC covers almost the entire Greater London and is more applicable to use as the only PCC to cover the NPS region "London".