### PR TITLE
Add observable IDs to the messages on group configuration issues

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -48,6 +48,8 @@ class ServiceProviderAccessScopeMapper(
 
     val contracts = getContracts(contractGroups, configErrors)
 
+    // FIXME we also need to remove contracts which do not belong to the user's provider
+
     if (configErrors.isNotEmpty()) {
       throw AccessError(errorMessage, configErrors)
     }
@@ -84,8 +86,9 @@ class ServiceProviderAccessScopeMapper(
       emptyList()
     } else {
       val contracts = dynamicFrameworkContractRepository.findAllByContractReferenceIn(contractGroups)
-      if (contracts.isEmpty()) {
-        configErrors.add("user has no valid contract groups configured")
+      val removedContracts = contractGroups.subtract(contracts.map(DynamicFrameworkContract::contractReference))
+      for (removedContract in removedContracts) {
+        configErrors.add("contract '$removedContract' does not exist in the interventions database")
       }
       contracts
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -68,9 +68,10 @@ class ServiceProviderAccessScopeMapper(
         null
       }
       else -> {
-        val provider = serviceProviderRepository.findByIdOrNull(serviceProviderGroups[0])
+        val providerGroupCode = serviceProviderGroups[0]
+        val provider = serviceProviderRepository.findByIdOrNull(providerGroupCode)
         if (provider == null) {
-          configErrors.add("service provider id does not exist in the interventions database")
+          configErrors.add("service provider id '$providerGroupCode' does not exist in the interventions database")
         }
         provider
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -162,7 +162,7 @@ class ListReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "service provider id does not exist in the interventions database",
+      "service provider id 'HOME_TRUST' does not exist in the interventions database",
       "user has no valid contract groups configured"
       ]}
       """.trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -163,7 +163,7 @@ class ListReferralEndpoints : IntegrationTestBase() {
       """
       {"accessErrors": [
       "service provider id 'HOME_TRUST' does not exist in the interventions database",
-      "user has no valid contract groups configured"
+      "contract '0999' does not exist in the interventions database"
       ]}
       """.trimIndent()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -132,7 +132,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       """
       {"accessErrors": [
       "service provider id 'BETTER_LTD' does not exist in the interventions database",
-      "user has no valid contract groups configured"
+      "contract '0002' does not exist in the interventions database"
       ]}
       """.trimIndent()
     )
@@ -204,7 +204,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "user has no valid contract groups configured"
+      "contract '0002' does not exist in the interventions database"
       ]}
       """.trimIndent()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -131,7 +131,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "service provider id does not exist in the interventions database",
+      "service provider id 'BETTER_LTD' does not exist in the interventions database",
       "user has no valid contract groups configured"
       ]}
       """.trimIndent()
@@ -230,7 +230,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
       """
       {"accessErrors": [
       "no service provider groups associated with user",
-      "no contract groups associated with user",
+      "no contract groups associated with user"
       ]}
       """.trimIndent()
     )


### PR DESCRIPTION
## What does this pull request do?

Essentially, add IDs to these `AccessError` reasons:

```diff
- configErrors.add("service provider id does not exist in the interventions database")
+ configErrors.add("service provider id '$providerGroupCode' does not exist in the interventions database")
```

```diff
- configErrors.add("user has no valid contract groups configured")
+ configErrors.add("contract '$removedContract' does not exist in the interventions database")
```

It also adds a **FIXME** to `ServiceProviderAccessScopeMapper.kt` about excluding contracts that belong to other providers 

## What is the intent behind these changes?

So when someone has a config error, we don't have to

1. find out the user id
2. look up the groups of the user id from hmpps-auth
3. figure out what it was

but have this information at hand (it's not sensitive)

It will also be useful for displaying on a "what can I have access to" page