### PR TITLE
Only allow reset for the research DB from main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,9 @@ workflows:
             - hmpps-interventions-service-research
       - approve_reset_research_db:
           type: approval
+          filters:
+            branches:
+              only: [main]
       - reset_research_db:
           requires:
             - approve_reset_research_db


### PR DESCRIPTION
## What does this pull request do?

Constraints user research environment reset to be only possible on `main` branches: https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service?branch=main

## What is the intent behind these changes?

This has two benefits as far as I can see

1. Ensures we only deploy seed files on the mainline, which reduces potential misunderstandings (trial deployment can still be made locally with `helm` CLI)
2. Removes the "never green" check on PRs, e.g.:
    ![image](https://user-images.githubusercontent.com/1526295/114694727-c0875980-9d12-11eb-8ac7-c9fb647181a1.png)
