### PR TITLE
DAPI-177 Provide Referral Id as part of requests to community-api so ensure a unique NSI can be located

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -7,6 +7,7 @@ import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 import java.time.OffsetDateTime
+import java.util.UUID
 import javax.validation.constraints.NotNull
 
 @Service
@@ -69,6 +70,7 @@ class CommunityAPIBookingService(
     return AppointmentCreateRequestDTO(
       contractType = appointment.actionPlan.referral.intervention.dynamicFrameworkContract.contractType.code,
       referralStart = appointment.actionPlan.referral.sentAt!!,
+      referralId = appointment.actionPlan.referral.id,
       appointmentStart = appointmentTime,
       appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
       officeLocationCode = officeLocation,
@@ -114,6 +116,7 @@ abstract class AppointmentRequestDTO
 data class AppointmentCreateRequestDTO(
   val contractType: String,
   val referralStart: OffsetDateTime,
+  val referralId: UUID,
   val appointmentStart: OffsetDateTime,
   val appointmentEnd: OffsetDateTime,
   val officeLocationCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.time.OffsetDateTime
+import java.util.UUID
 
 interface CommunityAPIService {
   fun getNotes(referral: Referral, url: String, description: String): String {
@@ -76,6 +77,7 @@ class CommunityAPIReferralEventService(
       event.referral.intervention.dynamicFrameworkContract.contractType.code,
       event.referral.sentAt!!,
       event.referral.relevantSentenceId!!,
+      event.referral.id,
       getNotes(event.referral, url, "Referral Sent"),
     )
 
@@ -92,6 +94,7 @@ class CommunityAPIReferralEventService(
       event.referral.sentAt!!,
       event.referral.concludedAt!!,
       event.referral.relevantSentenceId!!,
+      event.referral.id,
       event.type.name,
       getNotes(event.referral, url, "Referral Ended"),
     )
@@ -135,6 +138,7 @@ class CommunityAPIEndOfServiceReportEventService(
     val request = NotificationCreateRequestDTO(
       event.endOfServiceReport.referral.intervention.dynamicFrameworkContract.contractType.code,
       referral.sentAt!!,
+      referral.id,
       event.endOfServiceReport.submittedAt!!,
       getNotes(referral, url, "End of Service Report Submitted"),
     )
@@ -178,6 +182,7 @@ class CommunityAPIActionPlanEventService(
     val request = NotificationCreateRequestDTO(
       referral.intervention.dynamicFrameworkContract.contractType.code,
       referral.sentAt!!,
+      referral.id,
       event.actionPlan.submittedAt!!,
       getNotes(referral, url, "Action Plan Submitted"),
     )
@@ -228,6 +233,7 @@ data class ReferRequest(
   val contractType: String,
   val startedAt: OffsetDateTime,
   val sentenceId: Long,
+  val referralId: UUID,
   val notes: String,
 )
 
@@ -236,6 +242,7 @@ data class ReferralEndRequest(
   val startedAt: OffsetDateTime,
   val endedAt: OffsetDateTime,
   val sentenceId: Long,
+  val referralId: UUID,
   val endType: String,
   val notes: String,
 )
@@ -243,6 +250,7 @@ data class ReferralEndRequest(
 data class NotificationCreateRequestDTO(
   val contractType: String,
   val referralStart: OffsetDateTime,
+  val referralId: UUID,
   val contactDateTime: OffsetDateTime,
   val notes: String
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -197,6 +197,7 @@ class CommunityAPIClientTest {
   private val appointmentCreateRequest = AppointmentCreateRequestDTO(
     contractType = "ACC",
     referralStart = OffsetDateTime.now(),
+    referralId = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
     appointmentStart = OffsetDateTime.now(),
     appointmentEnd = OffsetDateTime.now(),
     officeLocationCode = "CRSEXTL",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIActionPlanServiceTest.kt
@@ -42,6 +42,7 @@ class CommunityAPIActionPlanServiceTest {
       NotificationCreateRequestDTO(
         "ACC",
         sentAtDefault,
+        event.actionPlan.referral.id,
         submittedAtDefault,
         "Action Plan Submitted for Accommodation Referral XX1234 with Prime Provider Harmony Living\n" +
           "http://testUrl/probation-practitioner/submit-action-plan/${event.actionPlan.referral.id}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -46,7 +46,16 @@ internal class CommunityAPIBookingServiceTest {
     val uri = "/appt/X1/123/CRS"
     val notes = "Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
       "http://url/view/${appointment.actionPlan.referral.id}"
-    val request = AppointmentCreateRequestDTO("ACC", now, now.plusMinutes(60), now.plusMinutes(120), "CRSEXTL", notes = notes, true)
+    val request = AppointmentCreateRequestDTO(
+      "ACC",
+      now,
+      appointment.actionPlan.referral.id,
+      now.plusMinutes(60),
+      now.plusMinutes(120),
+      "CRSEXTL",
+      notes = notes,
+      true
+    )
     val response = AppointmentResponseDTO(1234L)
 
     whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportServiceTest.kt
@@ -30,13 +30,15 @@ class CommunityAPIEndOfServiceReportServiceTest {
   @Test
   fun `notify submitted end of service report`() {
 
-    communityAPIService.onApplicationEvent(getEvent(SUBMITTED))
+    val event = getEvent(SUBMITTED)
+    communityAPIService.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "/secure/offenders/crn/X123456/sentence/1234/notifications/context/commissioned-rehabilitation-services",
       NotificationCreateRequestDTO(
         "ACC",
         sentAtDefault,
+        event.endOfServiceReport.referral.id,
         submittedAtDefault,
         "End of Service Report Submitted for Accommodation Referral XX1234 with Prime Provider Harmony Living\n" +
           "http://testUrl/probation-practitioner/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
@@ -33,7 +33,8 @@ class CommunityAPIReferralServiceTest {
   @Test
   fun `notify sent referral`() {
 
-    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.SENT))
+    val event = getEvent(ReferralEventType.SENT)
+    communityAPIService.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/start/context/commissioned-rehabilitation-services",
@@ -41,6 +42,7 @@ class CommunityAPIReferralServiceTest {
         "ACC",
         sentAtDefault,
         123456789,
+        event.referral.id,
         "Referral Sent for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/referral/sent/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
       )
@@ -50,7 +52,8 @@ class CommunityAPIReferralServiceTest {
   @Test
   fun `notify cancelled referral`() {
 
-    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.CANCELLED, concludedAtDefault))
+    val event = getEvent(ReferralEventType.CANCELLED, concludedAtDefault)
+    communityAPIService.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
@@ -59,6 +62,7 @@ class CommunityAPIReferralServiceTest {
         sentAtDefault,
         concludedAtDefault,
         123456789,
+        event.referral.id,
         "CANCELLED",
         "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/referral/progress/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
@@ -69,7 +73,8 @@ class CommunityAPIReferralServiceTest {
   @Test
   fun `notify prematurely ended referral`() {
 
-    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault, endOfServiceReport))
+    val event = getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault, endOfServiceReport)
+    communityAPIService.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
@@ -78,6 +83,7 @@ class CommunityAPIReferralServiceTest {
         sentAtDefault,
         concludedAtDefault,
         123456789,
+        event.referral.id,
         "PREMATURELY_ENDED",
         "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
@@ -88,7 +94,8 @@ class CommunityAPIReferralServiceTest {
   @Test
   fun `notify completed referral`() {
 
-    communityAPIService.onApplicationEvent(getEvent(ReferralEventType.COMPLETED, concludedAtDefault, endOfServiceReport))
+    val event = getEvent(ReferralEventType.COMPLETED, concludedAtDefault, endOfServiceReport)
+    communityAPIService.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
@@ -97,6 +104,7 @@ class CommunityAPIReferralServiceTest {
         sentAtDefault,
         concludedAtDefault,
         123456789,
+        event.referral.id,
         "COMPLETED",
         "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",


### PR DESCRIPTION
**What does this pull request do?**
There is an edge case when more that one Referral may be created in R&M that appear to cover the same Intervention, i.e. are for the same CRN and Sentence, cover the same Contract Type (e.g. Personal Wellbeing) and start on the same date. Prior to this change they would both be tied to the same NSI in Delius. After this change, each can result in its own NSI using the ReferralId (in the form of an URN) to distinguish them in community-api. 

**What is the intent behind these changes?**
To ensure that should multiple referrals be created which appear to be the same, they can be accounted for correctly by the calculations carried out in Delius.
