### PR TITLE
IC-1111 Notify/Booking in Delius of an appointment reschedule

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -106,7 +106,7 @@ class CommunityAPIBookingService(
     appointmentTime != null && durationInMinutes != null
 
   fun isDifferentTimings(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime, durationInMinutes: Int): Boolean =
-    !(existingAppointment.appointmentTime!!.isEqual(appointmentTime) && existingAppointment!!.durationInMinutes == durationInMinutes)
+    !existingAppointment.appointmentTime!!.isEqual(appointmentTime) || existingAppointment.durationInMinutes != durationInMinutes
 }
 
 abstract class AppointmentRequestDTO

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -15,6 +15,7 @@ class CommunityAPIBookingService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.view-appointment}") private val interventionsUIViewAppointment: String,
   @Value("\${community-api.locations.book-appointment}") private val communityApiBookAppointmentLocation: String,
+  @Value("\${community-api.locations.reschedule-appointment}") private val communityApiRescheduleAppointmentLocation: String,
   @Value("\${community-api.appointments.office-location}") private val officeLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   val communityAPIClient: CommunityAPIClient,
@@ -26,23 +27,46 @@ class CommunityAPIBookingService(
       return null
     }
 
+    return processingBooking(existingAppointment, appointmentTime, durationInMinutes)
+  }
+
+  private fun processingBooking(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?): Long? {
+
+    val referral = existingAppointment.actionPlan.referral
+
     when {
       isInitialBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
-        return makeInitialBooking(existingAppointment, appointmentTime!!, durationInMinutes!!)
+        val appointmentRequestDTO = buildAppointmentCreateRequestDTO(existingAppointment, appointmentTime!!, durationInMinutes!!)
+        return makeBooking(referral.serviceUserCRN, referral.relevantSentenceId!!, appointmentRequestDTO, communityApiBookAppointmentLocation)
       }
+
+      isRescheduleBooking(existingAppointment, appointmentTime, durationInMinutes) -> {
+        val appointmentRequestDTO = buildAppointmentRescheduleRequestDTO(appointmentTime!!, durationInMinutes!!)
+        return makeBooking(referral.serviceUserCRN, existingAppointment.deliusAppointmentId!!, appointmentRequestDTO, communityApiRescheduleAppointmentLocation)
+      }
+
       else -> {}
     }
 
     return null
   }
 
-  private fun makeInitialBooking(appointment: ActionPlanAppointment, appointmentTime: OffsetDateTime, durationInMinutes: Int): Long {
-    val resourceUrl = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
-      .path(interventionsUIViewAppointment)
-      .buildAndExpand(appointment.actionPlan.referral.id)
+  private fun makeBooking(serviceCrn: String, contextId: Long, appointmentRequestDTO: AppointmentRequestDTO, communityApiUrl: String): Long {
+
+    val communityApiBookAppointmentPath = UriComponentsBuilder.fromPath(communityApiUrl)
+      .buildAndExpand(serviceCrn, contextId, integrationContext)
       .toString()
 
-    val appointmentCreateRequestDTO = AppointmentCreateRequestDTO(
+    val response = communityAPIClient.makeSyncPostRequest(communityApiBookAppointmentPath, appointmentRequestDTO, AppointmentResponseDTO::class.java)
+    logger.debug("Requested booking for appointment. Returned appointment id: $response")
+
+    return response.appointmentId
+  }
+
+  private fun buildAppointmentCreateRequestDTO(appointment: ActionPlanAppointment, appointmentTime: OffsetDateTime, durationInMinutes: Int): AppointmentCreateRequestDTO {
+    val resourceUrl = buildReferralResourceUrl(appointment)
+
+    return AppointmentCreateRequestDTO(
       contractType = "ACC", // Fixme: Using only contract type Accommodation til contract type changes are in
       referralStart = appointment.actionPlan.referral.sentAt!!,
       appointmentStart = appointmentTime,
@@ -51,25 +75,41 @@ class CommunityAPIBookingService(
       notes = resourceUrl,
       countsTowardsRarDays = true, // Fixme: For assessment booking this should be false and will pass in when assessment booking is done
     )
+  }
 
-    val referral = appointment.actionPlan.referral
-    val communityApiBookAppointmentPath = UriComponentsBuilder.fromPath(communityApiBookAppointmentLocation)
-      .buildAndExpand(referral.serviceUserCRN, referral.relevantSentenceId!!, integrationContext)
+  private fun buildAppointmentRescheduleRequestDTO(appointmentTime: OffsetDateTime, durationInMinutes: Int): AppointmentRescheduleRequestDTO {
+
+    return AppointmentRescheduleRequestDTO(
+      updatedAppointmentStart = appointmentTime,
+      updatedAppointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
+      initiatedByServiceProvider = true, // fixme - needs to come from the user - defaulted to SP Initiated Reschedule
+    )
+  }
+
+  private fun buildReferralResourceUrl(existingAppointment: ActionPlanAppointment): String {
+    return UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
+      .path(interventionsUIViewAppointment)
+      .buildAndExpand(existingAppointment.actionPlan.referral.id)
       .toString()
-
-    val response = communityAPIClient.makeSyncPostRequest(communityApiBookAppointmentPath, appointmentCreateRequestDTO, AppointmentCreateResponseDTO::class.java)
-    logger.debug("Requested booking for appointment. Returned appointment id: $response")
-
-    return response.appointmentId
   }
 
   fun isInitialBooking(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?): Boolean =
     isTimingSpecified(appointmentTime, durationInMinutes) &&
       !isTimingSpecified(existingAppointment.appointmentTime, existingAppointment.durationInMinutes)
 
+  fun isRescheduleBooking(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime?, durationInMinutes: Int?): Boolean =
+    isTimingSpecified(appointmentTime, durationInMinutes) &&
+      isTimingSpecified(existingAppointment.appointmentTime, existingAppointment.durationInMinutes) &&
+      isDifferentTimings(existingAppointment, appointmentTime!!, durationInMinutes!!)
+
   fun isTimingSpecified(appointmentTime: OffsetDateTime?, durationInMinutes: Int?): Boolean =
     appointmentTime != null && durationInMinutes != null
+
+  fun isDifferentTimings(existingAppointment: ActionPlanAppointment, appointmentTime: OffsetDateTime, durationInMinutes: Int): Boolean =
+    !(existingAppointment.appointmentTime!!.isEqual(appointmentTime) && existingAppointment!!.durationInMinutes == durationInMinutes)
 }
+
+abstract class AppointmentRequestDTO
 
 data class AppointmentCreateRequestDTO(
   val contractType: String,
@@ -79,8 +119,14 @@ data class AppointmentCreateRequestDTO(
   val officeLocationCode: String,
   val notes: String,
   val countsTowardsRarDays: Boolean,
-)
+) : AppointmentRequestDTO()
 
-data class AppointmentCreateResponseDTO(
+data class AppointmentRescheduleRequestDTO(
+  val updatedAppointmentStart: OffsetDateTime?,
+  val updatedAppointmentEnd: OffsetDateTime?,
+  val initiatedByServiceProvider: Boolean,
+) : AppointmentRequestDTO()
+
+data class AppointmentResponseDTO(
   @NotNull val appointmentId: Long
 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,7 @@ community-api:
     sent-referral: "/secure/offenders/crn/{crn}/referral/start/context/{contextName}"
     ended-referral: "/secure/offenders/crn/{crn}/referral/end/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
+    reschedule-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/reschedule/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
   appointments:
     office-location: CRSEXTL

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentCreateRequestDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentCreateResponseDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentResponseDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingMemoryAppender
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -126,7 +126,7 @@ class CommunityAPIClientTest {
       .build()
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.just(clientResponse))
 
-    val response = communityAPIClient.makeSyncPostRequest("/uriValue", appointmentCreateRequest, AppointmentCreateResponseDTO::class.java)
+    val response = communityAPIClient.makeSyncPostRequest("/uriValue", appointmentCreateRequest, AppointmentResponseDTO::class.java)
 
     assertThat(response.appointmentId).isEqualTo(1234L)
 
@@ -147,7 +147,7 @@ class CommunityAPIClientTest {
     whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException("A problem"))
 
     val exception = Assertions.assertThrows(RuntimeException::class.java) {
-      communityAPIClient.makeSyncPostRequest("/uriValue", appointmentCreateRequest, AppointmentCreateResponseDTO::class.java)
+      communityAPIClient.makeSyncPostRequest("/uriValue", appointmentCreateRequest, AppointmentResponseDTO::class.java)
     }
     assertThat(exception.localizedMessage).isEqualTo("A problem")
 
@@ -170,7 +170,7 @@ class CommunityAPIClientTest {
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.just(clientResponse))
 
     val exception = Assertions.assertThrows(WebClientResponseException::class.java) {
-      communityAPIClient.makeSyncPostRequest("/uriValue", appointmentCreateRequest, AppointmentCreateResponseDTO::class.java)
+      communityAPIClient.makeSyncPostRequest("/uriValue", appointmentCreateRequest, AppointmentResponseDTO::class.java)
     }
     assertThat(exception.localizedMessage).isEqualTo("400 Bad Request from UNKNOWN ")
     assertThat(exception.responseBodyAsString).isEqualTo("There was a problem Houston")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -72,6 +73,17 @@ internal class CommunityAPIBookingServiceTest {
     communityAPIBookingService.book(appointment, now, 45)
 
     verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+  }
+
+  @Test
+  fun `does not reschedule an appointment when timings are same`() {
+    val now = now()
+    val deliusAppointmentId = 999L
+    val appointment = makeAppointment(now, now.plusDays(1), 60, deliusAppointmentId)
+
+    communityAPIBookingService.book(appointment, now.plusDays(1), 60)
+
+    verifyNoMoreInteractions(communityAPIClient)
   }
 
   @Test


### PR DESCRIPTION
What does this pull request do?
Rescheduling an appointment such that an existing booking in Delius is changed. This PR covers the call community-api to make those changes in Delius by closing the old booking and making a replacement.

What is the intent behind these changes?
As part of Referral Service Delivery, service providers make appointments and sometimes need to reschedule. This feature facilitates the rescheduling in Delius.

Breaking Changes?
None