### PR TITLE
use contract type to generate reference number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -287,10 +287,10 @@ class ReferralService(
   }
 
   private fun generateReferenceNumber(referral: Referral): String? {
-    val category = referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.elementAt(0).name
+    val type = referral.intervention.dynamicFrameworkContract.contractType.name
 
     for (i in 1..maxReferenceNumberTries) {
-      val candidate = referenceGenerator.generate(category)
+      val candidate = referenceGenerator.generate(type)
       if (!referralRepository.existsByReferenceNumber(candidate))
         return candidate
       else

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -346,7 +346,7 @@ class ReferralServiceTest @Autowired constructor(
     val draft1 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
     val draft2 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
 
-    whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.serviceCategories.elementAt(0).name))
+    whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.name))
       .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
 
     val sent1 = referralService.sendDraftReferral(draft1, user)


### PR DESCRIPTION
## What does this pull request do?

use contract type to generate reference number

## What is the intent behind these changes?

the reference number generator _used to use_ two letter abbreviations of the service category previously e.g. accommodation = AC. now that contracts are defined against contract types, these should be used instead e.g. women's services = WO.
