### PR TITLE
IC-1317 Notify Referral End to Delius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 
 enum class ReferralEventType {
-  SENT, ASSIGNED,
+  SENT, ASSIGNED, CANCELLED, PREMATURELY_ENDED, COMPLETED
 }
 
 class ReferralEvent(source: Any, val type: ReferralEventType, val referral: Referral, val detailUrl: String) : ApplicationEvent(source) {
@@ -29,6 +29,10 @@ class ReferralEventPublisher(
 
   fun referralAssignedEvent(referral: Referral) {
     applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.ASSIGNED, referral, getSentReferralURL(referral)))
+  }
+
+  fun referralConcludedEvent(referral: Referral, eventType: ReferralEventType) {
+    applicationEventPublisher.publishEvent(ReferralEvent(this, eventType, referral, getSentReferralURL(referral)))
   }
 
   private fun getSentReferralURL(referral: Referral): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -35,18 +35,7 @@ class CommunityAPIReferralEventService(
           .buildAndExpand(event.referral.id)
           .toString()
 
-        val referRequest = ReferRequest(
-          "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
-          event.referral.sentAt!!,
-          event.referral.relevantSentenceId!!,
-          url,
-        )
-
-        val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPISentReferralLocation)
-          .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
-          .toString()
-
-        communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referRequest)
+        postReferralStartRequest(event, url)
       }
       ReferralEventType.CANCELLED,
       -> {
@@ -55,20 +44,7 @@ class CommunityAPIReferralEventService(
           .buildAndExpand(event.referral.id)
           .toString()
 
-        val referralEndRequest = ReferralEndRequest(
-          "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
-          event.referral.sentAt!!,
-          event.referral.concludedAt!!,
-          event.referral.relevantSentenceId!!,
-          event.type.name,
-          url,
-        )
-
-        val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPIEndedReferralLocation)
-          .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
-          .toString()
-
-        communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referralEndRequest)
+        postReferralEndRequest(event, url)
       }
       ReferralEventType.PREMATURELY_ENDED,
       ReferralEventType.COMPLETED,
@@ -78,23 +54,42 @@ class CommunityAPIReferralEventService(
           .buildAndExpand(event.referral.endOfServiceReport!!.id)
           .toString()
 
-        val referralEndRequest = ReferralEndRequest(
-          "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
-          event.referral.sentAt!!,
-          event.referral.concludedAt!!,
-          event.referral.relevantSentenceId!!,
-          event.type.name,
-          url,
-        )
-
-        val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPIEndedReferralLocation)
-          .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
-          .toString()
-
-        communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referralEndRequest)
+        postReferralEndRequest(event, url)
       }
       else -> {}
     }
+  }
+
+  private fun postReferralStartRequest(event: ReferralEvent, url: String) {
+    val referRequest = ReferRequest(
+      "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
+      event.referral.sentAt!!,
+      event.referral.relevantSentenceId!!,
+      url,
+    )
+
+    val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPISentReferralLocation)
+      .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
+      .toString()
+
+    communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referRequest)
+  }
+
+  private fun postReferralEndRequest(event: ReferralEvent, url: String) {
+    val referralEndRequest = ReferralEndRequest(
+      "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
+      event.referral.sentAt!!,
+      event.referral.concludedAt!!,
+      event.referral.relevantSentenceId!!,
+      event.type.name,
+      url,
+    )
+
+    val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPIEndedReferralLocation)
+      .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
+      .toString()
+
+    communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referralEndRequest)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.CANCELLED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.COMPLETED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.PREMATURELY_ENDED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import java.time.OffsetDateTime
+import java.util.Objects.nonNull
+
+@Service
+class ReferralConcluder(
+  val referralRepository: ReferralRepository,
+  val actionPlanAppointmentRepository: ActionPlanAppointmentRepository,
+  val referralEventPublisher: ReferralEventPublisher,
+) {
+  companion object {
+    private val logger = KotlinLogging.logger {}
+  }
+
+  fun concludeIfEligible(referral: Referral) {
+    val concludedEventType = getConcludedEventType(referral)
+
+    if (concludedEventType != null) {
+      referral.concludedAt = OffsetDateTime.now()
+      referralRepository.save(referral)
+      referralEventPublisher.referralConcludedEvent(referral, concludedEventType)
+    }
+  }
+
+  private fun getConcludedEventType(referral: Referral): ReferralEventType? {
+
+    val hasActionPlan = nonNull(referral.actionPlan)
+
+    val numberOfAttendedAppointments = referral.actionPlan?.let {
+      actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(it.id)
+    } ?: 0
+    val hasAttendedNoAppointments = numberOfAttendedAppointments == 0
+
+    val totalNumberOfAppointments = referral.actionPlan?.numberOfSessions ?: 0
+    val hasAttendedSomeAppointments = totalNumberOfAppointments > numberOfAttendedAppointments
+    val hasAttendedAllAppointments = totalNumberOfAppointments == numberOfAttendedAppointments
+
+    val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
+
+    if (!hasActionPlan)
+      return CANCELLED
+
+    if (hasAttendedNoAppointments)
+      return CANCELLED
+
+    if (hasAttendedSomeAppointments && hasSubmittedEndOfServiceReport)
+      return PREMATURELY_ENDED
+
+    if (hasAttendedAllAppointments && hasSubmittedEndOfServiceReport)
+      return COMPLETED
+
+    return null
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,6 +83,7 @@ notify:
 interventions-ui:
   locations:
     sent-referral: "/service-provider/referrals/{id}/details"
+    cancelled-referral: "/service-provider/referrals/{id}/details"
     submit-action-plan: "/service-provider/referrals/{id}/progress" # fixme
     appointment-not-attended: "/service-provider/referrals/{id}/progress" # fixme
     view-appointment: "/probation-practitioner/referrals/{id}/progress"
@@ -93,6 +94,7 @@ interventions-ui:
 community-api:
   locations:
     sent-referral: "/secure/offenders/crn/{crn}/referral/start/context/{contextName}"
+    ended-referral: "/secure/offenders/crn/{crn}/referral/end/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
   appointments:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -71,6 +71,7 @@ class SampleData {
       assignedAt: OffsetDateTime = OffsetDateTime.now(),
       actionPlan: ActionPlan? = null,
       endOfServiceReport: EndOfServiceReport? = null,
+      concludedAt: OffsetDateTime? = null,
     ): Referral {
       return Referral(
         serviceUserCRN = crn,
@@ -92,6 +93,7 @@ class SampleData {
         ),
         actionPlan = actionPlan,
         endOfServiceReport = endOfServiceReport,
+        concludedAt = concludedAt,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -15,41 +16,114 @@ class CommunityAPIReferralServiceTest {
 
   private val communityAPIClient = mock<CommunityAPIClient>()
 
+  private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
+  private val concludedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
+
+  val communityAPIService = CommunityAPIReferralEventService(
+    "http://testUrl",
+    "/referral/sent/{id}",
+    "/referral/progress/{id}",
+    "/referral/end-of-service-report/{id}",
+    "secure/offenders/crn/{crn}/referral/start/context/{contextName}",
+    "secure/offenders/crn/{crn}/referral/end/context/{contextName}",
+    "commissioned-rehabilitation-services",
+    communityAPIClient
+  )
+
   @Test
-  fun `got service successfully`() {
+  fun `notify sent referral`() {
 
-    val communityAPIService = CommunityAPIReferralEventService(
-      "http://testUrl",
-      "secure/offenders/crn/{id}/referral/sent",
-      "secure/offenders/crn/{crn}/referral/start/context/{contextName}",
-      "commissioned-rehabilitation-services",
-      communityAPIClient
-    )
-
-    communityAPIService.onApplicationEvent(referralSentEvent)
+    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.SENT))
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/start/context/commissioned-rehabilitation-services",
       ReferRequest(
         "ACC",
-        OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC),
+        sentAtDefault,
         123456789,
-        "http://testUrl/secure/offenders/crn/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/referral/sent",
+        "http://testUrl/referral/sent/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
       )
     )
   }
 
-  private val referralSentEvent = ReferralEvent(
-    "source",
-    ReferralEventType.SENT,
-    SampleData.sampleReferral(
-      id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
-      referenceNumber = "HAS71263",
-      crn = "X123456",
-      relevantSentenceId = 123456789,
-      serviceProviderName = "Harmony Living",
-      sentAt = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
-    ),
-    "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
-  )
+  @Test
+  fun `notify cancelled referral`() {
+
+    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.CANCELLED, concludedAtDefault))
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      ReferralEndRequest(
+        "ACC",
+        sentAtDefault,
+        concludedAtDefault,
+        123456789,
+        "CANCELLED",
+        "http://testUrl/referral/progress/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
+      )
+    )
+  }
+
+  @Test
+  fun `notify prematurely ended referral`() {
+
+    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault, endOfServiceReport))
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      ReferralEndRequest(
+        "ACC",
+        sentAtDefault,
+        concludedAtDefault,
+        123456789,
+        "PREMATURELY_ENDED",
+        "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+  }
+
+  @Test
+  fun `notify completed referral`() {
+
+    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.COMPLETED, concludedAtDefault, endOfServiceReport))
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      ReferralEndRequest(
+        "ACC",
+        sentAtDefault,
+        concludedAtDefault,
+        123456789,
+        "COMPLETED",
+        "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+  }
+
+  private fun getEvent(
+    referralEventType: ReferralEventType,
+    concludedAt: OffsetDateTime? = null,
+    endOfServiceReport: EndOfServiceReport? = null
+  ): ReferralEvent =
+    ReferralEvent(
+      "source",
+      referralEventType,
+      SampleData.sampleReferral(
+        id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
+        referenceNumber = "HAS71263",
+        crn = "X123456",
+        relevantSentenceId = 123456789,
+        serviceProviderName = "Harmony Living",
+        sentAt = sentAtDefault,
+        concludedAt = concludedAt,
+        endOfServiceReport = endOfServiceReport,
+      ),
+      "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
+    )
+
+  private val endOfServiceReport =
+    SampleData.sampleEndOfServiceReport(
+      id = UUID.fromString("120b1a45-8ac7-4920-b05b-acecccf4734b"),
+      referral = SampleData.sampleReferral(crn = "X123456", serviceProviderName = "Harmony Living"),
+    )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
@@ -30,14 +30,14 @@ class EndOfServiceReportServiceTest {
   private val referralRepository: ReferralRepository = mock()
   private val endOfServiceReportRepository: EndOfServiceReportRepository = mock()
   private val endOfServiceReportEventPublisher: EndOfServiceReportEventPublisher = mock()
-  private val referralService: ReferralService = mock()
+  private val referralConcluder: ReferralConcluder = mock()
 
   private val referralFactory = ReferralFactory()
   private val endOfServiceReportFactory = EndOfServiceReportFactory()
 
   private val endOfServiceReportService = EndOfServiceReportService(
     authUserRepository, referralRepository,
-    endOfServiceReportRepository, endOfServiceReportEventPublisher, referralService,
+    endOfServiceReportRepository, endOfServiceReportEventPublisher, referralConcluder,
   )
 
   @Test
@@ -185,6 +185,7 @@ class EndOfServiceReportServiceTest {
     endOfServiceReportService.submitEndOfServiceReport(endOfServiceReportId, authUser)
 
     verify(endOfServiceReportRepository).save(argumentCaptor.capture())
+    verify(referralConcluder).concludeIfEligible(endOfServiceReport.referral)
     assertThat(argumentCaptor.firstValue.furtherInformation).isEqualTo(endOfServiceReport.furtherInformation)
     assertThat(argumentCaptor.firstValue.submittedAt).isNotNull
     assertThat(argumentCaptor.firstValue.submittedBy).isEqualTo(authUser)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -1,0 +1,151 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.firstValue
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import java.time.OffsetDateTime
+
+internal class ReferralConcluderTest {
+
+  private val referralRepository: ReferralRepository = mock()
+  private val actionPlanAppointmentRepository: ActionPlanAppointmentRepository = mock()
+  private val referralEventPublisher: ReferralEventPublisher = mock()
+
+  private val referralFactory = ReferralFactory()
+  private val actionPlanFactory = ActionPlanFactory()
+  private val endOfServiceReportFactory = EndOfServiceReportFactory()
+
+  private val referralConcluder = ReferralConcluder(
+    referralRepository, actionPlanAppointmentRepository, referralEventPublisher
+  )
+
+  @Test
+  fun `concludes referral as cancelled when ending a referral with no action plan`() {
+
+    val timeAtStart = OffsetDateTime.now()
+    val referralWithNoActionPlan = referralFactory.createSent()
+
+    referralConcluder.concludeIfEligible(referralWithNoActionPlan)
+
+    verifySaveWithConcludedAtSet(referralWithNoActionPlan, timeAtStart)
+    verifyEventPublished(referralWithNoActionPlan, ReferralEventType.CANCELLED)
+  }
+
+  @Test
+  fun `concludes referral as cancelled when ending a referral with no appointments attended`() {
+
+    val timeAtStart = OffsetDateTime.now()
+    val referralWithActionPlanAndNoAttendedAppointments = referralFactory.createSent()
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(referralWithActionPlanAndNoAttendedAppointments.id)).thenReturn(0)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttendedAppointments)
+
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoAttendedAppointments, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndNoAttendedAppointments, ReferralEventType.CANCELLED)
+  }
+
+  @Test
+  fun `concludes referral as prematurely ended when ending a referral with some appointments attended and an end of service report submitted`() {
+
+    val timeAtStart = OffsetDateTime.now()
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    referralWithActionPlanAndSomeAttendedAppointments.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(actionPlan.id)).thenReturn(1)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedAppointments)
+
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttendedAppointments, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeAttendedAppointments, ReferralEventType.PREMATURELY_ENDED)
+  }
+
+  @Test
+  fun `concludes referral as completed when ending a referral with all appointments attended and an end of service report submitted`() {
+
+    val timeAtStart = OffsetDateTime.now()
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    referralWithActionPlanAndSomeAttendedAppointments.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(actionPlan.id)).thenReturn(2)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedAppointments)
+
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttendedAppointments, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeAttendedAppointments, ReferralEventType.COMPLETED)
+  }
+
+  @Test
+  fun `does not conclude a referral when ending a referral with some appointments attended and an end of service report has not been submitted`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    referralWithActionPlanAndSomeAttendedAppointments.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(actionPlan.id)).thenReturn(1)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedAppointments)
+
+    verifyZeroInteractions(referralRepository, referralEventPublisher)
+  }
+
+  @Test
+  fun `does not conclude a referral when ending a referral with all appointments attended and an end of service report has not been submitted`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    referralWithActionPlanAndSomeAttendedAppointments.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(actionPlan.id)).thenReturn(2)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedAppointments)
+
+    verifyZeroInteractions(referralRepository, referralEventPublisher)
+  }
+
+  @Test
+  fun `does not conclude a referral when ending a referral with some appointments attended and an end of service report does not exist`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(actionPlan.id)).thenReturn(1)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedAppointments)
+
+    verifyZeroInteractions(referralRepository, referralEventPublisher)
+  }
+
+  @Test
+  fun `does not conclude a referral when ending a referral with all appointments attended and an end of service report does not exit`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(actionPlan.id)).thenReturn(2)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedAppointments)
+
+    verifyZeroInteractions(referralRepository, referralEventPublisher)
+  }
+
+  private fun verifyEventPublished(referralWithNoActionPlan: Referral, value: ReferralEventType) {
+    verify(referralEventPublisher).referralConcludedEvent(same(referralWithNoActionPlan), same(value))
+  }
+
+  private fun verifySaveWithConcludedAtSet(referralWithNoActionPlan: Referral, timeAtStart: OffsetDateTime?) {
+    val argumentCaptor: ArgumentCaptor<Referral> = ArgumentCaptor.forClass(Referral::class.java)
+    verify(referralRepository).save(argumentCaptor.capture())
+    assertThat(argumentCaptor.firstValue).isSameAs(referralWithNoActionPlan)
+    assertThat(argumentCaptor.firstValue.concludedAt).isAfter(timeAtStart)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -49,7 +49,8 @@ internal class ReferralConcluderTest {
   fun `concludes referral as cancelled when ending a referral with no appointments attended`() {
 
     val timeAtStart = OffsetDateTime.now()
-    val referralWithActionPlanAndNoAttendedAppointments = referralFactory.createSent()
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndNoAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
     whenever(actionPlanAppointmentRepository.countByActionPlanIdAndAttendedIsNotNull(referralWithActionPlanAndNoAttendedAppointments.id)).thenReturn(0)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttendedAppointments)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -58,10 +58,12 @@ class ReferralServiceTest @Autowired constructor(
 
   private val referralEventPublisher: ReferralEventPublisher = mock()
   private val referenceGenerator: ReferralReferenceGenerator = spy(ReferralReferenceGenerator())
+  private val referralConcluder: ReferralConcluder = mock()
   private val referralService = ReferralService(
     referralRepository,
     authUserRepository,
     interventionRepository,
+    referralConcluder,
     referralEventPublisher,
     referenceGenerator,
     cancellationReasonRepository,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
 
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
@@ -45,6 +46,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     serviceUserCRN: String = "X123456",
     intervention: Intervention = interventionFactory.create(),
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
+    actionPlan: ActionPlan? = null,
 
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
@@ -61,6 +63,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
       serviceUserCRN = serviceUserCRN,
       intervention = intervention,
       desiredOutcomes = desiredOutcomes,
+      actionPlan = actionPlan,
 
       sentAt = sentAt,
       sentBy = sentBy,
@@ -128,6 +131,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     completionDeadline: LocalDate? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
     serviceUserData: ServiceUserData? = null,
+    actionPlan: ActionPlan? = null,
 
     sentAt: OffsetDateTime? = null,
     sentBy: AuthUser? = null,
@@ -154,6 +158,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         completionDeadline = completionDeadline,
         desiredOutcomesIDs = desiredOutcomes.map { it.id },
         serviceUserData = serviceUserData,
+        actionPlan = actionPlan,
         sentAt = sentAt,
         sentBy = sentBy,
         referenceNumber = referenceNumber,


### PR DESCRIPTION
**What does this pull request do?**
Referrals in Interventions can end in one of three ways. They can be cancelled, prematurely ended or completed in their entirety. As a result, delius must be notified with the appropriate outcome and as a consequence, where there are any outstanding appointments, they are deleted. This PR provides the functionality to notify delius.

**What is the intent behind these changes?**
These changes allow interventions to end referrals with the knowledge that delius has been notified correctly.
