### PR TITLE
Upload daily snapshots for reporting

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: data-extractor-analytics
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: "Never"
+          containers:
+          - name: data-extractor-analytics
+            image: ministryofjustice/data-engineering-data-extractor:develop
+            {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
+            command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
+            {{ else }}
+            command: ["sh", "-c", "extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            {{ end }}
+            env:
+              - name: LOCAL_EXPORT_DESTINATION
+                value: export
+              - name: PGHOST
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: rds_instance_address
+              - name: PGDATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: database_name
+              - name: PGUSER
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: database_username
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres
+                    key: database_password
+              - name: S3_DESTINATION
+                valueFrom:
+                  secretKeyRef:
+                    name: analytical-platform-reporting-s3-bucket
+                    key: destination_bucket
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: analytical-platform-reporting-s3-bucket
+                    key: access_key_id
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: analytical-platform-reporting-s3-bucket
+                    key: secret_access_key
+              - name: AWS_DEFAULT_REGION
+                value: eu-west-2

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: data-extractor
+  name: data-extractor-reporting
 spec:
   schedule: "0 1 * * *"
   jobTemplate:
@@ -10,7 +10,7 @@ spec:
         spec:
           restartPolicy: "Never"
           containers:
-          - name: data-extractor
+          - name: data-extractor-reporting
             image: ministryofjustice/data-engineering-data-extractor:develop
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
             command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
@@ -43,17 +43,17 @@ spec:
               - name: S3_DESTINATION
                 valueFrom:
                   secretKeyRef:
-                    name: analytical-platform-reporting-s3-bucket
+                    name: reporting-s3-bucket
                     key: destination_bucket
               - name: AWS_ACCESS_KEY_ID
                 valueFrom:
                   secretKeyRef:
-                    name: analytical-platform-reporting-s3-bucket
+                    name: reporting-s3-bucket
                     key: access_key_id
               - name: AWS_SECRET_ACCESS_KEY
                 valueFrom:
                   secretKeyRef:
-                    name: analytical-platform-reporting-s3-bucket
+                    name: reporting-s3-bucket
                     key: secret_access_key
               - name: AWS_DEFAULT_REGION
                 value: eu-west-2


### PR DESCRIPTION
## What does this pull request do?

Periodically exports all tables to CSVs and then uploads those into a timestamped "folder" in an NDMIS S3 "landing" bucket for a reporting ETL process.

It has exactly the same pattern as the analytics data extractor (#184), except for configuration differences.

However, the script will be slightly different over time, so there's no point in further DRYing at the moment.

## Waiting on

- [x] Depends on changes introduced in #193, that one has to be merged first, then I can change the base branch of this PR to `main`
- [x] Also depends on https://github.com/ministryofjustice/cloud-platform-environments/pull/4635

## What is the intent behind these changes?

To enable the reporting on interventions data.