### PR TITLE
Make 'behaviour' not required for submitted session feedback.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -107,8 +107,8 @@ class AppointmentsService(
       throw ResponseStatusException(HttpStatus.CONFLICT, "session feedback has already been submitted for this appointment")
     }
 
-    if (appointment.attendanceBehaviourSubmittedAt == null || appointment.attendanceSubmittedAt == null) {
-      throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "can't submit session feedback unless attendance and behaviour have been recorded")
+    if (appointment.attendanceSubmittedAt == null) {
+      throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "can't submit session feedback unless attendance has been recorded")
     }
 
     appointment.sessionFeedbackSubmittedAt = OffsetDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsServiceTest.kt
@@ -305,20 +305,6 @@ internal class AppointmentsServiceTest {
   }
 
   @Test
-  fun `session feedback cant be submitted if behaviour is missing`() {
-    val actionPlan = SampleData.sampleActionPlan()
-    val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)
-    whenever(actionPlanAppointmentRepository.findByActionPlanIdAndSessionNumber(actionPlan.id, 1)).thenReturn(appointment)
-    whenever(actionPlanAppointmentRepository.save(any())).thenReturn(appointment)
-
-    appointmentsService.recordAttendance(actionPlan.id, 1, Attended.YES, "")
-
-    assertThrows(ResponseStatusException::class.java) {
-      appointmentsService.submitSessionFeedback(actionPlan.id, 1)
-    }
-  }
-
-  @Test
   fun `session feedback can be submitted and stores timestamp and emits application events`() {
     val actionPlan = SampleData.sampleActionPlan()
     val appointment = SampleData.sampleActionPlanAppointment(actionPlan = actionPlan, createdBy = actionPlan.createdBy)


### PR DESCRIPTION
## What does this pull request do?

Make 'behaviour' not required for submitted session feedback.
In the case of an SU not attending the session, no behaviour is recorded.

## What is the intent behind these changes?

allows submitted session feedback for cases of non attendance
