### PR TITLE
Reorganise CI jobs so APP_VERSION is memoised only once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ parameters:
 orbs:
   hmpps: ministryofjustice/hmpps@2.3.2
   kubernetes: circleci/kubernetes@0.11.2
+  mem: circleci/rememborb@0.0.1
   snyk: snyk/snyk@0.0.12
 
 _snyk_options: &snyk_options
@@ -56,7 +57,8 @@ jobs:
           POSTGRES_PASSWORD: password
     steps:
       - checkout
-      - hmpps/create_app_version
+      - mem/recall:
+          env_var: APP_VERSION
       - run:
           name: Migrate the database
           command: |
@@ -164,7 +166,10 @@ workflows:
     unless: << pipeline.parameters.only_pacts >>
     jobs:
       - validate
-      - publish_data
+      - publish_data:
+          requires:
+            - build_docker
+            - build_and_publish_docker
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:


### PR DESCRIPTION
## What does this pull request do?

The `publish_data`, `build_docker` and `build_and_publish_docker` jobs
each call `hmpps/create_app_version`.

This job stores the value of `APP_VERSION` in a temporary file to be
recalled in the `deploy_env` job.

This, however, causes

```
Concurrent upstream jobs persisted the same file(s) into the workspace:
  - .circleci_remember/APP_VERSION

Error applying workspace layer for job 1364866a-712f-4af6-be15-1936bc9e0aac: ⏎
  Concurrent upstream jobs persisted the same file(s)
```

To temporarily get around the problem, we'll `mem/recall` the
`APP_VERSION` in the `publish_data` job and chain it after the docker image
build, which creates it.

A long-term solution will be digging into how to make the APP_VERSION
and docker builds reusable with the HMPPS orb.

## What is the intent behind these changes?

Fix the deployment pipeline -- it is currently failing because `deploy_env` cannot run.