### PR TITLE
IC-1736 change contract group prefix from 'INT_CG_' to 'INT_CR_'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -23,7 +23,7 @@ class ServiceProviderAccessScopeMapper(
   private val userTypeChecker: UserTypeChecker,
 ) {
   private val serviceProviderGroupPrefix = "INT_SP_"
-  private val contractGroupPrefix = "INT_CG_"
+  private val contractGroupPrefix = "INT_CR_"
   private val errorMessage = "could not map service provider user to access scope"
 
   fun fromUser(user: AuthUser): ServiceProviderAccessScope {

--- a/src/main/resources/db/local/V99_0__contracts_and_providers.sql
+++ b/src/main/resources/db/local/V99_0__contracts_and_providers.sql
@@ -4,11 +4,11 @@ values ('HARMONY_LIVING', 'Harmony Living', 'contact@harmonyliving.com'),
        ('PROB_HELPING_HANDS', 'Helping Hands', 'contact@helpinghands.com');
 
 insert into dynamic_framework_contract (id, service_category_id, prime_provider_id, start_date, end_date, nps_region_id, pcc_region_id, allows_female, allows_male, minimum_age, maximum_age, contract_reference)
-values ('1d7f8fcc-aa12-4705-a6a5-0d40467e03e9', '428ee70f-3001-4399-95a6-ad25eaaede16', 'HARMONY_LIVING', TO_DATE('2020-12-15', 'YYYY-MM-DD'), TO_DATE('2023-12-15', 'YYYY-MM-DD'), 'G', null, true, true, 18, 25, 'Ref1'),
-       ('f9d24b4a-390d-4cc1-a7ee-3e6f022e1599', '428ee70f-3001-4399-95a6-ad25eaaede16', 'HARMONY_LIVING', TO_DATE('2020-01-01', 'YYYY-MM-DD'), TO_DATE('2022-12-31', 'YYYY-MM-DD'), 'G', null, true, false, 18, 25, 'ref2'),
-       ('24f7a423-15a6-438d-9d28-063e92b25a9b', '428ee70f-3001-4399-95a6-ad25eaaede16', 'HARMONY_LIVING', TO_DATE('2021-12-11', 'YYYY-MM-DD'), TO_DATE('2025-12-11', 'YYYY-MM-DD'), null, 'avon-and-somerset', true, true, 25, null, 'ref3'),
-       ('c7d39f92-6f43-49a4-bb62-e0f42c864765', 'c036826e-f077-49a5-8b33-601dca7ad479', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'G', null, false, true, 18, null, 'ref4'),
-       ('0b60d842-9c08-408e-8c8d-f6dbf8e5c3f4', '9556a399-3529-4993-8030-41db2090555e', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'J', null, true, true, 18, null, 'ref5');
+values ('1d7f8fcc-aa12-4705-a6a5-0d40467e03e9', '428ee70f-3001-4399-95a6-ad25eaaede16', 'HARMONY_LIVING', TO_DATE('2020-12-15', 'YYYY-MM-DD'), TO_DATE('2023-12-15', 'YYYY-MM-DD'), 'G', null, true, true, 18, 25, '0001'),
+       ('f9d24b4a-390d-4cc1-a7ee-3e6f022e1599', '428ee70f-3001-4399-95a6-ad25eaaede16', 'HARMONY_LIVING', TO_DATE('2020-01-01', 'YYYY-MM-DD'), TO_DATE('2022-12-31', 'YYYY-MM-DD'), 'G', null, true, false, 18, 25, '0002'),
+       ('24f7a423-15a6-438d-9d28-063e92b25a9b', '428ee70f-3001-4399-95a6-ad25eaaede16', 'HARMONY_LIVING', TO_DATE('2021-12-11', 'YYYY-MM-DD'), TO_DATE('2025-12-11', 'YYYY-MM-DD'), null, 'avon-and-somerset', true, true, 25, null, '0003'),
+       ('c7d39f92-6f43-49a4-bb62-e0f42c864765', 'c036826e-f077-49a5-8b33-601dca7ad479', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'G', null, false, true, 18, null, '0004'),
+       ('0b60d842-9c08-408e-8c8d-f6dbf8e5c3f4', '9556a399-3529-4993-8030-41db2090555e', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'J', null, true, true, 18, null, '0006');
 
 insert into intervention (id, dynamic_framework_contract_id, created_at, title, description)
 values ('98a42c61-c30f-4beb-8062-04033c376e2d', '1d7f8fcc-aa12-4705-a6a5-0d40467e03e9', TO_DATE('2020-10-15', 'YYYY-MM-DD'), 'Accommodation Service', 'The service aims are to support in securing settled accommodation.'),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -60,7 +60,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       user,
       listOf(
         "INT_SP_HARMONY_LIVING",
-        "INT_CG_0001",
+        "INT_CR_0001",
       )
     )
 
@@ -87,7 +87,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       user,
       listOf(
         "INT_SP_BETTER_LTD",
-        "INT_CG_0001",
+        "INT_CR_0001",
       )
     )
 
@@ -114,7 +114,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       user,
       listOf(
         "INT_SP_BETTER_LTD",
-        "INT_CG_0002",
+        "INT_CR_0002",
       )
     )
 
@@ -147,7 +147,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       user,
       listOf(
         "INT_SP_BETTER_LTD",
-        "INT_CG_0002",
+        "INT_CR_0002",
       )
     )
 
@@ -187,7 +187,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       user,
       listOf(
         "INT_SP_BETTER_LTD",
-        "INT_CG_0002",
+        "INT_CR_0002",
       )
     )
 
@@ -245,7 +245,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       listOf(
         "INT_SP_HARMONY_LIVING",
         "INT_SP_BETTER_LTD",
-        "INT_CG_0001"
+        "INT_CR_0001"
       )
     )
 


### PR DESCRIPTION
## What does this pull request do?

change contract group prefix from 'INT_CG_' to 'INT_CR_'

## What is the intent behind these changes?

make it more explicit that the contract group in auth should contain the contract reference number
