### PR TITLE
Changed command to  use the jsonl flow

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -12,6 +12,7 @@ spec:
           containers:
           - name: data-extractor-analytics
             image: ministryofjustice/data-engineering-data-extractor:develop
+            imagePullPolicy: Always
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
             command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -21,6 +21,8 @@ spec:
             env:
               - name: LOCAL_EXPORT_DESTINATION
                 value: export
+              - name: PGPORT
+                value: 5432
               - name: PGHOST
                 valueFrom:
                   secretKeyRef:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -15,7 +15,7 @@ spec:
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
             command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}
-            command: ["sh", "-c", "extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            command: ["sh", "-c", "python3 /data-engineering-data-extractor/modules/extract_table_names.py && python3 /data-engineering-data-extractor/modules/extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             {{ end }}
             env:
               - name: LOCAL_EXPORT_DESTINATION


### PR DESCRIPTION
## What does this pull request do?

Alters the commands run within the data extractor cronJob to use the jsonl flow.

## What is the intent behind these changes?

To transfer data from the Interventions development environment in jsonl format to the Analytical Platform. This is to allow us to prepare our processes to handle jsonl instead of csv.
