### PR TITLE
DAPI-170 Include Integration Context as path variable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -45,12 +45,11 @@ class CommunityAPIBookingService(
       appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
       officeLocationCode = officeLocation,
       notes = resourceUrl,
-      context = integrationContext,
     )
 
     val referral = appointment.actionPlan.referral
     val communityApiBookAppointmentPath = UriComponentsBuilder.fromPath(communityApiBookAppointmentLocation)
-      .buildAndExpand(referral.serviceUserCRN, referral.relevantSentenceId!!)
+      .buildAndExpand(referral.serviceUserCRN, referral.relevantSentenceId!!, integrationContext)
       .toString()
 
     val response = communityAPIClient.makeSyncPostRequest(communityApiBookAppointmentPath, appointmentCreateRequestDTO, AppointmentCreateResponseDTO::class.java)
@@ -70,7 +69,6 @@ data class AppointmentCreateRequestDTO(
   val appointmentEnd: OffsetDateTime,
   val officeLocationCode: String,
   val notes: String,
-  val context: String,
 )
 
 data class AppointmentCreateResponseDTO(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,7 +90,7 @@ interventions-ui:
 community-api:
   locations:
     sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
-    book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments"
+    book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
   appointments:
     office-location: CRSSHEF
   integration-context: commissioned-rehabilitation-services

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -180,7 +180,6 @@ class CommunityAPIClientTest {
     appointmentStart = OffsetDateTime.now(),
     appointmentEnd = OffsetDateTime.now(),
     officeLocationCode = "CRSSHEF",
-    notes = "http://backLink",
-    context = "c-r-s",
+    notes = "http://backLink"
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -19,7 +19,7 @@ internal class CommunityAPIBookingServiceTest {
 
   private val httpBaseUrl = "http://url"
   private val viewUrl = "/view/{referralId}"
-  private val apiUrl = "/appt/{CRN}/{sentenceId}"
+  private val apiUrl = "/appt/{CRN}/{sentenceId}/{contextName}"
   private val crsOfficeLocation = "CRSSHEF"
   private val crsBookingsContext = "CRS"
 
@@ -40,9 +40,9 @@ internal class CommunityAPIBookingServiceTest {
     val now = OffsetDateTime.now()
     val appointment = makeAppointment(null, null)
 
-    val uri = "/appt/X1/123"
+    val uri = "/appt/X1/123/CRS"
     val link = "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO(now, now.plusMinutes(60), "CRSSHEF", notes = link, "CRS")
+    val request = AppointmentCreateRequestDTO(now, now.plusMinutes(60), "CRSSHEF", notes = link)
     val response = AppointmentCreateResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java))


### PR DESCRIPTION
**What does this pull request do?**
Comunity-api Introduced the distinction between a client that requires additional processing and and one that doesn't. Each has its own endpoint for create appointment which shares same service implementation. Where additional processing is required, an integration context name must be supplied.

@RequestMapping(value = "/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}" ...

The additionally processing identified by contextName is in the form of

find a requirement for the sentence provided
use defaults as identified by the integration context

This change is to change the endpoint url called by interventions

**What is the intent behind these changes?**
This enables community-api to support consumers with differing needs whilst sharing the same implementation.
