### PR TITLE
DAPI-88 Improved request objects in calls to community api to use off…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -1,14 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import mu.KLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
-import java.time.LocalDate
-import java.time.LocalTime
 import java.time.OffsetDateTime
 import javax.validation.constraints.NotNull
 
@@ -44,9 +41,8 @@ class CommunityAPIBookingService(
       .toString()
 
     val appointmentCreateRequestDTO = AppointmentCreateRequestDTO(
-      appointmentDate = appointmentTime.toLocalDate(),
-      appointmentStartTime = appointmentTime.toLocalTime(),
-      appointmentEndTime = appointmentTime.plusMinutes(durationInMinutes.toLong()).toLocalTime(),
+      appointmentStart = appointmentTime,
+      appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
       officeLocationCode = officeLocation,
       notes = resourceUrl,
       context = integrationContext,
@@ -70,21 +66,11 @@ class CommunityAPIBookingService(
 }
 
 data class AppointmentCreateRequestDTO(
-
-  @JsonFormat(pattern = "yyyy-MM-dd")
-  @NotNull val appointmentDate: LocalDate,
-
-  @JsonFormat(pattern = "HH:mm:ss")
-  @NotNull val appointmentStartTime: LocalTime,
-
-  @JsonFormat(pattern = "HH:mm:ss")
-  @NotNull val appointmentEndTime: LocalTime,
-
-  @NotNull val officeLocationCode: String,
-
-  @NotNull val notes: String,
-
-  @NotNull val context: String,
+  val appointmentStart: OffsetDateTime,
+  val appointmentEnd: OffsetDateTime,
+  val officeLocationCode: String,
+  val notes: String,
+  val context: String,
 )
 
 data class AppointmentCreateResponseDTO(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
-    time-zone: "Europe/London"
   security:
     oauth2:
       client:
@@ -98,7 +97,7 @@ community-api:
 
 appointments:
   bookings:
-    enabled: false
+    enabled: true
 
 hmppsauth:
   api:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -29,8 +29,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleD
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentCreateRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentCreateResponseDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingMemoryAppender
-import java.time.LocalDate
-import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -179,9 +177,8 @@ class CommunityAPIClientTest {
   )
 
   private val appointmentCreateRequest = AppointmentCreateRequestDTO(
-    appointmentDate = LocalDate.now(),
-    appointmentStartTime = LocalTime.now(),
-    appointmentEndTime = LocalTime.now(),
+    appointmentStart = OffsetDateTime.now(),
+    appointmentEnd = OffsetDateTime.now(),
     officeLocationCode = "CRSSHEF",
     notes = "http://backLink",
     context = "c-r-s",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -37,12 +37,12 @@ internal class CommunityAPIBookingServiceTest {
 
   @Test
   fun `requests booking for an appointment when timings specified`() {
-    val now = now()
+    val now = OffsetDateTime.now()
     val appointment = makeAppointment(null, null)
 
     val uri = "/appt/X1/123"
     val link = "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO(now.toLocalDate(), now.toLocalTime(), now.toLocalTime().plusMinutes(60), "CRSSHEF", notes = link, "CRS")
+    val request = AppointmentCreateRequestDTO(now, now.plusMinutes(60), "CRSSHEF", notes = link, "CRS")
     val response = AppointmentCreateResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIServiceTest.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.Communit
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -23,6 +22,7 @@ class CommunityAPIServiceTest {
       "http://testUrl",
       "secure/offenders/crn/{id}/referral/sent",
       "secure/offenders/crn/{id}/referral/sent",
+      "commissioned-rehabilitation-services",
       communityAPIClient
     )
 
@@ -31,10 +31,11 @@ class CommunityAPIServiceTest {
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/sent",
       ReferRequest(
-        "Accommodation",
+        OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC),
+        referralSentEvent.referral.intervention.dynamicFrameworkContract.serviceCategory.id,
         123456789,
         "http://testUrl/secure/offenders/crn/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/referral/sent",
-        LocalDate.of(2020, 1, 1)
+        "commissioned-rehabilitation-services",
       )
     )
   }
@@ -48,7 +49,7 @@ class CommunityAPIServiceTest {
       crn = "X123456",
       relevantSentenceId = 123456789,
       serviceProviderName = "Harmony Living",
-      sentAt = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 0, ZoneOffset.of("+00:00"))
+      sentAt = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
     ),
     "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
   )


### PR DESCRIPTION
**What does this pull request do?**

After completing the end to end integration between Interventions and Delius UI (via community-api and delius-api) a number of improvements were identified in order to have a working integration. These comprise:

- Interventions to provide offsets with dates and times so that appointments and referrals can be converted correctly for Delius which relies on Europe/London local dates and times
- Use UUIDs over long text to identify reference data (e.g. service category). The use of descriptions was deemed fragile ( business codes are not available for service categories)
- Provide integration context in all requests to identify the correct mapping configuration for a client of community-api

**What is the intent behind these changes?**

To achieve a workable integration between new Interventions Service and the existing Case Management System Delius for both referrals and appointments creation.