### PR TITLE
Actually stop on errors in SQL report validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           name: Validate report SQLs
           command: |
             for sqlfile in helm_deploy/hmpps-interventions-service/reports/*.sql; do
-              PGPASSWORD="$POSTGRES_PASSWORD" psql -U"postgres" "postgresql://localhost:5432/$POSTGRES_DB" < "$sqlfile"
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -U"postgres" "postgresql://localhost:5432/$POSTGRES_DB" -f "$sqlfile"
             done
 
   publish_data:

--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -37,7 +37,7 @@ COPY (
     referral r
     JOIN intervention i ON (r.intervention_id = i.id)
     JOIN dynamic_framework_contract c ON (i.dynamic_framework_contract_id = c.id)
-    JOIN service_provider prime ON (c.service_provider_id = prime.id)
+    JOIN service_provider prime ON (c.prime_provider_id = prime.id)
     LEFT JOIN action_plan ap ON (ap.referral_id = r.id) --❗️assumes a SINGLE action plan
     LEFT JOIN end_of_service_report eosr ON (eosr.referral_id = r.id)
   WHERE


### PR DESCRIPTION
## What does this pull request do?

Actually stop on errors in SQL report validation. Turns out I assumed `psql` would exit with a non-zero status on script errors -- well, it doesn't 😅 TIL

**Before**
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/2106/workflows/25696979-a1a7-4245-96e2-a3847e66da78/jobs/6902
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/1526295/119341852-2c52cf80-bc8c-11eb-85a8-199ad2277a27.png">

**After**
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/2338/workflows/f9b7540d-4b30-4fad-97ce-4690aa2fb1b2/jobs/7932
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/1526295/119341829-24932b00-bc8c-11eb-80ed-8e0ba65405d1.png">

🐛 And also fixes the cause of the error in 1856234c3d2b6ef0f00be81f64c9885628bfa6ef

## What is the intent behind these changes?

To make sure we actually validate the SQL reports 😅 