### PR TITLE
Configure NDMIS report job to overwrite reports

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -37,6 +37,8 @@ spec:
               readOnly: true
               subPath: crs_performance_report.sql
             env:
+              - name: USE_STATIC_LOCATION
+                value: "true"
               - name: LOCAL_EXPORT_DESTINATION
                 value: export
               - name: PGHOST


### PR DESCRIPTION


## What does this pull request do?

Adds config to NDMIS report job so it always produces the same file in the same place

## What is the intent behind these changes?

The default behaviour of the data-extractor tool is to put each file in
an `extraction-timestamp=xyz...` folder, so that every snapshot has its
own location

The ask from the NDMIS team was to avoid doing this and always put the
files in the same location

After talking with @green-digger, we're going to use this env variable
as configuration for this toggle
