### PR TITLE
Shorten data dictionary names in Kubernetes

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_helpers.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_helpers.tpl
@@ -60,6 +60,6 @@ app: {{ include "app.name" . }}
 release: {{ .Release.Name }}
 {{- end }}
 {{- define "dataDictionary.selectorLabels" -}}
-app: {{ include "app.name" . }}-data-dictionary
+app: data-dictionary
 release: {{ .Release.Name }}
 {{- end }}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-data-dictionary.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-data-dictionary.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "app.fullname" . }}-data-dictionary
+  name: data-dictionary
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:

--- a/helm_deploy/hmpps-interventions-service/templates/service-data-dictionary.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/service-data-dictionary.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "app.fullname" . }}-data-dictionary
+  name: data-dictionary
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## What does this pull request do?

Shortens the Kubernetes resource names for data dictionary.

```
pod/hmpps-interventions-service-data-dictionary-75f6466ff4-fmbsb
service/hmpps-interventions-service-data-dictionary
deployment.apps/hmpps-interventions-service-data-dictionary
```

will now be

```
pod/data-dictionary-75f6466ff4-fmbsb
service/data-dictionary
deployment.apps/data-dictionary
```

## What is the intent behind these changes?

- This will make queries in Kibana and `stern` much easier
- Also less confusing, as it's clear it's not part of the service app