### PR TITLE
IC-535 Fixed email recipient - referral sender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
@@ -33,7 +33,7 @@ class NotifyActionPlanService(
     when (event.type) {
 
       ActionPlanEventType.SUBMITTED -> {
-        val userDetail = hmppsAuthService.getUserDetail(event.actionPlan.submittedBy!!)
+        val userDetail = hmppsAuthService.getUserDetail(event.actionPlan.referral.sentBy!!)
         val location = generateResourceUrl(interventionsUIBaseURL, interventionsUISubmitActionPlanLocation, event.actionPlan.id)
         emailSender.sendEmail(
           actionPlanSubmittedTemplateID,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
@@ -34,6 +34,7 @@ class NotifyActionPlanServiceTest {
         id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
         referenceNumber = "HAS71263",
         sentAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+        sentBy = AuthUser("abc999", "auth", "abc999")
       ),
       submittedBy = AuthUser("abc123", "auth", "abc123")
     ),
@@ -67,7 +68,8 @@ class NotifyActionPlanServiceTest {
 
   @Test
   fun `referral assigned event generates valid url and sends an email`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("tom", "tom@tom.tom"))
+    whenever(hmppsAuthService.getUserDetail(AuthUser("abc999", "auth", "abc999")))
+      .thenReturn(UserDetail("tom", "tom@tom.tom"))
 
     notifyService().onApplicationEvent(actionPlanSubmittedEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()


### PR DESCRIPTION
## What does this pull request do?

When an action plan is submitted the notification email should be sent to the "Sender of the Referral". 

## What is the intent behind these changes?

Fix as it was being sent to the wrong recipient.
