### PR TITLE
IC-1801: Amend CRS NDMIS report to support v1 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,17 @@ If you want to populate your local database with seeded values from [local data 
 ```
 SPRING_PROFILES_ACTIVE=local,seed ./gradlew bootRun
 ```
+
+### Testing cronjobs
+
+Run the CronJob as a one-off job with:
+
+```
+kubectl create job --from=cronjob/{name} "{any name for the one-off job}" --namespace=hmpps-interventions-{yournamespace}
+```
+
+For example:
+
+```
+kubectl create job --from=cronjob.batch/data-extractor-reporting data-extractor-reporting-once --namespace=hmpps-interventions-preprod
+```

--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -3,7 +3,7 @@ COPY (
     r.reference_number      AS referral_ref,
     r.id                    AS referral_id,
     c.contract_reference    AS crs_contract_reference,
-    'coming-later'          AS crs_contract_type,
+    ct.code                 AS crs_contract_type,
     prime.id                AS crs_provider_id,
     r.sent_by_id            AS referring_officer_id,
     r.relevant_sentence_id  AS relevant_sentence_id,
@@ -37,6 +37,7 @@ COPY (
     referral r
     JOIN intervention i ON (r.intervention_id = i.id)
     JOIN dynamic_framework_contract c ON (i.dynamic_framework_contract_id = c.id)
+    JOIN contract_type ct ON (c.contract_type_id = ct.id)
     JOIN service_provider prime ON (c.prime_provider_id = prime.id)
     LEFT JOIN action_plan ap ON (ap.referral_id = r.id) --❗️assumes a SINGLE action plan
     LEFT JOIN end_of_service_report eosr ON (eosr.referral_id = r.id)

--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -13,7 +13,6 @@ COPY (
     'coming-later'          AS date_saa_attended,
     ap.submitted_at         AS date_first_action_plan_submitted,
     'coming-later'          AS date_of_first_action_plan_approval,
-    r.assigned_to_id        AS caseworker_id,
     (
       select min(app.appointment_time)
       from action_plan_appointment app

--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -1,4 +1,10 @@
 COPY (
+  WITH attended_sessions AS (
+      select count(action_plan_id) AS attended, action_plan_id
+      from action_plan_appointment
+      where attended in ('YES', 'LATE')
+      group by action_plan_id
+  )
   SELECT
     r.reference_number      AS referral_ref,
     r.id                    AS referral_id,
@@ -25,12 +31,16 @@ COPY (
     )                       AS outcomes_to_be_achieved_count,
     'coming-later'          AS outcomes_progress,
     ap.number_of_sessions   AS count_of_sessions_expected,
-    (
-      select count(app.id)
-      from action_plan_appointment app
-      where app.action_plan_id = ap.id and attended in ('YES', 'LATE')
-    )                       AS count_of_sessions_attended,
+    s.attended              AS count_of_sessions_attended,
     r.concluded_at          AS date_intervention_ended,
+    (
+      CASE
+        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NULL THEN 'cancelled'
+        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NOT NULL AND ap.number_of_sessions > s.attended THEN 'ended'
+        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NOT NULL AND ap.number_of_sessions = s.attended THEN 'completed'
+        ELSE NULL
+      END
+    )                       AS intervention_end_reason,
     eosr.submitted_at       AS date_end_of_service_report_submitted
   FROM
     referral r
@@ -39,6 +49,7 @@ COPY (
     JOIN contract_type ct ON (c.contract_type_id = ct.id)
     JOIN service_provider prime ON (c.prime_provider_id = prime.id)
     LEFT JOIN action_plan ap ON (ap.referral_id = r.id) --❗️assumes a SINGLE action plan
+    LEFT JOIN attended_sessions s ON (s.action_plan_id = ap.id) --❗️should be linked to referrals instead, sessions are static
     LEFT JOIN end_of_service_report eosr ON (eosr.referral_id = r.id)
   WHERE
     r.sent_at IS NOT NULL


### PR DESCRIPTION
## What does this pull request do?

Amend CRS NDMIS report to support v1 schema:

- fills out `contract_type` as we have it now
- removes `caseworker_id`
- adds `intervention_end_reason`

## What is the intent behind these changes?

To satisfy the report schema, which defines these fields:
```
referral_ref
referral_id
crs_contract_reference
crs_contract_type
crs_provider_id
referring_officer_id
relevant_sentence_id
service_user_crn
date_referral_received
date_saa_booked
date_saa_attended
date_first_action_plan_submitted
date_of_first_action_plan_approval
date_of_first_session
outcomes_to_be_achieved_count
outcomes_progress
count_of_sessions_expected
count_of_sessions_attended
date_intervention_ended
intervention_end_reason
date_end_of_service_report_submitted
```
