### PR TITLE
IC-1412automatically create empty appointments on action plan submission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
@@ -43,6 +44,20 @@ class AppointmentsService(
     )
 
     return actionPlanAppointmentRepository.save(appointment)
+  }
+
+  fun createUnscheduledAppointmentsForActionPlan(submittedActionPlan: ActionPlan, actionPlanSubmitter: AuthUser) {
+    val numberOfSessions = submittedActionPlan.numberOfSessions!!
+    for (i in 1..numberOfSessions) {
+      val appointment = ActionPlanAppointment(
+        id = UUID.randomUUID(),
+        sessionNumber = i,
+        createdBy = authUserRepository.save(actionPlanSubmitter),
+        createdAt = OffsetDateTime.now(),
+        actionPlan = submittedActionPlan
+      )
+      actionPlanAppointmentRepository.save(appointment)
+    }
   }
 
   fun updateAppointment(


### PR DESCRIPTION
## What does this pull request do?

When a action plan is submitted, empty appointments will now be created based on the number of sessions the action plan has.

## What is the intent behind these changes?

Removed the need for the user to have to create the appointments manually
