### PR TITLE
Create nightly policy scan reports with Veracode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
-      - run: ./gradlew assemble --console=plain
+      - run: ./gradlew assemble
       - persist_to_workspace:
           root: build/libs
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ orbs:
   kubernetes: circleci/kubernetes@0.11.2
   mem: circleci/rememborb@0.0.1
   snyk: snyk/snyk@0.0.12
+  veracode: orb-01scan/sast-orb@0.0.9
 
 _snyk_options: &snyk_options
   snyk-scan: true
@@ -155,6 +156,30 @@ jobs:
           fail-on-issues: << parameters.snyk-fail-build >>
           additional-arguments: << parameters.snyk-args >>
 
+  assemble:
+    executor: hmpps/java
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle.kts" }}
+            - gradle-
+      - run: ./gradlew assemble --console=plain
+      - persist_to_workspace:
+          root: build/libs
+          paths:
+            - hmpps-interventions-service-*.jar
+
+  appsec_scan:
+    executor: veracode/default
+    steps:
+      - attach_workspace:
+          at: ./build
+      - run: mv -v ./build/hmpps-interventions-service-*.jar ./build/hmpps-interventions-service.jar
+      - veracode/policy-scan:
+          filepath: ./build/hmpps-interventions-service.jar
+          teams: hmpps-interventions
+
   reset_research_db:
     docker:
       - image: 'cimg/base:stable'
@@ -289,6 +314,10 @@ workflows:
           name: vulnerability_scan_and_monitor
           monitor: true
           <<: *snyk_options
+      - assemble
+      - appsec_scan:
+          requires: [assemble]
+          context: [veracode-credentials]
       - hmpps/build_docker:
           publish: false
           <<: *snyk_options


### PR DESCRIPTION

## What does this pull request do?

Adds daily veracode scanning ([link to reports](https://analysiscenter.veracode.com/auth/index.jsp#ViewReportsResultSummary:77328:1140482:12058273:12032662:12048325:3225960))

We are using the "policy scan" product, which doesn't support concurrent reports, so it's not feasible to run on every commit

As this is purely informational at this point, a daily report is useful. We may switch to blocking "pipeline scans" soon

## What is the intent behind these changes?

Using the continuous security tooling currently being tested/rolled out in Ministry of Justice
