### PR TITLE
IC-951: Turn on web application firewall on live envs

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -7,8 +7,16 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    {{- if .Values.env_details.contains_live_data }}
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+    {{- else }}
+    kubernetes.io/ingress.class: "nginx"
+    {{- end }}
 spec:
   tls:
   {{- range .Values.ingress.hosts }}

--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
     {{- else }}
     kubernetes.io/ingress.class: "nginx"
     {{- end }}


### PR DESCRIPTION
## What does this pull request do?

More details: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html

## What is the intent behind these changes?

Our agreements with the security team at the beginning was that we can go live without IP allow listing if we turn on Web Application Firewall. See the link above on why `mod_security` setting on the ingress achieves this.