### PR TITLE
IC-1478: Turn on Sentry for exception monitoring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,9 @@ tasks {
 }
 
 dependencies {
-  // logging
+  // monitoring and logging
+  implementation("io.sentry:sentry-spring-boot-starter:4.3.0")
+  implementation("io.sentry:sentry-logback:4.3.0")
   implementation("io.github.microutils:kotlin-logging-jvm:2.0.6")
 
   // openapi

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -78,4 +78,10 @@ env:
         name: notify
         key: api_key
 
+  - name: SENTRY_DSN
+    valueFrom:
+      secretKeyRef:
+        name: sentry
+        key: service_dsn
+
 {{- end -}}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,3 +20,4 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
+  SENTRY_ENVIRONMENT: "dev"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,3 +20,4 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
+  SENTRY_ENVIRONMENT: "preprod"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,3 +18,4 @@ ingress:
 env:
   JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+  SENTRY_ENVIRONMENT: "prod"

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -17,3 +17,4 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-research.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
+  SENTRY_ENVIRONMENT: "research"


### PR DESCRIPTION
## What does this pull request do?

Turn on Sentry for exception monitoring

I've set up a Slack alert to `#interventions-dev-notifications` 🤞 

## What is the intent behind these changes?

To enable real-time exception monitoring on our live environments, so we are aware of issues without having to actively monitor the logs