### PR TITLE
IC-1356 allow end endpoint to accept cancellation reason

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -100,9 +100,9 @@ class ReferralController(
       ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "referral not found [id=$id]")
 
     val user = jwtAuthUserMapper.map(authentication)
-    val cancellationReason = cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(endReferral.cancellationReasonId)
+    val cancellationReason = cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(endReferral.cancellationReasonCode)
 
-    val endedReferral = referralService.endSentReferral(sentReferral, user, cancellationReason)
+    val endedReferral = referralService.endSentReferral(sentReferral, user, cancellationReason, endReferral.cancellationComments)
 
     return EndedReferralDTO.from(endedReferral)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapper.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
+
+@Component
+class CancellationReasonMapper(
+  private val cancellationReasonRepository: CancellationReasonRepository
+) {
+  fun mapCancellationReasonIdToCancellationReason(cancellationReasonId: String): CancellationReason {
+    return cancellationReasonRepository.findByIdOrNull(cancellationReasonId)
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Cancellation reason not found [id=$cancellationReasonId]")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapper.kt
@@ -13,6 +13,6 @@ class CancellationReasonMapper(
 ) {
   fun mapCancellationReasonIdToCancellationReason(cancellationReasonId: String): CancellationReason {
     return cancellationReasonRepository.findByIdOrNull(cancellationReasonId)
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Cancellation reason not found [id=$cancellationReasonId]")
+      ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid cancellation code. [code=$cancellationReasonId]")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndReferralDTO.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 data class EndReferralDTO(
   val cancellationReasonCode: String,
-  val cancellationComments: String,
+  val cancellationComments: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndReferralDTO.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 data class EndReferralDTO(
-  val cancellationReasonId: String
+  val cancellationReasonCode: String,
+  val cancellationComments: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndReferralDTO.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+data class EndReferralDTO(
+  val cancellationReasonId: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
@@ -22,7 +22,7 @@ class EndedReferralDTO(
         referenceNumber = referral.referenceNumber!!,
         assignedTo = referral.assignedTo?.let { AuthUserDTO.from(it) },
         referral = DraftReferralDTO.from(referral),
-        cancellationReason = referral.cancellationReason!!.id
+        cancellationReason = referral.cancellationReason!!.code
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
@@ -11,6 +11,7 @@ class EndedReferralDTO(
   val referenceNumber: String,
   val assignedTo: AuthUserDTO?,
   val referral: DraftReferralDTO,
+  val cancellationReason: String
 ) {
   companion object {
     fun from(referral: Referral): EndedReferralDTO {
@@ -21,6 +22,7 @@ class EndedReferralDTO(
         referenceNumber = referral.referenceNumber!!,
         assignedTo = referral.assignedTo?.let { AuthUserDTO.from(it) },
         referral = DraftReferralDTO.from(referral),
+        cancellationReason = referral.cancellationReason!!.id
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
@@ -11,7 +11,9 @@ class EndedReferralDTO(
   val referenceNumber: String,
   val assignedTo: AuthUserDTO?,
   val referral: DraftReferralDTO,
-  val cancellationReason: String
+  val cancellationReason: String,
+  val cancellationComments: String,
+  val endOfServiceReport: EndOfServiceReportDTO?
 ) {
   companion object {
     fun from(referral: Referral): EndedReferralDTO {
@@ -22,7 +24,9 @@ class EndedReferralDTO(
         referenceNumber = referral.referenceNumber!!,
         assignedTo = referral.assignedTo?.let { AuthUserDTO.from(it) },
         referral = DraftReferralDTO.from(referral),
-        cancellationReason = referral.cancellationReason!!.code
+        cancellationReason = referral.cancellationReason!!.description,
+        cancellationComments = referral.cancellationComments!!,
+        endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) }
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EndedReferralDTO.kt
@@ -12,7 +12,7 @@ class EndedReferralDTO(
   val assignedTo: AuthUserDTO?,
   val referral: DraftReferralDTO,
   val cancellationReason: String,
-  val cancellationComments: String,
+  val cancellationComments: String?,
   val endOfServiceReport: EndOfServiceReportDTO?
 ) {
   companion object {
@@ -25,7 +25,7 @@ class EndedReferralDTO(
         assignedTo = referral.assignedTo?.let { AuthUserDTO.from(it) },
         referral = DraftReferralDTO.from(referral),
         cancellationReason = referral.cancellationReason!!.description,
-        cancellationComments = referral.cancellationComments!!,
+        cancellationComments = referral.cancellationComments,
         endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) }
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/CancellationReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/CancellationReason.kt
@@ -5,6 +5,6 @@ import javax.persistence.Id
 
 @Entity
 data class CancellationReason(
-  @Id val id: String,
+  @Id val code: String,
   val description: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -39,8 +39,9 @@ class Referral(
   var endedAt: OffsetDateTime? = null,
   @ManyToOne @Fetch(FetchMode.JOIN) var endedBy: AuthUser? = null,
 
-  @ManyToOne @JoinColumn(name = "cancellation_reason_id")
+  @ManyToOne @JoinColumn(name = "cancellation_reason_code")
   var cancellationReason: CancellationReason? = null,
+  var cancellationComments: String? = null,
 
   // draft referral fields
   @OneToOne(mappedBy = "referral", cascade = arrayOf(CascadeType.ALL)) @PrimaryKeyJoinColumn var serviceUserData: ServiceUserData? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -64,11 +64,11 @@ class ReferralService(
       .map { SentReferralDTO.from(it) }
   }
 
-  fun endSentReferral(referral: Referral, user: AuthUser, cancellationReason: CancellationReason, cancellationComments: String): Referral {
+  fun endSentReferral(referral: Referral, user: AuthUser, cancellationReason: CancellationReason, cancellationComments: String?): Referral {
     referral.endedAt = OffsetDateTime.now()
     referral.endedBy = authUserRepository.save(user)
     referral.cancellationReason = cancellationReason
-    referral.cancellationComments = cancellationComments
+    cancellationComments?.let { referral.cancellationComments = it }
     return referralRepository.save(referral)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -64,9 +64,10 @@ class ReferralService(
       .map { SentReferralDTO.from(it) }
   }
 
-  fun endSentReferral(referral: Referral, user: AuthUser): Referral {
+  fun endSentReferral(referral: Referral, user: AuthUser, cancellationReason: CancellationReason): Referral {
     referral.endedAt = OffsetDateTime.now()
     referral.endedBy = authUserRepository.save(user)
+    referral.cancellationReason = cancellationReason
     return referralRepository.save(referral)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -64,10 +64,11 @@ class ReferralService(
       .map { SentReferralDTO.from(it) }
   }
 
-  fun endSentReferral(referral: Referral, user: AuthUser, cancellationReason: CancellationReason): Referral {
+  fun endSentReferral(referral: Referral, user: AuthUser, cancellationReason: CancellationReason, cancellationComments: String): Referral {
     referral.endedAt = OffsetDateTime.now()
     referral.endedBy = authUserRepository.save(user)
     referral.cancellationReason = cancellationReason
+    referral.cancellationComments = cancellationComments
     return referralRepository.save(referral)
   }
 

--- a/src/main/resources/db/migration/V1_42_2__cancellation_reason_update.sql
+++ b/src/main/resources/db/migration/V1_42_2__cancellation_reason_update.sql
@@ -1,0 +1,8 @@
+alter table cancellation_reason
+    rename column id TO code;
+
+alter table referral drop constraint FK_cancellation_reason_id;
+alter table referral rename column cancellation_reason_id to cancellation_reason_code;
+alter table referral add column cancellation_comments text;
+
+alter table referral add constraint FK_cancellation_reason_code foreign key (cancellation_reason_code) references cancellation_reason;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -108,7 +108,7 @@ internal class ReferralControllerTest {
   @Test
   fun `successfully call end referral endpoint`() {
     val referral = referralFactory.createSent()
-    val endReferralDTO = EndReferralDTO("AAA")
+    val endReferralDTO = EndReferralDTO("AAA", "comment")
     val cancellationReason = CancellationReason("AAA", "description")
 
     whenever(cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(any())).thenReturn(cancellationReason)
@@ -117,15 +117,15 @@ internal class ReferralControllerTest {
     val authUser = AuthUser("CRN123", "auth", "user")
     val jwtAuthenticationToken = JwtAuthenticationToken(mock())
     whenever(jwtAuthUserMapper.map(jwtAuthenticationToken)).thenReturn(authUser)
-    whenever(referralService.endSentReferral(any(), any(), any())).thenReturn(referralFactory.createEnded())
+    whenever(referralService.endSentReferral(any(), any(), any(), any())).thenReturn(referralFactory.createEnded(cancellationComments = "comment"))
 
     referralController.endSentReferral(referral.id, endReferralDTO, jwtAuthenticationToken)
-    verify(referralService).endSentReferral(referral, authUser, cancellationReason)
+    verify(referralService).endSentReferral(referral, authUser, cancellationReason, "comment")
   }
 
   @Test
   fun `end referral endpoint does not find referral`() {
-    val endReferralDTO = EndReferralDTO("AAA")
+    val endReferralDTO = EndReferralDTO("AAA", "comment")
     val cancellationReason = CancellationReason("AAA", "description")
 
     whenever(cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(any())).thenReturn(cancellationReason)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -160,8 +160,8 @@ internal class ReferralControllerTest {
   @Test
   fun `get all cancellation reasons`() {
     val cancellationReasons = listOf(
-      CancellationReason(id = "aaa", description = "reason 1"),
-      CancellationReason(id = "bbb", description = "reason 2")
+      CancellationReason(code = "aaa", description = "reason 1"),
+      CancellationReason(code = "bbb", description = "reason 2")
     )
     whenever(referralService.getCancellationReasons()).thenReturn(cancellationReasons)
     val response = referralController.getCancellationReasons()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapperTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.CancellationReasonFactory
+import java.util.Optional.empty
+import java.util.Optional.of
+
+class CancellationReasonMapperTest {
+
+  private val cancellationReasonRepository = mock<CancellationReasonRepository>()
+  private val cancellationReasonFactory = CancellationReasonFactory()
+
+  private val cancellationReasonMapper = CancellationReasonMapper(cancellationReasonRepository)
+
+  @Test
+  fun `converts cancellation reason id into cancellation Reason object`() {
+    val cancellationReason = cancellationReasonFactory.create()
+    whenever(cancellationReasonRepository.findById(any())).thenReturn(of(cancellationReason))
+    val response = cancellationReasonMapper.mapCancellationReasonIdToCancellationReason("aaa")
+    assertThat(response).isEqualTo(cancellationReason)
+  }
+
+  @Test
+  fun `not found error thrown when no cancellation reason is found`() {
+    whenever(cancellationReasonRepository.findById(any())).thenReturn(empty())
+    val exception = assertThrows<ResponseStatusException> {
+      cancellationReasonMapper.mapCancellationReasonIdToCancellationReason("aaa")
+    }
+    assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/mappers/CancellationReasonMapperTest.kt
@@ -34,6 +34,6 @@ class CancellationReasonMapperTest {
     val exception = assertThrows<ResponseStatusException> {
       cancellationReasonMapper.mapCancellationReasonIdToCancellationReason("aaa")
     }
-    assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
+    assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/CancellationReasonRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/CancellationReasonRepositoryTest.kt
@@ -16,7 +16,7 @@ class CancellationReasonRepositoryTest @Autowired constructor(
     val persistedReason = cancellationReasonRepository.findById("MIS").get()
 
     assertThat(persistedReason).isNotNull
-    assertThat(persistedReason.id).isEqualTo("MIS")
+    assertThat(persistedReason.code).isEqualTo("MIS")
     assertThat(persistedReason.description).isEqualTo("Referral was made by mistake")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -41,14 +41,16 @@ class ReferralServiceUnitTest {
     val referral = referralFactory.createSent()
     val authUser = authUserFactory.create()
     val cancellationReason = cancellationReasonFactory.create()
+    val cancellationComments = "comment"
 
     whenever(authUserRepository.save(authUser)).thenReturn(authUser)
-    whenever(referralRepository.save(any())).thenReturn(referralFactory.createEnded())
+    whenever(referralRepository.save(any())).thenReturn(referralFactory.createEnded(cancellationComments = cancellationComments))
 
-    val endedReferral = referralService.endSentReferral(referral, authUser, cancellationReason)
+    val endedReferral = referralService.endSentReferral(referral, authUser, cancellationReason, cancellationComments)
     assertThat(endedReferral.endedAt).isNotNull
     assertThat(endedReferral.endedBy).isEqualTo(authUser)
     assertThat(endedReferral.cancellationReason).isEqualTo(cancellationReason)
+    assertThat(endedReferral.cancellationComments).isEqualTo(cancellationComments)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Can
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.CancellationReasonFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 
 class ReferralServiceUnitTest {
@@ -29,6 +30,7 @@ class ReferralServiceUnitTest {
 
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
+  private val cancellationReasonFactory = CancellationReasonFactory()
 
   private val referralService = ReferralService(
     referralRepository, authUserRepository, interventionRepository,
@@ -39,13 +41,15 @@ class ReferralServiceUnitTest {
   fun `set ended fields on a sent referral`() {
     val referral = referralFactory.createSent()
     val authUser = authUserFactory.create()
+    val cancellationReason = cancellationReasonFactory.create()
 
     whenever(authUserRepository.save(authUser)).thenReturn(authUser)
     whenever(referralRepository.save(any())).thenReturn(referralFactory.createEnded())
 
-    val endedReferral = referralService.endSentReferral(referral, authUser)
+    val endedReferral = referralService.endSentReferral(referral, authUser, cancellationReason)
     assertThat(endedReferral.endedAt).isNotNull
     assertThat(endedReferral.endedBy).isEqualTo(authUser)
+    assertThat(endedReferral.cancellationReason).isEqualTo(cancellationReason)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.firstValue
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -70,8 +69,8 @@ class ReferralServiceUnitTest {
   @Test
   fun `get all cancellation reasons`() {
     val cancellationReasons = listOf(
-      CancellationReason(id = "aaa", description = "reason 1"),
-      CancellationReason(id = "bbb", description = "reason 2")
+      CancellationReason(code = "aaa", description = "reason 1"),
+      CancellationReason(code = "bbb", description = "reason 2")
     )
     whenever(cancellationReasonRepository.findAll()).thenReturn(cancellationReasons)
     val result = referralService.getCancellationReasons()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/CancellationReasonFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/CancellationReasonFactory.kt
@@ -10,7 +10,7 @@ class CancellationReasonFactory(em: TestEntityManager? = null) : EntityFactory(e
   ): CancellationReason {
     return save(
       CancellationReason(
-        id = id,
+        code = id,
         description = description,
       )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
 
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
@@ -13,6 +14,7 @@ import java.util.UUID
 class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
   private val authUserFactory = AuthUserFactory(em)
   private val interventionFactory = InterventionFactory(em)
+  private val calcellationReasonFactory = CancellationReasonFactory(em)
 
   fun createDraft(
     id: UUID = UUID.randomUUID(),
@@ -84,6 +86,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     assignedAt: OffsetDateTime? = null,
     endedAt: OffsetDateTime? = OffsetDateTime.now(),
     endedBy: AuthUser? = authUserFactory.create(),
+    cancellationReason: CancellationReason? = calcellationReasonFactory.create()
   ): Referral {
     return create(
       id = id,
@@ -102,6 +105,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
 
       endedAt = endedAt,
       endedBy = endedBy,
+      cancellationReason = cancellationReason
     )
   }
 
@@ -125,6 +129,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     assignedTo: AuthUser? = null,
     endedAt: OffsetDateTime? = null,
     endedBy: AuthUser? = null,
+    cancellationReason: CancellationReason? = null,
   ): Referral {
     return save(
       Referral(
@@ -144,6 +149,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         assignedTo = assignedTo,
         endedAt = endedAt,
         endedBy = endedBy,
+        cancellationReason = cancellationReason,
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -86,7 +86,8 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     assignedAt: OffsetDateTime? = null,
     endedAt: OffsetDateTime? = OffsetDateTime.now(),
     endedBy: AuthUser? = authUserFactory.create(),
-    cancellationReason: CancellationReason? = calcellationReasonFactory.create()
+    cancellationReason: CancellationReason? = calcellationReasonFactory.create(),
+    cancellationComments: String? = null
   ): Referral {
     return create(
       id = id,
@@ -105,7 +106,8 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
 
       endedAt = endedAt,
       endedBy = endedBy,
-      cancellationReason = cancellationReason
+      cancellationReason = cancellationReason,
+      cancellationComments = cancellationComments
     )
   }
 
@@ -130,6 +132,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     endedAt: OffsetDateTime? = null,
     endedBy: AuthUser? = null,
     cancellationReason: CancellationReason? = null,
+    cancellationComments: String? = null,
   ): Referral {
     return save(
       Referral(
@@ -150,6 +153,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         endedAt = endedAt,
         endedBy = endedBy,
         cancellationReason = cancellationReason,
+        cancellationComments = cancellationComments,
       )
     )
   }


### PR DESCRIPTION
## What does this pull request do?

Allows a cancellation reason to be passed the the 'end' endpoint.

## What is the intent behind these changes?

Allows a cancellation reason to be persisted when ending a referral.
