### PR TITLE
IC-1769 - add the intervention id to the referral to allow looking up contract type for a referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ContractTypeDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ContractTypeDTO.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+data class ContractTypeDTO(
+  val code: String,
+  val name: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -31,6 +31,7 @@ data class DraftReferralDTO(
   val serviceUser: ServiceUserDTO? = null,
   val serviceProvider: ServiceProviderDTO? = null,
   val relevantSentenceId: Long? = null,
+  val interventionId: UUID? = null,
 ) {
   companion object {
     fun from(referral: Referral): DraftReferralDTO {
@@ -56,7 +57,8 @@ data class DraftReferralDTO(
         relevantSentenceId = referral.relevantSentenceId,
         // TODO: remove this once cohort referrals changes are complete
         serviceCategoryId = if (referral.selectedServiceCategories?.isNotEmpty() == true) referral.selectedServiceCategories!!.elementAt(0).id else null,
-        serviceCategoryIds = referral.selectedServiceCategories?.map { it.id }
+        serviceCategoryIds = referral.selectedServiceCategories?.map { it.id },
+        interventionId = referral.intervention.id,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/InterventionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/InterventionDTO.kt
@@ -13,6 +13,7 @@ data class InterventionDTO(
   val serviceCategories: List<ServiceCategoryFullDTO>,
   val serviceProvider: ServiceProviderDTO,
   val eligibility: ContractEligibilityDTO,
+  val contractType: ContractTypeDTO,
 ) {
   companion object {
     fun from(intervention: Intervention, pccRegions: List<PCCRegion>): InterventionDTO {
@@ -31,6 +32,7 @@ data class InterventionDTO(
           contract.allowsFemale,
           contract.allowsMale,
         ),
+        contractType = ContractTypeDTO(intervention.dynamicFrameworkContract.contractType.code, intervention.dynamicFrameworkContract.contractType.name),
       )
     }
   }


### PR DESCRIPTION
## What does this pull request do?

add the intervention id to the referral to allow looking up contract type for a referral

## What is the intent behind these changes?

allow the UI to determine the contract type for the referral
