### PR TITLE
🐛 Fix 503 accessing data dictionary

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
               servicePort: http
           - path: /meta/schema
             backend:
-              serviceName: {{ $fullName }}-data-dictionary
+              serviceName: data-dictionary
               servicePort: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this pull request do?

https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/meta/schema is now returning a 503 Service Temporarily Unavailable

### Cause
The ingress rule was still trying to select a backend service named `hmpps-interventions-service-data-dictionary`, but it was renamed to `data-dictionary` in b41ab8e7fdaa77b4c0fab12abef5aea9947de5a8

I missed this bit

### Follow-up?

We need to look into alerts to Slack on ingress errors

## What is the intent behind these changes?

Get data dictionary working again