### PR TITLE
fix eosr creation by swapping the parent of the one-to-one relationship

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
@@ -18,7 +18,7 @@ import javax.validation.constraints.NotNull
 @Table(name = "end_of_service_report")
 data class EndOfServiceReport(
   @Id val id: UUID,
-  @OneToOne(mappedBy = "endOfServiceReport") val referral: Referral,
+  @OneToOne val referral: Referral,
 
   @NotNull val createdAt: OffsetDateTime,
   @NotNull @ManyToOne @Fetch(FetchMode.JOIN) val createdBy: AuthUser,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -78,7 +78,7 @@ class Referral(
   @NotNull val createdAt: OffsetDateTime,
   @Id val id: UUID,
 
-  @OneToOne @Fetch(JOIN) var endOfServiceReport: EndOfServiceReport? = null,
+  @OneToOne(mappedBy = "referral") @Fetch(JOIN) var endOfServiceReport: EndOfServiceReport? = null,
 ) {
   fun getResponsibleProbationPractitioner(): AuthUser {
     // fixme: should this sentBy or createdBy?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -24,20 +24,14 @@ class EndOfServiceReportService(
     referralId: UUID,
     createdByUser: AuthUser
   ): EndOfServiceReport {
-    val referral = getReferral(referralId)
-
     val endOfServiceReport = EndOfServiceReport(
       id = UUID.randomUUID(),
-      referral = referral,
+      referral = referralRepository.getOne(referralId),
       createdBy = authUserRepository.save(createdByUser),
       createdAt = OffsetDateTime.now(),
     )
 
-    val savedEndOfServiceReport = endOfServiceReportRepository.save(endOfServiceReport)
-    referral.endOfServiceReport = endOfServiceReport
-    referralRepository.save(referral)
-
-    return savedEndOfServiceReport
+    return endOfServiceReportRepository.save(endOfServiceReport)
   }
 
   fun getEndOfServiceReport(endOfServiceReportId: UUID): EndOfServiceReport {

--- a/src/main/resources/db/local/V99_2_2__assigned_referrals.sql
+++ b/src/main/resources/db/local/V99_2_2__assigned_referrals.sql
@@ -20,9 +20,5 @@ values ('F6D6710F-8812-43D0-96F9-C0BDE9FF66F9', '21EA6AFE-C437-4018-9260-BF1A829
        ('7F8EBDFF-E127-475B-986F-635288CED216', '2EB8B0DB-EAF1-430A-BA69-39984D501EB9', 2, '2021-04-07 12:00:00.000000+00', 120, '2021-03-12 18:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949'),
        ('C6AA09D1-3BA2-4069-AFFB-1E9F98CDFF8D', '2EB8B0DB-EAF1-430A-BA69-39984D501EB9', 3, null, null, '2021-03-12 18:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949');
 
-insert into end_of_service_report(id, created_at, created_by_id, submitted_at, submitted_by_id, further_information)
-values ('2cfcfa79-bb3c-484a-9428-85072e600812', '2021-04-22 09:00:00.000000+00', '608955ae-52ed-44cc-884c-011597a77949', null, null, null);
-
-update referral
-    set end_of_service_report_id = '2cfcfa79-bb3c-484a-9428-85072e600812'
-    where id = 'a2a551aa-3d11-44b1-907b-42a028852bc1';
+insert into end_of_service_report(id, referral_id, created_at, created_by_id, submitted_at, submitted_by_id, further_information)
+values ('2cfcfa79-bb3c-484a-9428-85072e600812', 'a2a551aa-3d11-44b1-907b-42a028852bc1', '2021-04-22 09:00:00.000000+00', '608955ae-52ed-44cc-884c-011597a77949', null, null, null);

--- a/src/main/resources/db/migration/V1_43__swap_eosr_owning_entity.sql
+++ b/src/main/resources/db/migration/V1_43__swap_eosr_owning_entity.sql
@@ -1,0 +1,13 @@
+alter table end_of_service_report
+    add column referral_id uuid,
+    add constraint fk_referral_id foreign key (referral_id) references referral;
+
+update end_of_service_report
+    set referral_id = referral.id
+    from referral where end_of_service_report.id = referral.end_of_service_report_id;
+
+alter table end_of_service_report
+    alter column referral_id set not null;
+
+alter table referral
+    drop column end_of_service_report_id;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
@@ -36,7 +36,7 @@ class EndOfServiceReportServiceTest {
     val endOfServiceReport = SampleData.sampleEndOfServiceReport(outcomes = mutableSetOf(), referral = referral)
 
     whenever(authUserRepository.save(authUser)).thenReturn(authUser)
-    whenever(referralRepository.findById(referral.id)).thenReturn(of(referral))
+    whenever(referralRepository.getOne(referral.id)).thenReturn(referral)
     whenever(endOfServiceReportRepository.save(any())).thenReturn(endOfServiceReport)
     whenever(referralRepository.save(any())).thenReturn(referral)
 
@@ -49,12 +49,11 @@ class EndOfServiceReportServiceTest {
   fun `referral not found when creating end of service report`() {
     val authUser = AuthUser("CRN123", "auth", "user")
     val referralId = UUID.randomUUID()
-    whenever(referralRepository.findById(referralId)).thenReturn(empty())
+    whenever(referralRepository.getOne(referralId)).thenThrow(EntityNotFoundException::class.java)
 
     val exception = Assertions.assertThrows(EntityNotFoundException::class.java) {
       endOfServiceReportService.createEndOfServiceReport(referralId, authUser)
     }
-    assertThat(exception.message).isEqualTo("Referral not found [id=$referralId]")
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

fix eosr creation by swapping the parent of the one-to-one relationship.

by having the EOSR own the relationship, it means we do not have to mess around with saving the referral and the EOSR in the right order to ensure hibernate propagates the relationship.

## What is the intent behind these changes?

fix issues with creating EOSRs in dev. see https://sentry.io/organizations/ministryofjustice/issues/2363916337/?project=5666580&referrer=slack
