### PR TITLE
IC-1766: Tag pacts after deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,22 @@ jobs:
       - store_artifacts:
           path: build/reports/tests
 
+  tag_pact_version:
+    environment:
+      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+      PACT_BROKER_USERNAME: "interventions"
+    executor: hmpps/node
+    parameters:
+      tag:
+        type: string
+    steps:
+      - run:
+          name: Tag contract version with deployment
+          command: |
+            npx --package='@pact-foundation/pact-node' pact-broker create-version-tag \
+              --pacticipant="Interventions Service" --version="$CIRCLE_SHA1" --tag="<< parameters.tag >>" \
+              --broker-base-url="$PACT_BROKER_BASE_URL" --broker-username="$PACT_BROKER_USERNAME" --broker-password="$PACT_BROKER_PASSWORD"
+
   vulnerability_scan:
     executor: hmpps/java
     parameters:
@@ -243,6 +259,11 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+      - tag_pact_version:
+          name: "tag_pact_version_dev"
+          tag: "deployed:dev"
+          requires: [deploy_dev]
+          context: [hmpps-common-vars]
       - approve_research:
           type: approval
           requires:
@@ -271,6 +292,11 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-interventions-service-preprod
+      - tag_pact_version:
+          name: "tag_pact_version_preprod"
+          tag: "deployed:preprod"
+          requires: [deploy_preprod]
+          context: [hmpps-common-vars]
       - hmpps/deploy_env:
           name: deploy_prod
           env: "prod"
@@ -281,6 +307,11 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-interventions-service-prod
+      - tag_pact_version:
+          name: "tag_pact_version_prod"
+          tag: "deployed:prod"
+          requires: [deploy_prod]
+          context: [hmpps-common-vars]
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ parameters:
 
 orbs:
   hmpps: ministryofjustice/hmpps@3.0.4
+  gradle: circleci/gradle@2.2.0
   kubernetes: circleci/kubernetes@0.11.2
   mem: circleci/rememborb@0.0.1
   snyk: snyk/snyk@0.0.12
@@ -32,16 +33,10 @@ jobs:
           POSTGRES_PASSWORD: password
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-{{ checksum "build.gradle.kts" }}
-            - gradle-
-      - run:
-          command: ./gradlew check
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: gradle-{{ checksum "build.gradle.kts" }}
+      - gradle/with_cache:
+          cache_checksum_file: "build.gradle.kts"
+          steps:
+            - run: ./gradlew check
       - store_test_results:
           path: build/test-results
       - store_artifacts:
@@ -114,21 +109,16 @@ jobs:
           POSTGRES_PASSWORD: password
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-{{ checksum "build.gradle.kts" }}
-            - gradle-
-      - run:
-          command: |
-            PACT_PROVIDER_VERSION="$CIRCLE_SHA1" \
-              PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
-              PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="<< parameters.consumer_tags >>" \
-              PACT_PUBLISH_RESULTS="true" \
-              ./gradlew pactTestPublish
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: gradle-{{ checksum "build.gradle.kts" }}
+      - gradle/with_cache:
+          cache_checksum_file: "build.gradle.kts"
+          steps:
+            - run:
+                command: |
+                  PACT_PROVIDER_VERSION="$CIRCLE_SHA1" \
+                    PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
+                    PACTBROKER_CONSUMERVERSIONSELECTORS_TAGS="<< parameters.consumer_tags >>" \
+                    PACT_PUBLISH_RESULTS="true" \
+                    ./gradlew pactTestPublish
       - store_test_results:
           path: build/test-results
       - store_artifacts:
@@ -176,11 +166,10 @@ jobs:
     executor: hmpps/java
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-{{ checksum "build.gradle.kts" }}
-            - gradle-
-      - run: ./gradlew assemble
+      - gradle/with_cache:
+          cache_checksum_file: "build.gradle.kts"
+          steps:
+            - run: ./gradlew assemble
       - persist_to_workspace:
           root: build/libs
           paths:


### PR DESCRIPTION
## What does this pull request do?

Tag pacts after deploy. This will tag the "service"'s git SHA with the `deployed:environment` tag.

Also simplifies gradle-based caching a bit (indent changed, [whitespace-ignoring diff](https://github.com/ministryofjustice/hmpps-interventions-service/pull/234/files?diff=unified&w=1) recommended)

## What is the intent behind these changes?

Tagging contracts on deployments is [recommended][1] practice.

It enables us running verification against a specific deployed version of the contracts

[1]: https://docs.pact.io/pact_broker/tags#after-deploying-to-an-environment