### PR TITLE
IC-1777: Complete production helm values

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/NOTES.txt
+++ b/helm_deploy/hmpps-interventions-service/templates/NOTES.txt
@@ -1,6 +1,4 @@
 Application is running at:
-{{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-  https://{{ .host }}{{ $.Values.ingress.path }}
-{{- end }}
+  https://{{ .host }}/
 {{- end }}

--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "app.fullname" . -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
@@ -40,4 +39,3 @@ spec:
               serviceName: data-dictionary
               servicePort: http
   {{- end }}
-{{- end }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,7 +11,6 @@ image:
     dataDictionary: 8080
 
 ingress:
-  enabled: true
   hosts:
     - host: hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,7 +11,6 @@ image:
     dataDictionary: 8080
 
 ingress:
-  enabled: true
   hosts:
     - host: hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,6 +1,3 @@
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 replicaCount: 4
 
 image:
@@ -12,7 +9,7 @@ image:
 
 ingress:
   hosts:
-    - host: hmpps-interventions-service-prod.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
 
 env_details:
   contains_live_data: true
@@ -20,4 +17,6 @@ env_details:
 env:
   JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+  INTERVENTIONSUI_BASEURL: "https://refer-monitor-intervention.service.justice.gov.uk"
+  COMMUNITYAPI_BASEURL: "https://community-api-secure.probation.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "prod"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,7 +11,6 @@ image:
     dataDictionary: 8080
 
 ingress:
-  enabled: true
   hosts:
     - host: hmpps-interventions-service-prod.apps.live-1.cloud-platform.service.justice.gov.uk
 

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -8,10 +8,8 @@ image:
     dataDictionary: 8080
 
 ingress:
-  enabled: true
   hosts:
     - host: hmpps-interventions-service-research.apps.live-1.cloud-platform.service.justice.gov.uk
-  path: /
 
 env_details:
   contains_live_data: false


### PR DESCRIPTION
## What does this pull request do?

Completes production helm values. It doesn't deploy to production yet, just adds the remaining necessary configuration. Can be manually deployed by

```
$ cd helm_deploy/
$ helm upgrade hmpps-interventions-service hmpps-interventions-service \
  --wait --values=values-prod.yaml --namespace=hmpps-interventions-prod \
  --set "image.tag={get latest image from quay.io}"
```

"get latest image from quay.io" == check https://quay.io/repository/hmpps/hmpps-interventions-service?tag=latest&tab=tags

Also removes the ingress flag, they it's always the same

## What is the intent behind these changes?

Prepare for production deployment