### PR TITLE
change /sent-referrals endpoint to accept query params for filtering referrals based on different criteria

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -13,6 +13,8 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
   fun findByInterventionDynamicFrameworkContractServiceProviderIdAndSentAtIsNotNull(id: AuthGroupID): List<Referral>
   fun existsByReferenceNumber(reference: String): Boolean
   fun findBySentBy(user: AuthUser): List<Referral>
+  fun findBySentById(userId: String): List<Referral>
+  fun findByAssignedToId(userId: String): List<Referral>
 
   // queries for draft referrals
   fun findByIdAndSentAtIsNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -59,9 +59,16 @@ class ReferralService(
     return referralRepository.findBySentBy(user)
   }
 
-  fun getSentReferralsForServiceProviderID(serviceProviderID: AuthGroupID): List<SentReferralDTO> {
+  fun getSentReferralsSentBy(userId: String): List<Referral> {
+    return referralRepository.findBySentById(userId)
+  }
+
+  fun getSentReferralsAssignedTo(userId: String): List<Referral> {
+    return referralRepository.findByAssignedToId(userId)
+  }
+
+  fun getSentReferralsForServiceProviderID(serviceProviderID: AuthGroupID): List<Referral> {
     return referralRepository.findByInterventionDynamicFrameworkContractServiceProviderIdAndSentAtIsNotNull(serviceProviderID)
-      .map { SentReferralDTO.from(it) }
   }
 
   fun endSentReferral(referral: Referral, user: AuthUser): Referral {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -20,11 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CancellationRe
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAssignmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
-<<<<<<< HEAD
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
-=======
->>>>>>> fa6b81a (change /sent-referrals endpoint to accept query params for filtering referrals based on different criteria)
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
-import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebInputException
@@ -20,17 +19,18 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AuthUserDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CancellationReasonsDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAssignmentDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+<<<<<<< HEAD
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+=======
+>>>>>>> fa6b81a (change /sent-referrals endpoint to accept query params for filtering referrals based on different criteria)
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
-import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.EntityNotFoundException
 
@@ -53,17 +53,31 @@ internal class ReferralControllerTest {
   }
 
   @Test
-  fun `getSentReferrals filters by service provider organization from auth token`() {
-    whenever(hmppsAuthService.getServiceProviderOrganizationForUser(any())).thenReturn("HARMONY_LIVING")
-    referralController.getSentReferrals(tokenFactory.create())
+  fun `getSentReferrals filters by service provider organization from query param`() {
+    referralController.getSentReferrals(sentTo = "HARMONY_LIVING")
     verify(referralService).getSentReferralsForServiceProviderID("HARMONY_LIVING")
   }
 
   @Test
-  fun `getSentReferrals throws AccessDeniedException when user is not associated with a service provider`() {
-    whenever(hmppsAuthService.getServiceProviderOrganizationForUser(any())).thenReturn(null)
-    assertThrows<AccessDeniedException> {
-      referralController.getSentReferrals(tokenFactory.create())
+  fun `getSentReferrals filters by PP from query param`() {
+    referralController.getSentReferrals(sentBy = "bernard.beaks")
+    verify(referralService).getSentReferralsSentBy("bernard.beaks")
+  }
+
+  @Test
+  fun `getSentReferrals filters by assignee from query param`() {
+    referralController.getSentReferrals(assignedTo = "someone@provider.com")
+    verify(referralService).getSentReferralsAssignedTo("someone@provider.com")
+  }
+
+  @Test
+  fun `getSentReferrals throws error unless a single query param is passed`() {
+    assertThrows<ServerWebInputException> {
+      referralController.getSentReferrals()
+    }
+
+    assertThrows<ServerWebInputException> {
+      referralController.getSentReferrals(sentBy = "bernard.beaks", sentTo = "HARMONY_LIVING")
     }
   }
 
@@ -121,25 +135,6 @@ internal class ReferralControllerTest {
       referralController.endSentReferral(UUID.randomUUID(), jwtAuthenticationToken)
     }
     assertThat(e.status).isEqualTo(HttpStatus.NOT_FOUND)
-  }
-
-  @Test
-  fun `get all sent referrals from current user`() {
-    val authUser = AuthUser("CRN123", "auth", "user")
-    val jwtAuthenticationToken = JwtAuthenticationToken(mock())
-    val referral = SampleData.sampleReferral(
-      "CRN123", "Service Provider",
-      sentAt = OffsetDateTime.parse("2021-01-13T21:57:13+00:00"), sentBy = authUser, referenceNumber = "abc"
-    )
-    val expectedResponse = listOf(referral).map { SentReferralDTO.from(it) }
-
-    whenever(jwtAuthUserMapper.map(jwtAuthenticationToken)).thenReturn(authUser)
-    whenever(referralService.getSentReferralsSentBy(authUser)).thenReturn(listOf(referral))
-    val response = referralController.getSentReferralsSentBy(jwtAuthenticationToken)
-
-    verify(referralService).getSentReferralsSentBy(authUser)
-    assertThat(response.size).isEqualTo(1)
-    assertThat(response[0].id).isEqualTo(expectedResponse[0].id)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
@@ -62,7 +62,6 @@ class PactTest {
       npsRegionRepository,
       dynamicFrameworkContractRepository,
       desiredOutcomeRepository,
-      hmppsAuthService,
     )
 
     setupAssistant.cleanAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
@@ -12,12 +12,12 @@ class ReferralContracts(private val setupAssistant: SetupAssistant) {
 
   @State(
     "There is an existing sent referral with ID of 400be4c6-1aa4-4f52-ae86-cbd5d23309bf",
-    "There are some existing sent referrals",
+    "There are some existing sent referrals sent to HARMONY_LIVING",
+    "There are some existing sent referrals sent by user with id 'bernard.beaks'",
   )
   fun `create sent referral 400be4c6`() {
     val referral = setupAssistant.createSentReferral(id = UUID.fromString("400be4c6-1aa4-4f52-ae86-cbd5d23309bf"))
     setupAssistant.fillReferralFields(referral)
-    setupAssistant.mockServiceProviderOrganization(referral.intervention.dynamicFrameworkContract.serviceProvider.id)
   }
 
   @State("There is an existing draft referral with ID of ac386c25-52c8-41fa-9213-fcf42e24b0b5")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/SetupAssistant.kt
@@ -1,12 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.pact
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.whenever
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanActivity
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
@@ -23,7 +20,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.NPS
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceProviderRepository
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -49,7 +45,6 @@ class SetupAssistant(
   private val npsRegionRepository: NPSRegionRepository,
   private val dynamicFrameworkContractRepository: DynamicFrameworkContractRepository,
   private val desiredOutcomeRepository: DesiredOutcomeRepository,
-  private val mockHMPPSAuthService: HMPPSAuthService,
 ) {
   private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
   private val interventionFactory = InterventionFactory()
@@ -70,10 +65,6 @@ class SetupAssistant(
 
     serviceProviderRepository.deleteAll()
     authUserRepository.deleteAll()
-  }
-
-  fun mockServiceProviderOrganization(organization: AuthGroupID) {
-    whenever(mockHMPPSAuthService.getServiceProviderOrganizationForUser(any())).thenReturn(organization)
   }
 
   fun randomServiceCategory(): ServiceCategory {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -352,25 +352,4 @@ class ReferralServiceTest @Autowired constructor(
 
     assertThat(referralService.getAllSentReferrals().size).isEqualTo(2)
   }
-
-  @Test
-  fun `get sent referrals by provider id returns filtered referrals`() {
-    val referrals = listOf("PROVIDER1", "PROVIDER2").map {
-      SampleData.persistReferral(
-        entityManager,
-        SampleData.sampleReferral(
-          "X123456",
-          it,
-          sentAt = OffsetDateTime.now(),
-          sentBy = AuthUser("123456", "user_id", "user_name"),
-          referenceNumber = "REF123"
-        )
-      )
-    }
-
-    val sentReferrals = referralService.getSentReferralsForServiceProviderID("PROVIDER2")
-    assertThat(sentReferrals.first().actionPlanId).isEqualTo(referrals.last().actionPlan?.id)
-    assertThat(sentReferrals.size).isEqualTo(1)
-    assertThat(referralService.getSentReferralsForServiceProviderID("PROVIDER3").size).isEqualTo(0)
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -22,7 +22,12 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Aut
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProviderFactory
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
@@ -37,6 +42,12 @@ class ReferralServiceTest @Autowired constructor(
   val interventionRepository: InterventionRepository,
   val cancellationReasonRepository: CancellationReasonRepository,
 ) {
+
+  private val userFactory = AuthUserFactory(entityManager)
+  private val interventionFactory = InterventionFactory(entityManager)
+  private val contractFactory = DynamicFrameworkContractFactory(entityManager)
+  private val serviceProviderFactory = ServiceProviderFactory(entityManager)
+  private val referralFactory = ReferralFactory(entityManager)
 
   private val referralEventPublisher: ReferralEventPublisher = mock()
   private val referenceGenerator: ReferralReferenceGenerator = spy(ReferralReferenceGenerator())
@@ -351,5 +362,49 @@ class ReferralServiceTest @Autowired constructor(
     }
 
     assertThat(referralService.getAllSentReferrals().size).isEqualTo(2)
+  }
+
+  @Test
+  fun `get sent referrals sent by PP returns filtered referrals`() {
+    val users = listOf(userFactory.create("pp_user_1", "delius"), userFactory.create("pp_user_2", "delius"))
+    users.forEach {
+      referralFactory.createSent(sentBy = it)
+    }
+
+    val referrals = referralService.getSentReferralsSentBy(users[0])
+    assertThat(referralService.getSentReferralsSentBy(users[0].id)).isEqualTo(referrals)
+    assertThat(referrals.size).isEqualTo(1)
+    assertThat(referrals[0].sentBy).isEqualTo(users[0])
+
+    assertThat(referralService.getSentReferralsAssignedTo("missing")).isEmpty()
+  }
+
+  @Test
+  fun `get sent referrals sent to SP org returns filtered referrals`() {
+    val spOrgs = listOf(serviceProviderFactory.create("sp_org_1"), serviceProviderFactory.create("sp_org_2"))
+    spOrgs.forEach {
+      val intervention = interventionFactory.create(contract = contractFactory.create(serviceProvider = it))
+      referralFactory.createSent(intervention = intervention)
+    }
+
+    val referrals = referralService.getSentReferralsForServiceProviderID(spOrgs[0].id)
+    assertThat(referrals.size).isEqualTo(1)
+    assertThat(referrals[0].intervention.dynamicFrameworkContract.serviceProvider).isEqualTo(spOrgs[0])
+
+    assertThat(referralService.getSentReferralsForServiceProviderID("missing")).isEmpty()
+  }
+
+  @Test
+  fun `get sent referrals assigned to SP user returns filtered referrals`() {
+    val spUsers = listOf(userFactory.create("sp_user_1"), userFactory.create("sp_user_2"))
+    spUsers.forEach {
+      referralFactory.createSent(assignedTo = it)
+    }
+
+    val referrals = referralService.getSentReferralsAssignedTo(spUsers[0].id)
+    assertThat(referrals.size).isEqualTo(1)
+    assertThat(referrals[0].assignedTo).isEqualTo(spUsers[0])
+
+    assertThat(referralService.getSentReferralsAssignedTo("missing")).isEmpty()
   }
 }


### PR DESCRIPTION
## What does this pull request do?

change /sent-referrals endpoint to accept query params for filtering referrals based on different criteria

allows getting sent referrals based on who they were sent by, which SP org they were sent to, and which case worker they are assigned to.

## What is the intent behind these changes?

this makes the endpoint usable by both PP and SP pages in the UI
