### PR TITLE
Reset the research database on the research namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,8 @@ workflows:
       - reset_research_db:
           requires:
             - approve_reset_research_db
+          context:
+            - hmpps-interventions-service-research
       - hmpps/deploy_env:
           name: deploy_research_manually
           env: "research"


### PR DESCRIPTION
## What does this pull request do?

The current research reset DB job fails with a cryptic message

    from server for: "user_research/reset_env.yaml": \
      jobs.batch "clean-and-migrate-user-research-env" is forbidden: \
      User "system:serviceaccount:***********************:circleci" \
      cannot get resource "jobs" in API group "batch" \
      in the namespace "hmpps-interventions-research"

The research environment's CircleCI token **does** have these credentials though 🤔 

It turns out the default Kubernetes setup for CircleCI requires `KUBE_ENV_NAMESPACE` and `KUBE_ENV_TOKEN` -- these were set from the application's context, which defaults to **development** environment

To fix this, we need to use the research context to import the proper `KUBE_ENV_*` variables

So what _really_ happens is this:
```
  User "system:serviceaccount:hmpps-interventions-dev:circleci" \
  cannot get resource "jobs" in API group "batch" \
  in the namespace "hmpps-interventions-research"
```
But the dev namespace is coming from a secret, hence shows up as `system:serviceaccount:***********************:circleci`

## What is the intent behind these changes?

Make the "reset DB" job work :)
