### PR TITLE
IC-1505: Upload daily snapshots to Analytical Platform

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: data-extractor
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: "Never"
+          containers:
+          - name: data-extractor
+            image: ministryofjustice/data-engineering-data-extractor:develop
+            command: ["sh", "-c", "extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            env:
+              - name: LOCAL_EXPORT_DESTINATION
+                value: export
+              - name: PGHOST
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: rds_instance_address
+              - name: PGDATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: database_name
+              - name: PGUSER
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: database_username
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: database_password
+              - name: S3_DESTINATION
+                valueFrom:
+                  secretKeyRef:
+                    name: analytical-platform-reporting-s3-bucket
+                    key: destination_bucket
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: analytical-platform-reporting-s3-bucket
+                    key: access_key_id
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: analytical-platform-reporting-s3-bucket
+                    key: secret_access_key
+              - name: AWS_DEFAULT_REGION
+                value: eu-west-2


### PR DESCRIPTION
## What does this pull request do?

Periodically exports all tables to CSVs and then uploads those into a timestamped "folder" in an Analytical Platform S3 "landing" bucket for further analytical processing

It is scheduled for 1 am every day (UTC)

🙋 Uses the new `data-engineering-data-extractor` image: https://github.com/ministryofjustice/data-engineering-data-extractor/pull/4
🙋 The `s3://hmpps-interventions-dev-landing` bucket is provisioned by the Analytical Platform, but access to it is controlled via https://github.com/ministryofjustice/cloud-platform-environments/pull/4604

## Depends on

- [x] https://github.com/ministryofjustice/data-engineering-data-extractor/pull/4
- [x] https://github.com/ministryofjustice/cloud-platform-environments/pull/4604
- [x] https://github.com/ministryofjustice/cloud-platform-environments/pull/4607
- [x] https://github.com/ministryofjustice/data-engineering-data-extractor/pull/6
- there will be further PRs to add the policy/buckets to other environments

## What is the intent behind these changes?

To enable the analysis and processing of interventions data.