### PR TITLE
IC-1340 trigger SNS event on appointment attendance recorded

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 
 enum class AppointmentEventType {
-  NO_ATTENDANCE,
+  ATTENDANCE_RECORDED,
 }
 
 class AppointmentEvent(source: Any, val type: AppointmentEventType, val appointment: ActionPlanAppointment, val detailUrl: String) : ApplicationEvent(source) {
@@ -22,9 +22,10 @@ class AppointmentEventPublisher(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val locationMapper: LocationMapper
 ) {
-
-  fun appointmentNotAttendedEvent(appointment: ActionPlanAppointment) {
-    applicationEventPublisher.publishEvent(AppointmentEvent(this, AppointmentEventType.NO_ATTENDANCE, appointment, getAppointmentAttendanceURL(appointment)))
+  fun attendanceRecordedEvent(appointment: ActionPlanAppointment) {
+    applicationEventPublisher.publishEvent(
+      AppointmentEvent(this, AppointmentEventType.ATTENDANCE_RECORDED, appointment, getAppointmentAttendanceURL(appointment))
+    )
   }
 
   private fun getAppointmentAttendanceURL(appointment: ActionPlanAppointment): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -71,14 +71,8 @@ class AppointmentsService(
   ): ActionPlanAppointment {
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
     setAttendanceFields(appointment, attended, additionalInformation)
-    notifyIfNoAttendance(appointment, attended)
+    appointmentEventPublisher.attendanceRecordedEvent(appointment)
     return actionPlanAppointmentRepository.save(appointment)
-  }
-
-  private fun notifyIfNoAttendance(appointment: ActionPlanAppointment, attended: Attended) {
-    if (attended == Attended.NO) {
-      appointmentEventPublisher.appointmentNotAttendedEvent(appointment)
-    }
   }
 
   fun getAppointments(actionPlanId: UUID): List<ActionPlanAppointment> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -80,8 +80,7 @@ class SNSAppointmentService(
       AppointmentEventType.ATTENDANCE_RECORDED -> {
         val referral = event.appointment.actionPlan.referral
         val eventType = "intervention.session-appointment.${when (event.appointment.attended) {
-          Attended.YES -> "attended"
-          Attended.LATE -> "late"
+          Attended.YES, Attended.LATE -> "attended"
           Attended.NO -> "missed"
           null -> throw RuntimeException("event triggered for appointment with no recorded attendance")
         }}"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
-import java.time.OffsetDateTime
 
 interface SNSService
 
@@ -90,7 +89,7 @@ class SNSAppointmentService(
           eventType,
           "Attendance was recorded for a session appointment",
           event.detailUrl,
-          OffsetDateTime.now(),
+          event.appointment.attendanceSubmittedAt!!,
           mapOf("serviceUserCRN" to referral.serviceUserCRN, "referralId" to referral.id)
         )
         snsPublisher.publish(snsEvent)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -6,9 +6,13 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPubli
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import java.time.OffsetDateTime
 
 interface SNSService
 
@@ -59,6 +63,35 @@ class SNSReferralService(
           event.detailUrl,
           event.referral.assignedAt!!,
           mapOf("referralId" to event.referral.id, "assignedTo" to (event.referral.assignedTo?.userName!!))
+        )
+        snsPublisher.publish(snsEvent)
+      }
+    }
+  }
+}
+
+@Service
+class SNSAppointmentService(
+  private val snsPublisher: SNSPublisher,
+) : ApplicationListener<AppointmentEvent>, SNSService {
+
+  @AsyncEventExceptionHandling
+  override fun onApplicationEvent(event: AppointmentEvent) {
+    when (event.type) {
+      AppointmentEventType.ATTENDANCE_RECORDED -> {
+        val referral = event.appointment.actionPlan.referral
+        val eventType = "intervention.session-appointment.${when (event.appointment.attended) {
+          Attended.YES -> "attended"
+          Attended.LATE -> "late"
+          Attended.NO -> "missed"
+          null -> throw RuntimeException("event triggered for appointment with no recorded attendance")
+        }}"
+        val snsEvent = EventDTO(
+          eventType,
+          "Attendance was recorded for a session appointment",
+          event.detailUrl,
+          OffsetDateTime.now(),
+          mapOf("serviceUserCRN" to referral.serviceUserCRN, "referralId" to referral.id)
         )
         snsPublisher.publish(snsEvent)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
@@ -17,7 +17,7 @@ class AppointmentEventPublisherTest {
   private val locationMapper = mock<LocationMapper>()
 
   @Test
-  fun `builds an appointment not attended event and publishes it`() {
+  fun `builds an appointment attendance recorded event and publishes it`() {
     val appointment = SampleData.sampleActionPlanAppointment(
       actionPlan = SampleData.sampleActionPlan(),
       createdBy = SampleData.sampleAuthUser()
@@ -32,14 +32,14 @@ class AppointmentEventPublisherTest {
     whenever(locationMapper.getPathFromControllerMethod(AppointmentsController::getAppointment)).thenReturn("/action-plan/{id}/appointments/{sessionNumber}")
     val publisher = AppointmentEventPublisher(eventPublisher, locationMapper)
 
-    publisher.appointmentNotAttendedEvent(appointment)
+    publisher.attendanceRecordedEvent(appointment)
 
     val eventCaptor = argumentCaptor<AppointmentEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
     val event = eventCaptor.firstValue
 
     Assertions.assertThat(event.source).isSameAs(publisher)
-    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.NO_ATTENDANCE)
+    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.ATTENDANCE_RECORDED)
     Assertions.assertThat(event.appointment).isSameAs(appointment)
     Assertions.assertThat(event.detailUrl).isEqualTo(uri.toString())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
@@ -278,7 +278,7 @@ internal class AppointmentsServiceTest {
   }
 
   @Test
-  fun `appointment not attended calls notify to send email`() {
+  fun `appointment attendance recorded emits application event`() {
     val appointmentId = UUID.randomUUID()
     val sessionNumber = 1
     val createdByUser = SampleData.sampleAuthUser()
@@ -293,6 +293,6 @@ internal class AppointmentsServiceTest {
     whenever(actionPlanAppointmentRepository.save(any())).thenReturn(existingAppointment)
 
     appointmentsService.recordAttendance(appointmentId, 1, attended, additionalInformation)
-    verify(appointmentEventPublisher).appointmentNotAttendedEvent(existingAppointment)
+    verify(appointmentEventPublisher).attendanceRecordedEvent(existingAppointment)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSAppointmentServiceTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import java.time.OffsetDateTime
+import java.util.UUID
+
+internal class SNSAppointmentServiceTest {
+  private val publisher = mock<SNSPublisher>()
+  private val snsAppointmentService = SNSAppointmentService(publisher)
+
+  private val actionPlan = ActionPlanFactory().create(
+    referral = ReferralFactory().createSent(id = UUID.fromString("56b40f96-0657-4e01-925c-da208a6fbcfd"))
+  )
+  private val now = OffsetDateTime.now()
+  private fun attendanceRecordedEvent(attendance: Attended) = AppointmentEvent(
+    "source",
+    AppointmentEventType.ATTENDANCE_RECORDED,
+    SampleData.sampleActionPlanAppointment(
+      actionPlan = actionPlan,
+      createdBy = actionPlan.createdBy,
+      attended = attendance,
+      attendanceSubmittedAt = now,
+    ),
+    "http://localhost:8080/action-plan/77df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1"
+  )
+
+  @Test
+  fun `appointment attendance recorded event publishes message with valid DTO`() {
+    snsAppointmentService.onApplicationEvent(attendanceRecordedEvent(Attended.NO))
+
+    val eventDTO = EventDTO(
+      eventType = "intervention.session-appointment.missed",
+      description = "Attendance was recorded for a session appointment",
+      detailUrl = "http://localhost:8080/action-plan/77df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1",
+      occurredAt = now,
+      additionalInformation = mapOf(
+        "serviceUserCRN" to "X123456",
+        "referralId" to UUID.fromString("56b40f96-0657-4e01-925c-da208a6fbcfd")
+      ),
+    )
+
+    verify(publisher).publish(eventDTO)
+  }
+
+  @Test
+  fun `appointment attendance recorded event type reflects attendance status`() {
+    snsAppointmentService.onApplicationEvent(attendanceRecordedEvent(Attended.YES))
+    snsAppointmentService.onApplicationEvent(attendanceRecordedEvent(Attended.LATE))
+
+    val eventCaptor = argumentCaptor<EventDTO>()
+    verify(publisher, times(2)).publish(eventCaptor.capture())
+    eventCaptor.allValues.forEach {
+      assertThat(it.eventType).isEqualTo("intervention.session-appointment.attended")
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

IC-1340 trigger SNS event on appointment attendance recorded

this also has a commit which refactoring the existing event to trigger on all types of attendance, but only email the pp on missed appointments

## What is the intent behind these changes?

allow attendance of sessions to be tracked by external event subscribers
