### PR TITLE
DAPI-170 Change to url for community-api create appointments endpoint

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,7 +90,7 @@ interventions-ui:
 community-api:
   locations:
     sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
-    book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments"
+    book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/well-known/appointments"
   appointments:
     office-location: CRSSHEF
   integration-context: commissioned-rehabilitation-services


### PR DESCRIPTION
**What does this pull request do?**
Community-api has Introduced the distinction between a well known client and a none well known client. Each has its own endpoint for create appointment which shares same service implementation. For the well known client like interventions, defaults/preprocessing are provided by community-api:
1) find a requirement for the service provided
2) use defaults as identified by the integration context

**What is the intent behind these changes?**
This enables community-api to support consumers with differing needs whilst sharing the same implementation.