### PR TITLE
DAPI-172 Updates to the endpoint for referral sent (start)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import java.time.OffsetDateTime
-import java.util.UUID
 
 interface CommunityAPIService
 
@@ -34,15 +33,14 @@ class CommunityAPIReferralEventService(
           .toString()
 
         val referRequest = ReferRequest(
+          "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
           event.referral.sentAt!!,
-          event.referral.intervention.dynamicFrameworkContract.serviceCategory.id,
           event.referral.relevantSentenceId!!,
           url,
-          integrationContext
         )
 
         val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPISentReferralLocation)
-          .buildAndExpand(event.referral.serviceUserCRN)
+          .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
           .toString()
 
         communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referRequest)
@@ -88,11 +86,10 @@ class CommunityAPIAppointmentEventService(
 }
 
 data class ReferRequest(
-  val sentAt: OffsetDateTime,
-  val serviceCategoryId: UUID,
+  val contractType: String,
+  val startedAt: OffsetDateTime,
   val sentenceId: Long,
   val notes: String,
-  val context: String,
 )
 
 data class AppointmentOutcomeRequest(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,7 +92,7 @@ interventions-ui:
 
 community-api:
   locations:
-    sent-referral: "/secure/offenders/crn/{crn}/referral/sent"
+    sent-referral: "/secure/offenders/crn/{crn}/referral/start/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
   appointments:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
@@ -21,7 +21,7 @@ class CommunityAPIReferralServiceTest {
     val communityAPIService = CommunityAPIReferralEventService(
       "http://testUrl",
       "secure/offenders/crn/{id}/referral/sent",
-      "secure/offenders/crn/{id}/referral/sent",
+      "secure/offenders/crn/{crn}/referral/start/context/{contextName}",
       "commissioned-rehabilitation-services",
       communityAPIClient
     )
@@ -29,13 +29,12 @@ class CommunityAPIReferralServiceTest {
     communityAPIService.onApplicationEvent(referralSentEvent)
 
     verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/sent",
+      "secure/offenders/crn/X123456/referral/start/context/commissioned-rehabilitation-services",
       ReferRequest(
+        "ACC",
         OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC),
-        referralSentEvent.referral.intervention.dynamicFrameworkContract.serviceCategory.id,
         123456789,
         "http://testUrl/secure/offenders/crn/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/referral/sent",
-        "commissioned-rehabilitation-services",
       )
     )
   }


### PR DESCRIPTION
**What does this pull request do?**
After a review of the interaction with Interventions, a number of changes where identified for the referral sent end point:

1) A more generic name for the endpoint is ReferralStart
2) ContractType is to be used to map to NsiType instead of ServiceCategory
3) SentAt is renamed to StartedAt
4) Context name is to be specified in URL as apposed to in the body - in line with appointment creation

**What is the intent behind these changes?**
This change means that interventions new contract type change will be supportable and the endpoint is using the agreed scheme for well-known clients.

**Breaking Changes?**
Yes and limited to interventions referralSent endpoint.