### PR TITLE
IC-1426 API for recording session behaviour and notifying PP if necessary

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("com.nimbusds:oauth2-oidc-sdk:9.3.1")
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AppointmentsController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ActionPlanAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentAttendanceDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentBehaviourDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentsService
 import java.util.UUID
@@ -64,5 +65,10 @@ class AppointmentsController(
     )
 
     return ActionPlanAppointmentDTO.from(updatedAppointment)
+  }
+
+  @PostMapping("/action-plan/{actionPlanId}/appointment/{sessionNumber}/record-behaviour")
+  fun recordBehaviour(@PathVariable actionPlanId: UUID, @PathVariable sessionNumber: Int, @RequestBody update: UpdateAppointmentBehaviourDTO): ActionPlanAppointmentDTO {
+    return ActionPlanAppointmentDTO.from(appointmentsService.recordBehaviour(actionPlanId, sessionNumber, update.behaviourDescription, update.notifyProbationPractitioner))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTO.kt
@@ -33,7 +33,7 @@ data class ActionPlanAppointmentDTO(
   override val durationInMinutes: Int?,
   val createdAt: OffsetDateTime,
   val createdBy: AuthUserDTO,
-  val attendance: AttendanceDTO,
+  val sessionFeedback: SessionFeedbackDTO,
 ) : BaseAppointmentDTO(appointmentTime, durationInMinutes) {
   companion object {
     fun from(appointment: ActionPlanAppointment): ActionPlanAppointmentDTO {
@@ -44,7 +44,12 @@ data class ActionPlanAppointmentDTO(
         durationInMinutes = appointment.durationInMinutes,
         createdAt = appointment.createdAt,
         createdBy = AuthUserDTO.from(appointment.createdBy),
-        attendance = AttendanceDTO.from(appointment.attended, appointment.additionalAttendanceInformation),
+        sessionFeedback = SessionFeedbackDTO.from(
+          appointment.attended,
+          appointment.additionalAttendanceInformation,
+          appointment.attendanceBehaviour,
+          appointment.notifyPPOfAttendanceBehaviour,
+        ),
       )
     }
     fun from(appointments: List<ActionPlanAppointment>): List<ActionPlanAppointmentDTO> {
@@ -53,16 +58,31 @@ data class ActionPlanAppointmentDTO(
   }
 }
 
-data class AttendanceDTO(
-  val attended: Attended?,
-  val additionalAttendanceInformation: String?
+data class SessionFeedbackDTO(
+  val attendance: AttendanceDTO,
+  val behaviour: BehaviourDTO,
 ) {
   companion object {
-    fun from(attended: Attended?, additionalAttendanceInformation: String?): AttendanceDTO {
-      return AttendanceDTO(
-        attended = attended,
-        additionalAttendanceInformation = additionalAttendanceInformation
+    fun from(
+      attended: Attended?,
+      additionalAttendanceInformation: String?,
+      behaviourDescription: String?,
+      notifyProbationPractitioner: Boolean?
+    ): SessionFeedbackDTO {
+      return SessionFeedbackDTO(
+        AttendanceDTO(attended = attended, additionalAttendanceInformation = additionalAttendanceInformation),
+        BehaviourDTO(behaviourDescription, notifyProbationPractitioner),
       )
     }
   }
 }
+
+data class AttendanceDTO(
+  val attended: Attended?,
+  val additionalAttendanceInformation: String?,
+)
+
+data class BehaviourDTO(
+  val behaviourDescription: String?,
+  val notifyProbationPractitioner: Boolean?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTO.kt
@@ -26,6 +26,11 @@ data class UpdateAppointmentAttendanceDTO(
   val additionalAttendanceInformation: String?
 )
 
+data class UpdateAppointmentBehaviourDTO(
+  val behaviourDescription: String,
+  val notifyProbationPractitioner: Boolean,
+)
+
 data class ActionPlanAppointmentDTO(
   val id: UUID,
   val sessionNumber: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -9,9 +9,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionP
 
 enum class AppointmentEventType {
   ATTENDANCE_RECORDED,
+  BEHAVIOUR_RECORDED,
 }
 
-class AppointmentEvent(source: Any, val type: AppointmentEventType, val appointment: ActionPlanAppointment, val detailUrl: String) : ApplicationEvent(source) {
+class AppointmentEvent(source: Any, val type: AppointmentEventType, val appointment: ActionPlanAppointment, val detailUrl: String, val notifyPP: Boolean) : ApplicationEvent(source) {
   override fun toString(): String {
     return "AppointmentEvent(type=$type, appointment=${appointment.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -22,13 +23,19 @@ class AppointmentEventPublisher(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val locationMapper: LocationMapper
 ) {
-  fun attendanceRecordedEvent(appointment: ActionPlanAppointment) {
+  fun attendanceRecordedEvent(appointment: ActionPlanAppointment, notifyPP: Boolean) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.ATTENDANCE_RECORDED, appointment, getAppointmentAttendanceURL(appointment))
+      AppointmentEvent(this, AppointmentEventType.ATTENDANCE_RECORDED, appointment, getAppointmentURL(appointment), notifyPP)
     )
   }
 
-  private fun getAppointmentAttendanceURL(appointment: ActionPlanAppointment): String {
+  fun behaviourRecordedEvent(appointment: ActionPlanAppointment, notifyPP: Boolean) {
+    applicationEventPublisher.publishEvent(
+      AppointmentEvent(this, AppointmentEventType.BEHAVIOUR_RECORDED, appointment, getAppointmentURL(appointment), notifyPP)
+    )
+  }
+
+  private fun getAppointmentURL(appointment: ActionPlanAppointment): String {
     val path = locationMapper.getPathFromControllerMethod(AppointmentsController::getAppointment)
     return locationMapper.expandPathToCurrentRequestBaseUrl(path, appointment.actionPlan.id, appointment.sessionNumber).toString()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanAppointment.kt
@@ -28,6 +28,9 @@ data class ActionPlanAppointment(
   var attended: Attended? = null,
   var additionalAttendanceInformation: String? = null,
   var attendanceSubmittedAt: OffsetDateTime? = null,
+  var attendanceBehaviour: String? = null,
+  var attendanceBehaviourSubmittedAt: OffsetDateTime? = null,
+  var notifyPPOfAttendanceBehaviour: Boolean? = null,
 
   // Activities
   var appointmentTime: OffsetDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -74,7 +74,19 @@ class AppointmentsService(
   ): ActionPlanAppointment {
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
     setAttendanceFields(appointment, attended, additionalInformation)
-    appointmentEventPublisher.attendanceRecordedEvent(appointment)
+    appointmentEventPublisher.attendanceRecordedEvent(appointment, attended == Attended.NO)
+    return actionPlanAppointmentRepository.save(appointment)
+  }
+
+  fun recordBehaviour(
+    actionPlanId: UUID,
+    sessionNumber: Int,
+    behaviourDescription: String,
+    notifyProbationPractitioner: Boolean,
+  ): ActionPlanAppointment {
+    val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
+    setBehaviourFields(appointment, behaviourDescription, notifyProbationPractitioner)
+    appointmentEventPublisher.behaviourRecordedEvent(appointment, notifyProbationPractitioner)
     return actionPlanAppointmentRepository.save(appointment)
   }
 
@@ -94,6 +106,16 @@ class AppointmentsService(
     appointment.attended = attended
     additionalInformation?.let { appointment.additionalAttendanceInformation = additionalInformation }
     appointment.attendanceSubmittedAt = OffsetDateTime.now()
+  }
+
+  private fun setBehaviourFields(
+    appointment: ActionPlanAppointment,
+    behaviour: String,
+    notifyProbationPractitioner: Boolean,
+  ) {
+    appointment.attendanceBehaviour = behaviour
+    appointment.attendanceBehaviourSubmittedAt = OffsetDateTime.now()
+    appointment.notifyPPOfAttendanceBehaviour = notifyProbationPractitioner
   }
 
   private fun checkAppointmentSessionIsNotDuplicate(actionPlanId: UUID, sessionNumber: Int) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ notify:
     referral-assigned: "f0fe2fce-df0f-46c0-839a-822037d39c28"
     action-plan-submitted: "83743b43-9abb-4ffb-913d-dc583ab22dbf"
     appointment-not-attended: "21b14c86-30d2-4bf2-b355-8f3deb62ef69"
+    concerning-behaviour: "a8ef6769-4c8e-4459-938c-19dd4b661b04"
 
 interventions-ui:
   locations:
@@ -85,6 +86,7 @@ interventions-ui:
     submit-action-plan: "/service-provider/referrals/{id}/progress" # fixme
     appointment-not-attended: "/service-provider/referrals/{id}/progress" # fixme
     view-appointment: "/probation-practitioner/referrals/{id}/progress"
+    pp-referral-progress: "/probation-practitioner/referrals/{id}/progress"
 
 community-api:
   locations:

--- a/src/main/resources/db/migration/V1_39__appointment_behaviour.sql
+++ b/src/main/resources/db/migration/V1_39__appointment_behaviour.sql
@@ -1,0 +1,4 @@
+alter table action_plan_appointment
+    add column attendance_behaviour text,
+    add column notifyppof_attendance_behaviour boolean,
+    add column attendance_behaviour_submitted_at timestamp with time zone;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
@@ -1,36 +1,37 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.AppointmentsController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import java.net.URI
 
 class AppointmentEventPublisherTest {
   private val eventPublisher = mock<ApplicationEventPublisher>()
   private val locationMapper = mock<LocationMapper>()
+  private val publisher = AppointmentEventPublisher(eventPublisher, locationMapper)
+
+  @BeforeEach
+  fun setup() {
+    whenever(locationMapper.getPathFromControllerMethod(any())).thenReturn("")
+    whenever(locationMapper.expandPathToCurrentRequestBaseUrl(any(), any(), any()))
+      .thenReturn(URI.create("http://localhost/action-plan/123/appointments/1"))
+  }
 
   @Test
   fun `builds an appointment attendance recorded event and publishes it`() {
+    val actionPlan = SampleData.sampleActionPlan()
     val appointment = SampleData.sampleActionPlanAppointment(
-      actionPlan = SampleData.sampleActionPlan(),
-      createdBy = SampleData.sampleAuthUser()
+      actionPlan = actionPlan,
+      createdBy = actionPlan.createdBy
     )
-    val uri = URI.create("http://localhost//action-plan/${appointment.id}/appointments/${appointment.sessionNumber}")
-    whenever(
-      locationMapper.expandPathToCurrentRequestBaseUrl(
-        "/action-plan/{id}/appointments/{sessionNumber}",
-        appointment.actionPlan.id, appointment.sessionNumber
-      )
-    ).thenReturn(uri)
-    whenever(locationMapper.getPathFromControllerMethod(AppointmentsController::getAppointment)).thenReturn("/action-plan/{id}/appointments/{sessionNumber}")
-    val publisher = AppointmentEventPublisher(eventPublisher, locationMapper)
 
     publisher.attendanceRecordedEvent(appointment, false)
 
@@ -41,7 +42,28 @@ class AppointmentEventPublisherTest {
     Assertions.assertThat(event.source).isSameAs(publisher)
     Assertions.assertThat(event.type).isSameAs(AppointmentEventType.ATTENDANCE_RECORDED)
     Assertions.assertThat(event.appointment).isSameAs(appointment)
-    Assertions.assertThat(event.detailUrl).isEqualTo(uri.toString())
+    Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/action-plan/123/appointments/1")
     Assertions.assertThat(event.notifyPP).isFalse
+  }
+
+  @Test
+  fun `builds an appointment behaviour recorded event and publishes it`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(
+      actionPlan = actionPlan,
+      createdBy = actionPlan.createdBy
+    )
+
+    publisher.behaviourRecordedEvent(appointment, true)
+
+    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    verify(eventPublisher).publishEvent(eventCaptor.capture())
+    val event = eventCaptor.firstValue
+
+    Assertions.assertThat(event.source).isSameAs(publisher)
+    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.BEHAVIOUR_RECORDED)
+    Assertions.assertThat(event.appointment).isSameAs(appointment)
+    Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/action-plan/123/appointments/1")
+    Assertions.assertThat(event.notifyPP).isTrue
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
@@ -32,7 +32,7 @@ class AppointmentEventPublisherTest {
     whenever(locationMapper.getPathFromControllerMethod(AppointmentsController::getAppointment)).thenReturn("/action-plan/{id}/appointments/{sessionNumber}")
     val publisher = AppointmentEventPublisher(eventPublisher, locationMapper)
 
-    publisher.attendanceRecordedEvent(appointment)
+    publisher.attendanceRecordedEvent(appointment, false)
 
     val eventCaptor = argumentCaptor<AppointmentEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
@@ -42,5 +42,6 @@ class AppointmentEventPublisherTest {
     Assertions.assertThat(event.type).isSameAs(AppointmentEventType.ATTENDANCE_RECORDED)
     Assertions.assertThat(event.appointment).isSameAs(appointment)
     Assertions.assertThat(event.detailUrl).isEqualTo(uri.toString())
+    Assertions.assertThat(event.notifyPP).isFalse
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/PactTest.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanActivity
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
@@ -341,6 +342,29 @@ class PactTest {
 
     appointmentsService.createAppointment(actionPlan, 1, OffsetDateTime.parse("2021-05-13T13:30:00+01:00"), 120, authUser)
     appointmentsService.createAppointment(actionPlan, 2, OffsetDateTime.parse("2021-05-13T13:30:00+01:00"), 120, authUser)
+  }
+
+  @State("an action plan with ID 81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d exists with 1 appointment with recorded attendance")
+  fun `create an empty action plan with 1 appointment that has had attendance recorded`() {
+    val referral = referralService.createDraftReferral(deliusUser, "X862134", accommodationInterventionID)
+    referralRepository.save(referral)
+
+    val actionPlan = ActionPlan(
+      id = UUID.fromString("81987e8b-aeb9-4fbf-8ecb-1a054ad74b2d"),
+      createdBy = authUser,
+      createdAt = OffsetDateTime.now(),
+      referral = referral,
+      activities = mutableListOf(),
+      submittedAt = OffsetDateTime.now(),
+      submittedBy = authUser,
+    )
+    actionPlanRepository.save(actionPlan)
+
+    val appointment = appointmentsService.createAppointment(actionPlan, 1, OffsetDateTime.parse("2021-05-13T13:30:00+01:00"), 120, authUser)
+    appointment.attended = Attended.LATE
+    appointment.additionalAttendanceInformation = "Alex missed the bus"
+    appointment.attendanceSubmittedAt = OffsetDateTime.now()
+    actionPlanAppointmentRepository.save(appointment)
   }
 
   @State("There is an existing sent referral with ID of 8b423e17-9b60-4cc2-a927-8941ac76fdf9, and it has an action plan")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
@@ -43,7 +42,6 @@ internal class AppointmentsServiceTest {
 
   @Test
   fun `creates an appointment`() {
-    val startTimeOfTest = OffsetDateTime.now()
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = 1
     val appointmentTime = OffsetDateTime.now()
@@ -55,34 +53,7 @@ internal class AppointmentsServiceTest {
     whenever(authUserRepository.save(createdByUser)).thenReturn(createdByUser)
     whenever(actionPlanRepository.findById(actionPlanId)).thenReturn(of(actionPlan))
     val savedAppointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = createdByUser)
-    whenever(
-      actionPlanAppointmentRepository.save(
-        ArgumentMatchers.argThat { (
-          sessionNumberArg,
-          sessionAttendanceArg,
-          additionalAttendanceInformationArg,
-          attendanceSubmittedAtArg,
-          appointmentTimeArg,
-          durationInMinutesArg,
-          createdByArg,
-          createdAtArg,
-          actionPlanArg,
-          _
-        ) ->
-          (
-            sessionNumberArg == sessionNumber &&
-              sessionAttendanceArg == null &&
-              additionalAttendanceInformationArg == null &&
-              attendanceSubmittedAtArg == null &&
-              appointmentTimeArg == appointmentTime &&
-              durationInMinutesArg == durationInMinutes &&
-              createdByArg == createdByUser &&
-              createdAtArg.isAfter(startTimeOfTest) &&
-              actionPlanArg == actionPlan
-            )
-        }
-      )
-    ).thenReturn(savedAppointment)
+    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(savedAppointment)
 
     val createdAppointment = appointmentsService.createAppointment(
       actionPlan,
@@ -130,35 +101,7 @@ internal class AppointmentsServiceTest {
 
     whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(actionPlanAppointment)
     whenever(authUserRepository.save(createdByUser)).thenReturn(createdByUser)
-    whenever(
-      actionPlanAppointmentRepository.save(
-        ArgumentMatchers.argThat { (
-          sessionNumberArg,
-          sessionAttendanceArg,
-          additionalAttendanceInformationArg,
-          attendanceSubmittedAtArg,
-          appointmentTimeArg,
-          durationInMinutesArg,
-          createdByArg,
-          createdAtArg,
-          actionPlanArg,
-          _
-        ) ->
-          (
-            sessionNumberArg == sessionNumber &&
-              sessionAttendanceArg == null &&
-              additionalAttendanceInformationArg == null &&
-              attendanceSubmittedAtArg == null &&
-              appointmentTimeArg == appointmentTime &&
-              durationInMinutesArg == durationInMinutes &&
-              createdByArg == createdByUser &&
-              createdAtArg.isAfter(startTimeOfTest) &&
-              actionPlanArg == actionPlan
-
-            )
-        }
-      )
-    ).thenReturn(actionPlanAppointment)
+    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(actionPlanAppointment)
 
     val updatedAppointment = appointmentsService.updateAppointment(
       actionPlanId,
@@ -320,6 +263,6 @@ internal class AppointmentsServiceTest {
     whenever(actionPlanAppointmentRepository.save(any())).thenReturn(existingAppointment)
 
     appointmentsService.recordAttendance(appointmentId, 1, attended, additionalInformation)
-    verify(appointmentEventPublisher).attendanceRecordedEvent(existingAppointment)
+    verify(appointmentEventPublisher).attendanceRecordedEvent(existingAppointment, true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
@@ -22,7 +22,7 @@ class NotifyAppointmentServiceTest {
   private val emailSender = mock<EmailSender>()
   private val hmppsAuthService = mock<HMPPSAuthService>()
 
-  private fun appointmentAttendanceRecordedEvent(attended: Attended): AppointmentEvent {
+  private fun appointmentAttendanceRecordedEvent(notifyPP: Boolean): AppointmentEvent {
     return AppointmentEvent(
       "source",
       AppointmentEventType.ATTENDANCE_RECORDED,
@@ -38,17 +38,19 @@ class NotifyAppointmentServiceTest {
           ),
         ),
         createdBy = SampleData.sampleAuthUser(),
-        attended = attended,
+        attended = Attended.YES,
       ),
       "http://localhost:8080/appointment/42c7d267-0776-4272-a8e8-a673bfe30d0d",
+      notifyPP,
     )
   }
 
   private fun notifyService(): NotifyAppointmentService {
     return NotifyAppointmentService(
       "template",
+      "template",
       "http://example.com",
-      "/appointment/{id}",
+      "/referral/{id}/progress",
       emailSender,
       hmppsAuthService,
     )
@@ -58,14 +60,14 @@ class NotifyAppointmentServiceTest {
   fun `appointment attendance recorded event does not send email when user details are not available`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
-      notifyService().onApplicationEvent(appointmentAttendanceRecordedEvent(Attended.NO))
+      notifyService().onApplicationEvent(appointmentAttendanceRecordedEvent(true))
     }
     verifyZeroInteractions(emailSender)
   }
 
   @Test
-  fun `appointment attendance recorded event does not send email when appointment was attended`() {
-    notifyService().onApplicationEvent(appointmentAttendanceRecordedEvent(Attended.YES))
+  fun `appointment attendance recorded event does not send email when notifyPP is false`() {
+    notifyService().onApplicationEvent(appointmentAttendanceRecordedEvent(false))
     verifyZeroInteractions(emailSender)
   }
 
@@ -73,11 +75,11 @@ class NotifyAppointmentServiceTest {
   fun `appointment attendance recorded event calls email client`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
 
-    notifyService().onApplicationEvent(appointmentAttendanceRecordedEvent(Attended.NO))
+    notifyService().onApplicationEvent(appointmentAttendanceRecordedEvent(true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
     Assertions.assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("HAS71263")
-    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/appointment/42c7d267-0776-4272-a8e8-a673bfe30d0d")
+    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/progress")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSAppointmentServiceTest.kt
@@ -34,7 +34,8 @@ internal class SNSAppointmentServiceTest {
       attended = attendance,
       attendanceSubmittedAt = now,
     ),
-    "http://localhost:8080/action-plan/77df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1"
+    "http://localhost:8080/action-plan/77df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1",
+    false,
   )
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

new endpoint and service methods for recording SU behaviour during a session.

new event type for informing the PP on unacceptable behaviour

event refactoring to push the logic about whether or not to inform the PP into the service layer.

new contract state to satify the contract tests for this on the UI.

## What is the intent behind these changes?

alllow SPs to record SU behaviour for a session.
