### PR TITLE
Switch from cmd arg

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -19,8 +19,6 @@ spec:
             args: ["sh", "-c", "python3 /data-engineering-data-extractor/modules/extract_table_names.py && python3 /data-engineering-data-extractor/modules/extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             {{ end }}
             env:
-              - name: LOCAL_EXPORT_DESTINATION
-                value: export
               - name: PGPORT
                 value: "5432"
               - name: PGHOST

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -14,9 +14,9 @@ spec:
             image: ministryofjustice/data-engineering-data-extractor:develop
             imagePullPolicy: Always
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
-            command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
+            args: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}
-            command: ["sh", "-c", "python3 /data-engineering-data-extractor/modules/extract_table_names.py && python3 /data-engineering-data-extractor/modules/extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
+            args: ["sh", "-c", "python3 /data-engineering-data-extractor/modules/extract_table_names.py && python3 /data-engineering-data-extractor/modules/extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             {{ end }}
             env:
               - name: LOCAL_EXPORT_DESTINATION

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -16,7 +16,7 @@ spec:
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
             args: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}
-            args: ["sh", "-c", "python3 /data-engineering-data-extractor/modules/extract_table_names.py && python3 /data-engineering-data-extractor/modules/extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
+            args: ["sh", "-c", "extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             {{ end }}
             env:
               - name: PGPORT

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -27,9 +27,9 @@ spec:
           - name: data-extractor-reporting
             image: ministryofjustice/data-engineering-data-extractor:develop
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
-            command: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
+            args: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}
-            command: ["sh", "-c", "mkdir -p 'export/csv/reports' && psql --file=/reports/crs_performance_report.sql > 'export/csv/reports/crs_performance_report.csv' && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            args: ["sh", "-c", "mkdir -p 'export/csv/reports' && psql --file=/reports/crs_performance_report.sql > 'export/csv/reports/crs_performance_report.csv' && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
             {{ end }}
             volumeMounts:
             - name: data-extractor-reports

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -39,8 +39,6 @@ spec:
             env:
               - name: USE_STATIC_LOCATION
                 value: "true"
-              - name: LOCAL_EXPORT_DESTINATION
-                value: export
               - name: PGHOST
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## What does this pull request do?

Switches the reporting and analytical jobs to supply arguments rather than commands to the docker container. Plus, removes the env variables 'LOCAL_EXPORT_DESTINATION' as that is now set as part of the entry point wrapper.

For the analytical job, it switches to calling the python scripts directly.

## What is the intent behind these changes?

To ensure the entry point wrapper can set env variables before running the supplied arguments.


