### PR TITLE
IC-1288 Create appointment in delius via community-api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
@@ -4,7 +4,9 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.BadRequestException
 
 @Component
 class CommunityAPIClient(
@@ -18,9 +20,35 @@ class CommunityAPIClient(
       .retrieve()
       .bodyToMono(Unit::class.java)
       .onErrorResume { e ->
-        logger.error("Call to community api failed", e, StructuredArguments.kv("requestBody", requestBody))
+        handleResponse(e, requestBody)
         Mono.empty()
       }
       .subscribe()
+  }
+
+  fun makeSyncPostRequest(uri: String, requestBody: Any) {
+    communityApiWebClient.post().uri(uri)
+      .body(Mono.just(requestBody), requestBody::class.java)
+      .retrieve()
+      .bodyToMono(Unit::class.java)
+      .onErrorMap { e ->
+        val responseBodyAsString = handleResponse(e, requestBody)
+        BadRequestException(responseBodyAsString)
+      }
+      .block()
+  }
+
+  fun handleResponse(e: Throwable, requestBody: Any): String {
+    val responseBodyAsString = when (e) {
+      is BadRequest -> e.responseBodyAsString
+      else -> e.localizedMessage
+    }
+    logger.error(
+      "Call to community api failed",
+      e,
+      StructuredArguments.kv("req.body", requestBody),
+      StructuredArguments.kv("res.body", responseBodyAsString)
+    )
+    return responseBodyAsString.let { it } ?: "No response body message"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest
 import reactor.core.publisher.Mono
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.BadRequestException
 
 @Component
 class CommunityAPIClient(
@@ -26,14 +25,14 @@ class CommunityAPIClient(
       .subscribe()
   }
 
-  fun makeSyncPostRequest(uri: String, requestBody: Any) {
-    communityApiWebClient.post().uri(uri)
+  fun <T : Any> makeSyncPostRequest(uri: String, requestBody: Any, responseBodyClass: Class<T>): T? {
+    return communityApiWebClient.post().uri(uri)
       .body(Mono.just(requestBody), requestBody::class.java)
       .retrieve()
-      .bodyToMono(Unit::class.java)
+      .bodyToMono(responseBodyClass)
       .onErrorMap { e ->
-        val responseBodyAsString = handleResponse(e, requestBody)
-        BadRequestException(responseBodyAsString)
+        handleResponse(e, requestBody)
+        e
       }
       .block()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -9,6 +9,7 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityNotFoundException
@@ -82,6 +83,12 @@ class ErrorConfiguration(private val telemetryClient: TelemetryClient) {
   fun handleEntityExistsException(e: EntityExistsException): ResponseEntity<ErrorResponse> {
     logger.info("entity exists exception", e)
     return errorResponse(HttpStatus.CONFLICT, "entity already exists", e.message)
+  }
+
+  @ExceptionHandler(WebClientResponseException::class)
+  fun handleWebClientResponseException(e: WebClientResponseException): ResponseEntity<ErrorResponse> {
+    logger.info("web client exception", e)
+    return errorResponse(e.statusCode, "web client exception", e.responseBodyAsString)
   }
 
   private fun errorResponse(status: HttpStatus, summary: String, description: String?, validationErrors: List<FieldError>? = null): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/BadRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/BadRequestException.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception
-
-class BadRequestException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/BadRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/BadRequestException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception
+
+class BadRequestException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -19,7 +19,8 @@ class AppointmentsService(
   val actionPlanAppointmentRepository: ActionPlanAppointmentRepository,
   val actionPlanRepository: ActionPlanRepository,
   val authUserRepository: AuthUserRepository,
-  val appointmentEventPublisher: AppointmentEventPublisher
+  val appointmentEventPublisher: AppointmentEventPublisher,
+  val communityAPIBookingService: CommunityAPIBookingService,
 ) {
   fun createAppointment(
     actionPlan: ActionPlan,
@@ -59,6 +60,8 @@ class AppointmentsService(
   ): ActionPlanAppointment {
 
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
+    communityAPIBookingService.book(appointment, appointmentTime, durationInMinutes)
+
     mergeAppointment(appointment, appointmentTime, durationInMinutes)
     return actionPlanAppointmentRepository.save(appointment)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -13,6 +13,7 @@ import javax.validation.constraints.NotNull
 
 @Service
 class CommunityAPIBookingService(
+  @Value("\${appointments.bookings.enabled}") private val bookingsEnabled: Boolean,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.view-appointment}") private val interventionsUIViewAppointment: String,
   @Value("\${community-api.locations.book-appointment}") private val communityApiBookAppointmentLocation: String,
@@ -22,10 +23,14 @@ class CommunityAPIBookingService(
 ) {
 
   fun book(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?) {
-    when {
-      isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
-        makeInitialBooking(existingAppointment, appointmentTime, durationInMinutes)
-      }
+    when (bookingsEnabled) {
+      true ->
+        when {
+          isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
+            makeInitialBooking(existingAppointment, appointmentTime, durationInMinutes)
+          }
+          else -> {}
+        }
       else -> {}
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -25,14 +25,14 @@ class CommunityAPIBookingService(
   companion object : KLogging()
 
   fun book(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?) {
-    when (bookingsEnabled) {
-      true ->
-        when {
-          isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
-            makeInitialBooking(existingAppointment, appointmentTime!!, durationInMinutes!!)
-          }
-          else -> {}
-        }
+    if (!bookingsEnabled) {
+      return
+    }
+
+    when {
+      isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
+        makeInitialBooking(existingAppointment, appointmentTime!!, durationInMinutes!!)
+      }
       else -> {}
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -29,7 +29,7 @@ class CommunityAPIBookingService(
       true ->
         when {
           isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
-            makeInitialBooking(existingAppointment, appointmentTime, durationInMinutes)
+            makeInitialBooking(existingAppointment, appointmentTime!!, durationInMinutes!!)
           }
           else -> {}
         }
@@ -37,16 +37,16 @@ class CommunityAPIBookingService(
     }
   }
 
-  private fun makeInitialBooking(appointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?) {
+  private fun makeInitialBooking(appointment: ActionPlanAppointment, appointmentTime: OffsetDateTime, durationInMinutes: Int) {
     val resourceUrl = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
       .path(interventionsUIViewAppointment)
       .buildAndExpand(appointment.actionPlan.referral.id)
       .toString()
 
     val appointmentCreateRequestDTO = AppointmentCreateRequestDTO(
-      appointmentDate = appointmentTime!!.toLocalDate(),
+      appointmentDate = appointmentTime.toLocalDate(),
       appointmentStartTime = appointmentTime.toLocalTime(),
-      appointmentEndTime = appointmentTime.plusMinutes(durationInMinutes!!.toLong()).toLocalTime(),
+      appointmentEndTime = appointmentTime.plusMinutes(durationInMinutes.toLong()).toLocalTime(),
       officeLocationCode = officeLocation,
       notes = resourceUrl,
       context = integrationContext,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import javax.validation.constraints.NotNull
+
+@Service
+class CommunityAPIBookingService(
+  @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
+  @Value("\${interventions-ui.locations.view-appointment}") private val interventionsUIViewAppointment: String,
+  @Value("\${community-api.locations.book-appointment}") private val communityApiBookAppointmentLocation: String,
+  @Value("\${community-api.crs.office-location}") private val crsOfficeLocation: String,
+  @Value("\${community-api.crs.bookings-context}") private val crsBookingsContext: String,
+  val communityAPIClient: CommunityAPIClient,
+) {
+
+  fun book(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?) {
+    when {
+      isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
+        makeInitialBooking(existingAppointment, appointmentTime, durationInMinutes)
+      }
+      else -> {}
+    }
+  }
+
+  private fun makeInitialBooking(appointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?) {
+    val resourceUrl = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
+      .path(interventionsUIViewAppointment)
+      .buildAndExpand(appointment.actionPlan.referral.id)
+      .toString()
+
+    val appointmentCreateRequestDTO = AppointmentCreateRequestDTO(
+      appointmentDate = appointmentTime!!.toLocalDate(),
+      appointmentStartTime = appointmentTime.toLocalTime(),
+      appointmentEndTime = appointmentTime.plusMinutes(durationInMinutes!!.toLong()).toLocalTime(),
+      officeLocationCode = crsOfficeLocation,
+      notes = resourceUrl,
+      context = crsBookingsContext,
+    )
+
+    val referral = appointment.actionPlan.referral
+    val communityApiBookAppointmentPath = UriComponentsBuilder.fromPath(communityApiBookAppointmentLocation)
+      .buildAndExpand(referral.serviceUserCRN, referral.relevantSentenceId!!)
+      .toString()
+    communityAPIClient.makeSyncPostRequest(communityApiBookAppointmentPath, appointmentCreateRequestDTO)
+  }
+
+  fun isInitialBooking(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?): Boolean =
+    isTimingSpecified(appointmentTime, durationInMinutes) &&
+      !isTimingSpecified(existingAppointment.appointmentTime, existingAppointment.durationInMinutes)
+
+  fun isTimingSpecified(appointmentTime: OffsetDateTime?, durationInMinutes: Int?): Boolean =
+    appointmentTime != null && durationInMinutes != null
+}
+
+data class AppointmentCreateRequestDTO(
+
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  @NotNull val appointmentDate: LocalDate,
+
+  @JsonFormat(pattern = "HH:mm:ss")
+  @NotNull val appointmentStartTime: LocalTime,
+
+  @JsonFormat(pattern = "HH:mm:ss")
+  @NotNull val appointmentEndTime: LocalTime,
+
+  @NotNull val officeLocationCode: String,
+
+  @NotNull val notes: String,
+
+  @NotNull val context: String,
+)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,10 @@
 notify:
   enabled: false
 
+appointments:
+  bookings:
+    enabled: false
+
 interventions-ui:
   baseurl: http://localhost:3000
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+    time-zone: "Europe/London"
   security:
     oauth2:
       client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,10 +83,15 @@ interventions-ui:
     sent-referral: "/service-provider/referrals/{id}/details"
     submit-action-plan: "/service-provider/referrals/{id}/progress" # fixme
     appointment-not-attended: "/service-provider/referrals/{id}/progress" # fixme
+    view-appointment: "/probation-practitioner/referrals/{id}/progress"
 
 community-api:
   locations:
     sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
+    book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments"
+  crs:
+    office-location: CRSSHEF
+    bookings-context: commissioned-rehabilitation-services
 
 hmppsauth:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,7 +96,7 @@ community-api:
 
 appointments:
   bookings:
-    enabled: true
+    enabled: false
 
 hmppsauth:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,10 @@ community-api:
     office-location: CRSSHEF
     bookings-context: commissioned-rehabilitation-services
 
+appointments:
+  bookings:
+    enabled: true
+
 hmppsauth:
   api:
     locations:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,9 +89,9 @@ community-api:
   locations:
     sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments"
-  crs:
+  appointments:
     office-location: CRSSHEF
-    bookings-context: commissioned-rehabilitation-services
+  integration-context: commissioned-rehabilitation-services
 
 appointments:
   bookings:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -15,11 +15,12 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus.OK
 import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.BadRequestException
@@ -31,9 +32,6 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import org.springframework.http.HttpStatus.LENGTH_REQUIRED
-import org.springframework.http.HttpStatus.OK
-import org.springframework.web.reactive.function.client.ClientResponse
 
 class CommunityAPIClientTest {
 
@@ -105,7 +103,7 @@ class CommunityAPIClientTest {
     )
     val clientResponse: ClientResponse = ClientResponse
       .create(OK)
-      .header("Content-Type","application/json")
+      .header("Content-Type", "application/json")
       .build()
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.just(clientResponse))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -25,6 +25,7 @@ internal class CommunityAPIBookingServiceTest {
   private val communityAPIClient: CommunityAPIClient = mock()
 
   private val communityAPIBookingService = CommunityAPIBookingService(
+    true,
     httpBaseUrl,
     viewUrl,
     apiUrl,
@@ -48,7 +49,7 @@ internal class CommunityAPIBookingServiceTest {
   }
 
   @Test
-  fun `does nothing if not initial booking`() {
+  fun `does nothing if not not enabled`() {
     communityAPIBookingService.book(makeAppointment(null, null), now(), null)
     verifyZeroInteractions(communityAPIClient)
   }
@@ -69,6 +70,25 @@ internal class CommunityAPIBookingServiceTest {
     assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), 60), null, null)).isFalse()
     assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), now(), null)).isFalse()
     assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), now(), 60)).isTrue()
+  }
+
+  @Test
+  fun `does nothing if not initial booking`() {
+    val now = now()
+    val appointment = makeAppointment(null, null)
+
+    val communityAPIBookingServiceNotEnabled = CommunityAPIBookingService(
+      false,
+      httpBaseUrl,
+      viewUrl,
+      apiUrl,
+      crsOfficeLocation,
+      crsBookingsContext,
+      communityAPIClient
+    )
+
+    communityAPIBookingServiceNotEnabled.book(appointment, now(), 60)
+    verifyZeroInteractions(communityAPIClient)
   }
 
   private fun makeAppointment(appointmentTime: OffsetDateTime?, durationInMinutes: Int?): ActionPlanAppointment {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -49,7 +49,7 @@ internal class CommunityAPIBookingServiceTest {
   }
 
   @Test
-  fun `does nothing if not not enabled`() {
+  fun `does nothing if not initial booking`() {
     communityAPIBookingService.book(makeAppointment(null, null), now(), null)
     verifyZeroInteractions(communityAPIClient)
   }
@@ -73,7 +73,7 @@ internal class CommunityAPIBookingServiceTest {
   }
 
   @Test
-  fun `does nothing if not initial booking`() {
+  fun `does nothing if not enabled`() {
     val now = now()
     val appointment = makeAppointment(null, null)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import java.time.OffsetDateTime
+import java.time.OffsetDateTime.now
+
+internal class CommunityAPIBookingServiceTest {
+
+  private val crn = "X1"
+  private val sentenceId = 123L
+
+  private val httpBaseUrl = "http://url"
+  private val viewUrl = "/view/{referralId}"
+  private val apiUrl = "/appt/{CRN}/{sentenceId}"
+  private val crsOfficeLocation = "CRSSHEF"
+  private val crsBookingsContext = "CRS"
+
+  private val communityAPIClient: CommunityAPIClient = mock()
+
+  private val communityAPIBookingService = CommunityAPIBookingService(
+    httpBaseUrl,
+    viewUrl,
+    apiUrl,
+    crsOfficeLocation,
+    crsBookingsContext,
+    communityAPIClient
+  )
+
+  @Test
+  fun `requests booking for an appointment when timings specified`() {
+    val now = now()
+    val appointment = makeAppointment(null, null)
+
+    communityAPIBookingService.book(appointment, now, 60)
+
+    val link = "http://url/view/${appointment.actionPlan.referral.id}"
+    verify(communityAPIClient).makeSyncPostRequest(
+      "/appt/X1/123",
+      AppointmentCreateRequestDTO(now.toLocalDate(), now.toLocalTime(), now.toLocalTime().plusMinutes(60), "CRSSHEF", notes = link, "CRS")
+    )
+  }
+
+  @Test
+  fun `does nothing if not initial booking`() {
+    communityAPIBookingService.book(makeAppointment(null, null), now(), null)
+    verifyZeroInteractions(communityAPIClient)
+  }
+
+  @Test
+  fun `is timing specified`() {
+    assertThat(communityAPIBookingService.isTimingSpecified(null, null)).isFalse()
+    assertThat(communityAPIBookingService.isTimingSpecified(now(), null)).isFalse()
+    assertThat(communityAPIBookingService.isTimingSpecified(null, 60)).isFalse()
+    assertThat(communityAPIBookingService.isTimingSpecified(now(), 60)).isTrue()
+  }
+
+  @Test
+  fun `is initial booking`() {
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), null), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, 60), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), 60), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), now(), null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), now(), 60)).isTrue()
+  }
+
+  private fun makeAppointment(appointmentTime: OffsetDateTime?, durationInMinutes: Int?): ActionPlanAppointment {
+    val referral = SampleData.sampleReferral(crn = crn, relevantSentenceId = sentenceId, serviceProviderName = "SPN")
+    return SampleData.sampleActionPlanAppointment(
+      actionPlan = SampleData.sampleActionPlan(referral = referral),
+      createdBy = SampleData.sampleAuthUser(),
+      appointmentTime = appointmentTime,
+      durationInMinutes = durationInMinutes
+    )
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

This takes an appointment in a patch action in interventions and tries to book an appointment with the CRN in delius going through community-api and delius-api.

## What is the intent behind these changes?

The reason for the is change to ensue that a service user can attend appointments and that conflict for their time do not arise
