### PR TITLE
Make application state observable from logs

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -64,7 +64,7 @@
             </encoder>
         </appender>
 
-        <root level="warn">
+        <root level="info">
             <appender-ref ref="stdout" />
         </root>
     </springProfile>


### PR DESCRIPTION
## What does this pull request do?

Make more events visible on non-local environments by reducing the default log level to `INFO`.

## What is the intent behind these changes?

Reducing the minimum log level to `INFO` makes us able to observe steps in the boot process, e.g. migrations, web listeners, etc.

That capability is required for us to have a sense of what is happening