### PR TITLE
IC-1718 Notify Delius of a Submitted End Of Service Report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -140,7 +140,7 @@ class CommunityAPIEndOfServiceReportEventService(
 
   private fun getNotes(referral: Referral, url: String): String {
     val contractTypeDescription = "Accommodation" // Fixme: Using only contract type Accommodation til contract type changes are in
-    return "End of Service Report has been submitted for ${contractTypeDescription} Referral ${referral.referenceNumber}\n" +
+    return "End of Service Report has been submitted for $contractTypeDescription Referral ${referral.referenceNumber}\n" +
       "$url"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -140,8 +140,7 @@ class CommunityAPIEndOfServiceReportEventService(
 
   private fun getNotes(referral: Referral, url: String): String {
     val contractTypeDescription = "Accommodation" // Fixme: Using only contract type Accommodation til contract type changes are in
-    return "End of Service Report for Referral ${referral.referenceNumber} has been submitted\n" +
-      "Prime Provider is ${referral.intervention.dynamicFrameworkContract.primeProvider.name} for Contract Type ${contractTypeDescription}\n" +
+    return "End of Service Report has been submitted for ${contractTypeDescription} Referral ${referral.referenceNumber}\n" +
       "$url"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -8,8 +8,11 @@ import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType.SESSION_FEEDBACK_RECORDED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.time.OffsetDateTime
 
 interface CommunityAPIService
@@ -94,6 +97,56 @@ class CommunityAPIReferralEventService(
 }
 
 @Service
+class CommunityAPIEndOfServiceReportEventService(
+  @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
+  @Value("\${interventions-ui.locations.submit-end-of-service-report}") private val interventionsUIEndOfServiceReportLocation: String,
+  @Value("\${community-api.locations.notification-request}") private val communityAPINotificationLocation: String,
+  @Value("\${community-api.integration-context}") private val integrationContext: String,
+  private val communityAPIClient: CommunityAPIClient,
+) : ApplicationListener<EndOfServiceReportEvent>, CommunityAPIService {
+  companion object : KLogging()
+
+  override fun onApplicationEvent(event: EndOfServiceReportEvent) {
+    when (event.type) {
+      EndOfServiceReportEventType.SUBMITTED,
+      -> {
+        val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
+          .path(interventionsUIEndOfServiceReportLocation)
+          .buildAndExpand(event.endOfServiceReport.id)
+          .toString()
+
+        postNotificationRequest(event, url)
+      }
+    }
+  }
+
+  private fun postNotificationRequest(event: EndOfServiceReportEvent, url: String) {
+
+    val referral = event.endOfServiceReport.referral
+
+    val request = NotificationCreateRequestDTO(
+      "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
+      referral.sentAt!!,
+      event.endOfServiceReport.submittedAt!!,
+      getNotes(referral, url),
+    )
+
+    val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPINotificationLocation)
+      .buildAndExpand(referral.serviceUserCRN, referral.relevantSentenceId!!, integrationContext)
+      .toString()
+
+    communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, request)
+  }
+
+  private fun getNotes(referral: Referral, url: String): String {
+    val contractTypeDescription = "Accommodation" // Fixme: Using only contract type Accommodation til contract type changes are in
+    return "End of Service Report for Referral ${referral.referenceNumber} has been submitted\n" +
+      "Prime Provider is ${referral.intervention.dynamicFrameworkContract.primeProvider.name} for Contract Type ${contractTypeDescription}\n" +
+      "$url"
+  }
+}
+
+@Service
 class CommunityAPIAppointmentEventService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.session-feedback}") private val interventionsUISessionFeedbackLocation: String,
@@ -142,6 +195,13 @@ data class ReferralEndRequest(
   val sentenceId: Long,
   val endType: String,
   val notes: String,
+)
+
+data class NotificationCreateRequestDTO(
+  val contractType: String,
+  val referralStart: OffsetDateTime,
+  val contactDateTime: OffsetDateTime,
+  val notes: String
 )
 
 data class AppointmentOutcomeRequest(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,6 +97,7 @@ community-api:
     ended-referral: "/secure/offenders/crn/{crn}/referral/end/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
+    notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
   appointments:
     office-location: CRSEXTL
   integration-context: commissioned-rehabilitation-services

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportServiceTest.kt
@@ -38,8 +38,7 @@ class CommunityAPIEndOfServiceReportServiceTest {
         "ACC",
         sentAtDefault,
         submittedAtDefault,
-        "End of Service Report for Referral null has been submitted\n" +
-          "Prime Provider is Harmony Living for Contract Type Accommodation\n" +
+        "End of Service Report has been submitted for Accommodation Referral XX1234\n" +
           "http://testUrl/probation-practitioner/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
       )
     )
@@ -59,6 +58,7 @@ class CommunityAPIEndOfServiceReportServiceTest {
           relevantSentenceId = 1234L,
           serviceProviderName = "Harmony Living",
           sentAt = sentAtDefault,
+          referenceNumber = "XX1234"
         ),
       ),
       "http://localhost:8080/end-of-service-report/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportServiceTest.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType.SUBMITTED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+class CommunityAPIEndOfServiceReportServiceTest {
+
+  private val communityAPIClient = mock<CommunityAPIClient>()
+
+  private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
+  private val submittedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
+
+  val communityAPIService = CommunityAPIEndOfServiceReportEventService(
+    "http://testUrl",
+    "/probation-practitioner/end-of-service-report/{id}",
+    "/secure/offenders/crn/{crn}/sentence/{sentenceId}/notifications/context/{contextName}",
+    "commissioned-rehabilitation-services",
+    communityAPIClient
+  )
+
+  @Test
+  fun `notify submitted end of service report`() {
+
+    communityAPIService.onApplicationEvent(getEvent(SUBMITTED))
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "/secure/offenders/crn/X123456/sentence/1234/notifications/context/commissioned-rehabilitation-services",
+      NotificationCreateRequestDTO(
+        "ACC",
+        sentAtDefault,
+        submittedAtDefault,
+        "End of Service Report for Referral null has been submitted\n" +
+          "Prime Provider is Harmony Living for Contract Type Accommodation\n" +
+          "http://testUrl/probation-practitioner/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+  }
+
+  private fun getEvent(
+    endOfServiceReportEventType: EndOfServiceReportEventType
+  ): EndOfServiceReportEvent =
+    EndOfServiceReportEvent(
+      "source",
+      endOfServiceReportEventType,
+      SampleData.sampleEndOfServiceReport(
+        id = UUID.fromString("120b1a45-8ac7-4920-b05b-acecccf4734b"),
+        submittedAt = submittedAtDefault,
+        referral = SampleData.sampleReferral(
+          crn = "X123456",
+          relevantSentenceId = 1234L,
+          serviceProviderName = "Harmony Living",
+          sentAt = sentAtDefault,
+        ),
+      ),
+      "http://localhost:8080/end-of-service-report/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
+    )
+}


### PR DESCRIPTION
**What does this pull request do?**
This feature notifies Delius of the submission of an End Of Service Report.

**What is the intent behind these changes?**
So that a log of any significant events pertaining to a CRN can be maintained in Delius.
