### PR TITLE
Block extraction with live data until DPIA signoff

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor.yaml
@@ -12,7 +12,11 @@ spec:
           containers:
           - name: data-extractor
             image: ministryofjustice/data-engineering-data-extractor:develop
+            {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
+            command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
+            {{ else }}
             command: ["sh", "-c", "extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            {{ end }}
             env:
               - name: LOCAL_EXPORT_DESTINATION
                 value: export

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,9 @@ ingress:
   hosts:
     - host: hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
 
+env_details:
+  contains_live_data: false
+
 env:
   JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,9 @@ ingress:
   hosts:
     - host: hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
 
+env_details:
+  contains_live_data: true
+
 env:
   JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,9 @@ ingress:
   hosts:
     - host: hmpps-interventions-service-prod.apps.live-1.cloud-platform.service.justice.gov.uk
 
+env_details:
+  contains_live_data: true
+
 env:
   JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -13,6 +13,9 @@ ingress:
     - host: hmpps-interventions-service-research.apps.live-1.cloud-platform.service.justice.gov.uk
   path: /
 
+env_details:
+  contains_live_data: false
+
 env:
   SPRING_PROFILES_ACTIVE: research
   JAVA_OPTS: "-Xmx512m"


### PR DESCRIPTION
## What does this pull request do?

Prevent the transfer of data on environments that contain real data until our data protection impact assessment is signed off.

Once we have sign-off, this code can be reverted.

## What is the intent behind these changes?

For environments that contain live data, a data protection impact assessment is required before the data can be transferred

Until it's signed off, still run the job every day by testing the PSQL connection and the S3 upload, uploading a dummy file