### PR TITLE
DAPI-174 DAPI-175 Appointment creation to supply Contract type, RAR indication and referral sent at 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -15,6 +15,7 @@ class CommunityAPIBookingService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.view-appointment}") private val interventionsUIViewAppointment: String,
   @Value("\${community-api.locations.book-appointment}") private val communityApiBookAppointmentLocation: String,
+  @Value("\${community-api.appointments.office-location}") private val officeLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   val communityAPIClient: CommunityAPIClient,
 ) {
@@ -46,7 +47,7 @@ class CommunityAPIBookingService(
       referralStart = appointment.actionPlan.referral.sentAt!!,
       appointmentStart = appointmentTime,
       appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
-      officeLocationCode = null,
+      officeLocationCode = officeLocation,
       notes = resourceUrl,
       countsTowardsRarDays = true, // Fixme: For assessment booking this should be false and will pass in when assessment booking is done
     )
@@ -75,7 +76,7 @@ data class AppointmentCreateRequestDTO(
   val referralStart: OffsetDateTime,
   val appointmentStart: OffsetDateTime,
   val appointmentEnd: OffsetDateTime,
-  val officeLocationCode: String?,
+  val officeLocationCode: String,
   val notes: String,
   val countsTowardsRarDays: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -46,6 +46,7 @@ class CommunityAPIBookingService(
       referralStart = appointment.actionPlan.referral.sentAt!!,
       appointmentStart = appointmentTime,
       appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
+      officeLocationCode = null,
       notes = resourceUrl,
       countsTowardsRarDays = true, // Fixme: For assessment booking this should be false and will pass in when assessment booking is done
     )
@@ -74,6 +75,7 @@ data class AppointmentCreateRequestDTO(
   val referralStart: OffsetDateTime,
   val appointmentStart: OffsetDateTime,
   val appointmentEnd: OffsetDateTime,
+  val officeLocationCode: String?,
   val notes: String,
   val countsTowardsRarDays: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -15,7 +15,6 @@ class CommunityAPIBookingService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.view-appointment}") private val interventionsUIViewAppointment: String,
   @Value("\${community-api.locations.book-appointment}") private val communityApiBookAppointmentLocation: String,
-  @Value("\${community-api.appointments.office-location}") private val officeLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   val communityAPIClient: CommunityAPIClient,
 ) {
@@ -43,10 +42,12 @@ class CommunityAPIBookingService(
       .toString()
 
     val appointmentCreateRequestDTO = AppointmentCreateRequestDTO(
+      contractType = "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
+      referralStart = appointment.actionPlan.referral.sentAt!!,
       appointmentStart = appointmentTime,
       appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
-      officeLocationCode = officeLocation,
       notes = resourceUrl,
+      countsTowardsRarDays = true, // Fixme: For assessment booking this should be false and will pass in when assessment booking is done
     )
 
     val referral = appointment.actionPlan.referral
@@ -69,10 +70,12 @@ class CommunityAPIBookingService(
 }
 
 data class AppointmentCreateRequestDTO(
+  val contractType: String,
+  val referralStart: OffsetDateTime,
   val appointmentStart: OffsetDateTime,
   val appointmentEnd: OffsetDateTime,
-  val officeLocationCode: String,
   val notes: String,
+  val countsTowardsRarDays: Boolean,
 )
 
 data class AppointmentCreateResponseDTO(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,7 +96,7 @@ community-api:
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
   appointments:
-    office-location: CRSDEFLOC
+    office-location: CRSEXTL
   integration-context: commissioned-rehabilitation-services
 
 appointments:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,8 +95,6 @@ community-api:
     sent-referral: "/secure/offenders/crn/{crn}/referral/start/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
-  appointments:
-    office-location: CRSSHEF
   integration-context: commissioned-rehabilitation-services
 
 appointments:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,8 @@ community-api:
     sent-referral: "/secure/offenders/crn/{crn}/referral/start/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
+  appointments:
+    office-location: CRSDEFLOC
   integration-context: commissioned-rehabilitation-services
 
 appointments:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -199,7 +199,7 @@ class CommunityAPIClientTest {
     referralStart = OffsetDateTime.now(),
     appointmentStart = OffsetDateTime.now(),
     appointmentEnd = OffsetDateTime.now(),
-    officeLocationCode = "CRSDEFLOC",
+    officeLocationCode = "CRSEXTL",
     notes = "http://backLink",
     countsTowardsRarDays = true,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -199,7 +199,7 @@ class CommunityAPIClientTest {
     referralStart = OffsetDateTime.now(),
     appointmentStart = OffsetDateTime.now(),
     appointmentEnd = OffsetDateTime.now(),
-    officeLocationCode = null,
+    officeLocationCode = "CRSDEFLOC",
     notes = "http://backLink",
     countsTowardsRarDays = true,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -199,6 +199,7 @@ class CommunityAPIClientTest {
     referralStart = OffsetDateTime.now(),
     appointmentStart = OffsetDateTime.now(),
     appointmentEnd = OffsetDateTime.now(),
+    officeLocationCode = null,
     notes = "http://backLink",
     countsTowardsRarDays = true,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -195,9 +195,11 @@ class CommunityAPIClientTest {
   )
 
   private val appointmentCreateRequest = AppointmentCreateRequestDTO(
+    contractType = "ACC",
+    referralStart = OffsetDateTime.now(),
     appointmentStart = OffsetDateTime.now(),
     appointmentEnd = OffsetDateTime.now(),
-    officeLocationCode = "CRSSHEF",
-    notes = "http://backLink"
+    notes = "http://backLink",
+    countsTowardsRarDays = true,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -20,7 +20,7 @@ internal class CommunityAPIBookingServiceTest {
   private val httpBaseUrl = "http://url"
   private val viewUrl = "/view/{referralId}"
   private val apiUrl = "/appt/{CRN}/{sentenceId}/{contextName}"
-  private val crsOfficeLocation = "CRSDEFLOC"
+  private val crsOfficeLocation = "CRSEXTL"
   private val crsBookingsContext = "CRS"
 
   private val communityAPIClient: CommunityAPIClient = mock()
@@ -42,7 +42,7 @@ internal class CommunityAPIBookingServiceTest {
 
     val uri = "/appt/X1/123/CRS"
     val link = "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), "CRSDEFLOC", notes = link, true)
+    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), "CRSEXTL", notes = link, true)
     val response = AppointmentCreateResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -20,6 +20,7 @@ internal class CommunityAPIBookingServiceTest {
   private val httpBaseUrl = "http://url"
   private val viewUrl = "/view/{referralId}"
   private val apiUrl = "/appt/{CRN}/{sentenceId}/{contextName}"
+  private val crsOfficeLocation = "CRSDEFLOC"
   private val crsBookingsContext = "CRS"
 
   private val communityAPIClient: CommunityAPIClient = mock()
@@ -29,6 +30,7 @@ internal class CommunityAPIBookingServiceTest {
     httpBaseUrl,
     viewUrl,
     apiUrl,
+    crsOfficeLocation,
     crsBookingsContext,
     communityAPIClient
   )
@@ -40,7 +42,7 @@ internal class CommunityAPIBookingServiceTest {
 
     val uri = "/appt/X1/123/CRS"
     val link = "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), null, notes = link, true)
+    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), "CRSDEFLOC", notes = link, true)
     val response = AppointmentCreateResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java))
@@ -87,6 +89,7 @@ internal class CommunityAPIBookingServiceTest {
       httpBaseUrl,
       viewUrl,
       apiUrl,
+      crsOfficeLocation,
       crsBookingsContext,
       communityAPIClient
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -40,7 +40,7 @@ internal class CommunityAPIBookingServiceTest {
 
     val uri = "/appt/X1/123/CRS"
     val link = "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), notes = link, true)
+    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), null, notes = link, true)
     val response = AppointmentCreateResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -20,7 +20,6 @@ internal class CommunityAPIBookingServiceTest {
   private val httpBaseUrl = "http://url"
   private val viewUrl = "/view/{referralId}"
   private val apiUrl = "/appt/{CRN}/{sentenceId}/{contextName}"
-  private val crsOfficeLocation = "CRSSHEF"
   private val crsBookingsContext = "CRS"
 
   private val communityAPIClient: CommunityAPIClient = mock()
@@ -30,7 +29,6 @@ internal class CommunityAPIBookingServiceTest {
     httpBaseUrl,
     viewUrl,
     apiUrl,
-    crsOfficeLocation,
     crsBookingsContext,
     communityAPIClient
   )
@@ -38,17 +36,17 @@ internal class CommunityAPIBookingServiceTest {
   @Test
   fun `requests booking for an appointment when timings specified`() {
     val now = OffsetDateTime.now()
-    val appointment = makeAppointment(null, null)
+    val appointment = makeAppointment(now, null, null)
 
     val uri = "/appt/X1/123/CRS"
     val link = "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO(now, now.plusMinutes(60), "CRSSHEF", notes = link)
+    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), notes = link, true)
     val response = AppointmentCreateResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java))
       .thenReturn(response)
 
-    val deliusAppointmentId = communityAPIBookingService.book(appointment, now, 60)
+    val deliusAppointmentId = communityAPIBookingService.book(appointment, now.plusMinutes(60), 60)
 
     assertThat(deliusAppointmentId).isEqualTo(1234L)
     verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentCreateResponseDTO::class.java)
@@ -56,7 +54,7 @@ internal class CommunityAPIBookingServiceTest {
 
   @Test
   fun `does nothing if not initial booking`() {
-    val deliusAppointmentId = communityAPIBookingService.book(makeAppointment(null, null), now(), null)
+    val deliusAppointmentId = communityAPIBookingService.book(makeAppointment(now(), null, null), now(), null)
 
     assertThat(deliusAppointmentId).isNull()
     verifyZeroInteractions(communityAPIClient)
@@ -72,24 +70,23 @@ internal class CommunityAPIBookingServiceTest {
 
   @Test
   fun `is initial booking`() {
-    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), null, null)).isFalse()
-    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), null), null, null)).isFalse()
-    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, 60), null, null)).isFalse()
-    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), 60), null, null)).isFalse()
-    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), now(), null)).isFalse()
-    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(null, null), now(), 60)).isTrue()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), null, null), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), now(), null), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), null, 60), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), now(), 60), null, null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), null, null), now(), null)).isFalse()
+    assertThat(communityAPIBookingService.isInitialBooking(makeAppointment(now(), null, null), now(), 60)).isTrue()
   }
 
   @Test
   fun `does nothing if not enabled`() {
-    val appointment = makeAppointment(null, null)
+    val appointment = makeAppointment(now(), null, null)
 
     val communityAPIBookingServiceNotEnabled = CommunityAPIBookingService(
       false,
       httpBaseUrl,
       viewUrl,
       apiUrl,
-      crsOfficeLocation,
       crsBookingsContext,
       communityAPIClient
     )
@@ -98,8 +95,8 @@ internal class CommunityAPIBookingServiceTest {
     verifyZeroInteractions(communityAPIClient)
   }
 
-  private fun makeAppointment(appointmentTime: OffsetDateTime?, durationInMinutes: Int?): ActionPlanAppointment {
-    val referral = SampleData.sampleReferral(crn = crn, relevantSentenceId = sentenceId, serviceProviderName = "SPN")
+  private fun makeAppointment(sentAt: OffsetDateTime, appointmentTime: OffsetDateTime?, durationInMinutes: Int?): ActionPlanAppointment {
+    val referral = SampleData.sampleReferral(crn = crn, relevantSentenceId = sentenceId, sentAt = sentAt, serviceProviderName = "SPN")
     return SampleData.sampleActionPlanAppointment(
       actionPlan = SampleData.sampleActionPlan(referral = referral),
       createdBy = SampleData.sampleAuthUser(),


### PR DESCRIPTION
**What does this pull request do?**
After a review of the functionality required by interventions/delius the changes were made to the endpoint in community-api 

1) Contract Type is provided and used to map to NsiType - used for looking an existing NSI
2) Referral Sent At is provided - used for looking up an existing NSI
3) Counts towards RAR - used for assigning correct contact type, CRSAPT (service delivery) or CRSSAA (assessment)

**What is the intent behind these changes?**
These changes are necessary to ensure that appointments can be tied to the appropriate NSI is delius and are accounted for correctly

**Breaking Changes?**
As a result of changes in community-api.