### PR TITLE
IC-1704 add custom equality checks for contract and provider entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
@@ -43,4 +43,19 @@ data class DynamicFrameworkContract(
     inverseJoinColumns = [JoinColumn(name = "subcontractor_provider_id")]
   )
   val subcontractorProviders: Set<ServiceProvider> = setOf(),
-)
+) {
+  // using contract_reference for hashCode and equals because
+  // it's guaranteed to have a unique hash (UUID isn't).
+  // the field is enforced as unique at the database level.
+  override fun hashCode(): Int {
+    return contractReference.hashCode()
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other !is DynamicFrameworkContract) {
+      return false
+    }
+
+    return contractReference == other.contractReference
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProvider.kt
@@ -4,11 +4,24 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.validation.constraints.NotNull
 
+typealias AuthGroupID = String
+
 @Entity
 data class ServiceProvider(
   // Service Provider id maps to the hmpps-auth field Group#groupCode
   @NotNull @Id val id: AuthGroupID,
   @NotNull val name: String,
   @NotNull val incomingReferralDistributionEmail: String,
-)
-typealias AuthGroupID = String
+) {
+  override fun hashCode(): Int {
+    return id.hashCode()
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other !is ServiceProvider) {
+      return false
+    }
+
+    return id == other.id
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

add custom equality checks for contract and provider entities

## What is the intent behind these changes?

ensure that all the logic for comparing providers and contracts in the auth components is comparing based on business keys, not object instances.
