### PR TITLE
IC-1427 add endpoint to 'submit' session feedback and defer notifications until submission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AppointmentsController.kt
@@ -71,4 +71,9 @@ class AppointmentsController(
   fun recordBehaviour(@PathVariable actionPlanId: UUID, @PathVariable sessionNumber: Int, @RequestBody update: UpdateAppointmentBehaviourDTO): ActionPlanAppointmentDTO {
     return ActionPlanAppointmentDTO.from(appointmentsService.recordBehaviour(actionPlanId, sessionNumber, update.behaviourDescription, update.notifyProbationPractitioner))
   }
+
+  @PostMapping("/action-plan/{actionPlanId}/appointment/{sessionNumber}/submit")
+  fun submitSessionFeedback(@PathVariable actionPlanId: UUID, @PathVariable sessionNumber: Int): ActionPlanAppointmentDTO {
+    return ActionPlanAppointmentDTO.from(appointmentsService.submitSessionFeedback(actionPlanId, sessionNumber))
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanAppointmentsDTO.kt
@@ -54,6 +54,7 @@ data class ActionPlanAppointmentDTO(
           appointment.additionalAttendanceInformation,
           appointment.attendanceBehaviour,
           appointment.notifyPPOfAttendanceBehaviour,
+          appointment.attendanceSubmittedAt != null,
         ),
       )
     }
@@ -66,17 +67,20 @@ data class ActionPlanAppointmentDTO(
 data class SessionFeedbackDTO(
   val attendance: AttendanceDTO,
   val behaviour: BehaviourDTO,
+  val submitted: Boolean,
 ) {
   companion object {
     fun from(
       attended: Attended?,
       additionalAttendanceInformation: String?,
       behaviourDescription: String?,
-      notifyProbationPractitioner: Boolean?
+      notifyProbationPractitioner: Boolean?,
+      submitted: Boolean,
     ): SessionFeedbackDTO {
       return SessionFeedbackDTO(
         AttendanceDTO(attended = attended, additionalAttendanceInformation = additionalAttendanceInformation),
         BehaviourDTO(behaviourDescription, notifyProbationPractitioner),
+        submitted,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanAppointment.kt
@@ -31,6 +31,7 @@ data class ActionPlanAppointment(
   var attendanceBehaviour: String? = null,
   var attendanceBehaviourSubmittedAt: OffsetDateTime? = null,
   var notifyPPOfAttendanceBehaviour: Boolean? = null,
+  var sessionFeedbackSubmittedAt: OffsetDateTime? = null,
 
   // Activities
   var appointmentTime: OffsetDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -75,6 +75,11 @@ class AppointmentsService(
     additionalInformation: String?
   ): ActionPlanAppointment {
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
+
+    if (appointment.sessionFeedbackSubmittedAt != null) {
+      throw ResponseStatusException(HttpStatus.CONFLICT, "session feedback has already been submitted for this appointment")
+    }
+
     setAttendanceFields(appointment, attended, additionalInformation)
     return actionPlanAppointmentRepository.save(appointment)
   }
@@ -86,6 +91,11 @@ class AppointmentsService(
     notifyProbationPractitioner: Boolean,
   ): ActionPlanAppointment {
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
+
+    if (appointment.sessionFeedbackSubmittedAt != null) {
+      throw ResponseStatusException(HttpStatus.CONFLICT, "session feedback has already been submitted for this appointment")
+    }
+
     setBehaviourFields(appointment, behaviourDescription, notifyProbationPractitioner)
     return actionPlanAppointmentRepository.save(appointment)
   }
@@ -94,7 +104,7 @@ class AppointmentsService(
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
 
     if (appointment.sessionFeedbackSubmittedAt != null) {
-      throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "session feedback has already been submitted for this appointment")
+      throw ResponseStatusException(HttpStatus.CONFLICT, "session feedback has already been submitted for this appointment")
     }
 
     if (appointment.attendanceBehaviourSubmittedAt == null || appointment.attendanceSubmittedAt == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -93,7 +93,7 @@ class AppointmentsService(
   fun submitSessionFeedback(actionPlanId: UUID, sessionNumber: Int): ActionPlanAppointment {
     val appointment = getActionPlanAppointmentOrThrowException(actionPlanId, sessionNumber)
 
-    if (appointment.attendanceSubmittedAt != null) {
+    if (appointment.sessionFeedbackSubmittedAt != null) {
       throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "session feedback has already been submitted for this appointment")
     }
 

--- a/src/main/resources/db/migration/V1_40__appointment_session_feedback.sql
+++ b/src/main/resources/db/migration/V1_40__appointment_session_feedback.sql
@@ -1,0 +1,2 @@
+alter table action_plan_appointment
+    add column session_feedback_submitted_at timestamp with time zone;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.firstValue
 import com.nhaarman.mockitokotlin2.mock
@@ -11,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
+import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
@@ -248,25 +251,6 @@ internal class AppointmentsServiceTest {
   }
 
   @Test
-  fun `appointment attendance recorded emits application event`() {
-    val appointmentId = UUID.randomUUID()
-    val sessionNumber = 1
-    val createdByUser = SampleData.sampleAuthUser()
-    val actionPlan = SampleData.sampleActionPlan()
-    val attended = Attended.NO
-    val additionalInformation = "extra info"
-
-    val existingAppointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = createdByUser)
-
-    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(appointmentId, sessionNumber))
-      .thenReturn(existingAppointment)
-    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(existingAppointment)
-
-    appointmentsService.recordAttendance(appointmentId, 1, attended, additionalInformation)
-    verify(appointmentEventPublisher).attendanceRecordedEvent(existingAppointment, true)
-  }
-
-  @Test
   fun `updating session behaviour sets relevant fields`() {
     val actionPlan = SampleData.sampleActionPlan()
     val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
@@ -288,5 +272,76 @@ internal class AppointmentsServiceTest {
     assertThrows(EntityNotFoundException::class.java) {
       appointmentsService.recordBehaviour(UUID.randomUUID(), 1, "not good", false)
     }
+  }
+
+  @Test
+  fun `session feedback cant be submitted more than once`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
+    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(appointment)
+    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(appointment)
+
+    appointmentsService.recordAttendance(actionPlan.id, 1, Attended.YES, "")
+    appointmentsService.recordBehaviour(actionPlan.id, 1, "bad", false)
+    appointment.sessionFeedbackSubmittedAt = OffsetDateTime.now()
+
+    assertThrows(ResponseStatusException::class.java) {
+      appointmentsService.submitSessionFeedback(actionPlan.id, 1)
+    }
+  }
+
+  @Test
+  fun `session feedback cant be submitted if attendance is missing`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
+    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(appointment)
+    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(appointment)
+
+    appointmentsService.recordBehaviour(actionPlan.id, 1, "bad", false)
+
+    assertThrows(ResponseStatusException::class.java) {
+      appointmentsService.submitSessionFeedback(actionPlan.id, 1)
+    }
+  }
+
+  @Test
+  fun `session feedback cant be submitted if behaviour is missing`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
+    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(appointment)
+    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(appointment)
+
+    appointmentsService.recordAttendance(actionPlan.id, 1, Attended.YES, "")
+
+    assertThrows(ResponseStatusException::class.java) {
+      appointmentsService.submitSessionFeedback(actionPlan.id, 1)
+    }
+  }
+
+  @Test
+  fun `session feedback can be submitted and stores timestamp and emits application events`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
+    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(
+      appointment
+    )
+    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(appointment)
+
+    appointmentsService.recordAttendance(actionPlan.id, 1, Attended.YES, "")
+    appointmentsService.recordBehaviour(actionPlan.id, 1, "bad", true)
+    appointmentsService.submitSessionFeedback(actionPlan.id, 1)
+
+    val appointmentCaptor = argumentCaptor<ActionPlanAppointment>()
+    verify(actionPlanAppointmentRepository, atLeastOnce()).save(appointmentCaptor.capture())
+    appointmentCaptor.allValues.forEach {
+      if (it == appointmentCaptor.lastValue) {
+        assertThat(it.sessionFeedbackSubmittedAt != null)
+      } else {
+        assertThat(it.sessionFeedbackSubmittedAt == null)
+      }
+    }
+
+    verify(appointmentEventPublisher).attendanceRecordedEvent(appointment, false)
+    verify(appointmentEventPublisher).behaviourRecordedEvent(appointment, true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
@@ -344,4 +344,28 @@ internal class AppointmentsServiceTest {
     verify(appointmentEventPublisher).attendanceRecordedEvent(appointment, false)
     verify(appointmentEventPublisher).behaviourRecordedEvent(appointment, true)
   }
+
+  @Test
+  fun `attendance can't be updated once session feedback has been submitted`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
+    appointment.sessionFeedbackSubmittedAt = OffsetDateTime.now()
+    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(appointment)
+
+    assertThrows(ResponseStatusException::class.java) {
+      appointmentsService.recordAttendance(actionPlan.id, 1, Attended.YES, "")
+    }
+  }
+
+  @Test
+  fun `behaviour can't be updated once session feedback has been submitted`() {
+    val actionPlan = SampleData.sampleActionPlan()
+    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
+    appointment.sessionFeedbackSubmittedAt = OffsetDateTime.now()
+    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(appointment)
+
+    assertThrows(ResponseStatusException::class.java) {
+      appointmentsService.recordBehaviour(actionPlan.id, 1, "bad", false)
+    }
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

IC-1427 add endpoint to 'submit' session feedback and defer notifications until submission

## What is the intent behind these changes?

allow the 'confirm your answers page' to be built on the UI for the session feedback screens
