### PR TITLE
Change default log level to INFO locally

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,7 +12,7 @@
             </encoder>
         </appender>
 
-        <root level="debug">
+        <root level="info">
             <appender-ref ref="stdout" />
         </root>
 


### PR DESCRIPTION
## What does this pull request do?

Reduces local logging noise by switching to INFO log level on `local` profile.

## What is the intent behind these changes?

When I start the app with `SPRING_PROFILES_ACTIVE=local,seed ./gradlew bootRun`, I feel the amount of spam is incredible and unhelpful