### PR TITLE
IC-1808: 🤖 Get PRs for out of date and insecure dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this pull request do?

Turns on dependabot on the project

## What is the intent behind these changes?

To get library upgrades in the pipeline quickly and painlessly (given we trust our tests)

History: I _think_ I looked at dependabot and it didn't support Kotlin flavoured Gradle. I might have been dazed. Anyhow, it works now!