### PR TITLE
IC-1709 do not allow an action plan to be created for a referral that already has one

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanController.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateActionPl
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateActionPlanDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
 import java.util.UUID
+import javax.persistence.EntityExistsException
 
 @RestController
 class ActionPlanController(
@@ -32,12 +33,17 @@ class ActionPlanController(
     @RequestBody createActionPlanDTO: CreateActionPlanDTO,
     authentication: JwtAuthenticationToken
   ): ResponseEntity<ActionPlanDTO> {
+    val referralId = createActionPlanDTO.referralId
+
+    if (actionPlanService.checkActionPlanExistsForReferral(referralId)) {
+      throw EntityExistsException("action plan already exists for referral [referralId=$referralId]")
+    }
 
     val createdByUser = userMapper.fromToken(authentication)
     val createActionPlanActivities = actionPlanMapper.mapActionPlanActivityDtoToActionPlanActivity(createActionPlanDTO.activities)
 
     val draftActionPlan = actionPlanService.createDraftActionPlan(
-      createActionPlanDTO.referralId,
+      referralId,
       createActionPlanDTO.numberOfSessions,
       createActionPlanActivities,
       createdByUser

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -7,4 +7,5 @@ import java.util.UUID
 interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
   fun findByIdAndSubmittedAtIsNull(id: UUID): ActionPlan?
   fun findByReferralId(referralId: UUID): ActionPlan?
+  fun existsByReferralId(referralId: UUID): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -94,6 +94,10 @@ class ActionPlanService(
       ?: throw EntityNotFoundException("action plan not found [referralId=$referralId]")
   }
 
+  fun checkActionPlanExistsForReferral(referralId: UUID): Boolean {
+    return actionPlanRepository.existsByReferralId(referralId)
+  }
+
   private fun updateDraftActivityPlan(
     draftActionPlan: ActionPlan,
     numberOfSessions: Int?,

--- a/src/main/resources/db/migration/V1_49__action_plan_referral_unique_constraint.sql
+++ b/src/main/resources/db/migration/V1_49__action_plan_referral_unique_constraint.sql
@@ -1,0 +1,2 @@
+drop index idx_action_plan_referral_id;
+create unique index idx_action_plan_referral_id on action_plan (referral_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
@@ -6,15 +6,28 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import java.util.UUID
 
 @RepositoryTest
 class ActionPlanRepositoryTest @Autowired constructor(
   val entityManager: TestEntityManager,
   val actionPlanRepository: ActionPlanRepository,
 ) {
+  private val actionPlanFactory = ActionPlanFactory(entityManager)
   private val authUserFactory = AuthUserFactory(entityManager)
+  private val referralFactory = ReferralFactory(entityManager)
+
+  @Test
+  fun `existsByReferralId returns true for duplicate action plans`() {
+    val id = UUID.randomUUID()
+    actionPlanFactory.create(referral = referralFactory.createSent(id))
+    assertThat(actionPlanRepository.existsByReferralId(id)).isTrue
+    assertThat(actionPlanRepository.existsByReferralId(UUID.randomUUID())).isFalse
+  }
 
   @Test
   fun `can retrieve an action plan`() {


### PR DESCRIPTION
## What does this pull request do?

 do not allow an action plan to be created for a referral that already has one

## What is the intent behind these changes?

it's possible to do this when you open the referral progress page in two tabs at once. if you get into this state it causes sql consistency issues and breaks the referral entirely.
