### PR TITLE
🐛 Fix invalid Kubernetes CronJob resource

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -22,7 +22,7 @@ spec:
               - name: LOCAL_EXPORT_DESTINATION
                 value: export
               - name: PGPORT
-                value: 5432
+                value: "5432"
               - name: PGHOST
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## What does this pull request do?

It looks like our Kubernetes server does not accept environment configurations that are not strings. This PR fixes that.

The real reason is only detected when trying to apply the configuration to the server:

```
$ kubectl apply -f temp-apply-cronjob.yml --dry-run=server
The request is invalid: patch: Invalid value: "map[metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"batch/v1beta1\",\"kind\":\"CronJob\",\"metadata\":{\"annotations\":{},\"name\":\"data-extractor-analytics\",\"namespace\":\"hmpps-interventions-dev\"},\"spec\":{\"jobTemplate\":{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"python3 /data-engineering-data-extractor/modules/extract_table_names.py \\u0026\\u0026 python3 /data-engineering-data-extractor/modules/extract_pg_jsonl_snapshot.py \\u0026\\u0026 transfer_local_to_s3.sh\"],\"env\":[{\"name\":\"LOCAL_EXPORT_DESTINATION\",\"value\":\"export\"},{\"name\":\"PGPORT\",\"value\":5432},{\"name\":\"PGHOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"rds_instance_address\",\"name\":\"postgres\"}}},{\"name\":\"PGDATABASE\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"database_name\",\"name\":\"postgres\"}}},{\"name\":\"PGUSER\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"database_username\",\"name\":\"postgres\"}}},{\"name\":\"PGPASSWORD\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"database_password\",\"name\":\"postgres\"}}},{\"name\":\"S3_DESTINATION\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"destination_bucket\",\"name\":\"analytical-platform-reporting-s3-bucket\"}}},{\"name\":\"AWS_ACCESS_KEY_ID\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"access_key_id\",\"name\":\"analytical-platform-reporting-s3-bucket\"}}},{\"name\":\"AWS_SECRET_ACCESS_KEY\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"secret_access_key\",\"name\":\"analytical-platform-reporting-s3-bucket\"}}},{\"name\":\"AWS_DEFAULT_REGION\",\"value\":\"eu-west-2\"}],\"image\":\"ministryofjustice/data-engineering-data-extractor:develop\",\"imagePullPolicy\":\"Always\",\"name\":\"data-extractor-analytics\"}],\"restartPolicy\":\"Never\"}}}},\"schedule\":\"0 1 * * *\"}}\n]] spec:map[jobTemplate:map[spec:map[template:map[spec:map[]]]]]]": 
  cannot convert int64 to string
```

I tried these things to incorporate this to the CI check:

- `helm template --validate`
- `helm install --dry-run`
- `helm template | kubectl apply -f - --dry-run=server`

Out of this, only the last one works in detecting the error, but once fixed dies on `Service` and `Ingress` dry-runs, so it will always would be 🔴:

```
Error from server (BadRequest): error when applying patch:
<snip>
to:
Resource: "/v1, Resource=services", GroupVersionKind: "/v1, Kind=Service"
Name: "data-dictionary", Namespace: "hmpps-interventions-dev"
for: "STDIN": admission webhook "webhook.openpolicyagent.org" does not support dry run

Error from server (BadRequest): error when applying patch:
<snip>
to:
Resource: "/v1, Resource=services", GroupVersionKind: "/v1, Kind=Service"
Name: "hmpps-interventions-service", Namespace: "hmpps-interventions-dev"
for: "STDIN": admission webhook "webhook.openpolicyagent.org" does not support dry run

Error from server (BadRequest): error when applying patch:
<snip>
to:
Resource: "networking.k8s.io/v1beta1, Resource=ingresses", GroupVersionKind: "networking.k8s.io/v1beta1, Kind=Ingress"
Name: "hmpps-interventions-service", Namespace: "hmpps-interventions-dev"
for: "STDIN": admission webhook "webhook.openpolicyagent.org" does not support dry run
```

In short, I gave up adding a verification to CI for now

## What is the intent behind these changes?

Fix the deploy.