### PR TITLE
Export custom report during NDMIS extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,17 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
+      - run:
+          name: Setup for SQL validation
+          command: |
+            sudo apt update
+            sudo apt install postgresql-client
+      - run:
+          name: Validate report SQLs
+          command: |
+            for sqlfile in helm_deploy/hmpps-interventions-service/reports/*.sql; do
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -U"postgres" "postgresql://localhost:5432/$POSTGRES_DB" < "$sqlfile"
+            done
 
   publish_data:
     executor: hmpps/java

--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -1,0 +1,47 @@
+COPY (
+  SELECT
+    r.reference_number      AS referral_ref,
+    r.id                    AS referral_id,
+    'coming-later'          AS crs_contract_reference,
+    'coming-later'          AS crs_contract_type,
+    prime.id                AS crs_provider_id,
+    r.sent_by_id            AS referring_officer_id,
+    r.relevant_sentence_id  AS relevant_sentence_id,
+    r.service_usercrn       AS service_user_crn,
+    r.sent_at               AS date_referral_received,
+    'coming-later'          AS date_saa_booked,
+    'coming-later'          AS date_saa_attended,
+    ap.submitted_at         AS date_first_action_plan_submitted,
+    'coming-later'          AS date_of_first_action_plan_approval,
+    r.assigned_to_id        AS caseworker_id,
+    (
+      select min(app.appointment_time)
+      from action_plan_appointment app
+      where app.action_plan_id = ap.id and attended in ('YES', 'LATE')
+    )                       AS date_of_first_session,
+    (
+      select count(o.desired_outcome_id)
+      from referral_desired_outcome o
+      where o.referral_id = r.id
+    )                       AS outcomes_to_be_achieved_count,
+    'coming-later'          AS outcomes_progress,
+    ap.number_of_sessions   AS count_of_sessions_expected,
+    (
+      select count(app.id)
+      from action_plan_appointment app
+      where app.action_plan_id = ap.id and attended in ('YES', 'LATE')
+    )                       AS count_of_sessions_attended,
+    r.concluded_at          AS date_intervention_ended,
+    eosr.submitted_at       AS date_end_of_service_report_submitted
+  FROM
+    referral r
+    JOIN intervention i ON (r.intervention_id = i.id)
+    JOIN dynamic_framework_contract c ON (i.dynamic_framework_contract_id = c.id)
+    JOIN service_provider prime ON (c.service_provider_id = prime.id)
+    LEFT JOIN action_plan ap ON (ap.referral_id = r.id) --❗️assumes a SINGLE action plan
+    LEFT JOIN end_of_service_report eosr ON (eosr.referral_id = r.id)
+  WHERE
+    r.sent_at IS NOT NULL
+  ORDER BY
+    r.sent_at
+) TO STDOUT WITH CSV HEADER

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -1,3 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-extractor-reports
+data:
+{{ (.Files.Glob "reports/*.sql").AsConfig | indent 2 }}
+
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -9,14 +18,24 @@ spec:
       template:
         spec:
           restartPolicy: "Never"
+          volumes:
+          - name: data-extractor-reports
+            configMap:
+              name: data-extractor-reports
+              defaultMode: 0755
           containers:
           - name: data-extractor-reporting
             image: ministryofjustice/data-engineering-data-extractor:develop
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
             command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}
-            command: ["sh", "-c", "extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            command: ["sh", "-c", "mkdir -p 'export/csv/reports' && psql --file=/reports/crs_performance_report.sql > 'export/csv/reports/crs_performance_report.csv' && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
             {{ end }}
+            volumeMounts:
+            - name: data-extractor-reports
+              mountPath: /reports/crs_performance_report.sql
+              readOnly: true
+              subPath: crs_performance_report.sql
             env:
               - name: LOCAL_EXPORT_DESTINATION
                 value: export


### PR DESCRIPTION
## What does this pull request do?

Adds a "near-static" view of the performance report for NDMIS ETL.

The query is stored as a "file" in a `ConfigMap` in the environments. Later, it must be replaced with an API call, once we have an appropriate endpoint.

This will make the resulting upload to S3 look:
```
# reports (new)
export/csv/reports/crs_performance_report.csv

# table exports (already exist)
export/csv/end_of_service_report_outcome.csv
..snip..
export/csv/cancellation_reason.csv
```

## What is the intent behind these changes?

To reduce the amount of change to the reporting ETL pipeline, provide a relatively static report

This is to help kicking off the pipeline in the beginning

## Performance

The query executes in 4.192 ms on the dev environment.
Will run only once a day, 1 am UTC.

Query plan:
```
                                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=2211.04..2211.95 rows=362 width=419)
   Sort Key: r.sent_at
   ->  Hash Left Join  (cost=39.65..2195.66 rows=362 width=419)
         Hash Cond: (r.id = ap.referral_id)
         ->  Hash Join  (cost=38.24..56.54 rows=362 width=191)
               Hash Cond: (i.dynamic_framework_contract_id = c.id)
               ->  Hash Join  (cost=29.02..45.94 rows=362 width=129)
                     Hash Cond: (r.intervention_id = i.id)
                     ->  Hash Right Join  (cost=5.29..21.25 rows=362 width=129)
                           Hash Cond: (eosr.referral_id = r.id)
                           ->  Seq Scan on end_of_service_report eosr  (cost=0.00..14.70 rows=470 width=24)
                           ->  Hash  (cost=4.17..4.17 rows=90 width=121)
                                 ->  Seq Scan on referral r  (cost=0.00..4.17 rows=90 width=121)
                                       Filter: (sent_at IS NOT NULL)
                     ->  Hash  (cost=16.10..16.10 rows=610 width=32)
                           ->  Seq Scan on intervention i  (cost=0.00..16.10 rows=610 width=32)
               ->  Hash  (cost=9.21..9.21 rows=1 width=94)
                     ->  Nested Loop  (cost=0.15..9.21 rows=1 width=94)
                           ->  Seq Scan on dynamic_framework_contract c  (cost=0.00..1.01 rows=1 width=94)
                           ->  Index Only Scan using service_provider_pkey on service_provider prime  (cost=0.15..8.17 rows=1 width=78)
                                 Index Cond: (id = (c.service_provider_id)::text)
         ->  Hash  (cost=1.18..1.18 rows=18 width=44)
               ->  Seq Scan on action_plan ap  (cost=0.00..1.18 rows=18 width=44)
         SubPlan 1
           ->  Aggregate  (cost=1.68..1.69 rows=1 width=8)
                 ->  Seq Scan on action_plan_appointment app  (cost=0.00..1.67 rows=1 width=8)
                       Filter: ((attended = ANY ('{YES,LATE}'::attended[])) AND (action_plan_id = ap.id))
         SubPlan 2
           ->  Aggregate  (cost=2.52..2.52 rows=1 width=8)
                 ->  Seq Scan on referral_desired_outcome o  (cost=0.00..2.51 rows=1 width=16)
                       Filter: (referral_id = r.id)
         SubPlan 3
           ->  Aggregate  (cost=1.68..1.69 rows=1 width=8)
                 ->  Seq Scan on action_plan_appointment app_1  (cost=0.00..1.67 rows=1 width=16)
                       Filter: ((attended = ANY ('{YES,LATE}'::attended[])) AND (action_plan_id = ap.id))
(35 rows)
```