### PR TITLE
DAPI-1824 Call to community-api for referral send is synchronous and made services transactions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -13,8 +13,10 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.UUID.randomUUID
 import javax.persistence.EntityNotFoundException
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class ActionPlanService(
   val authUserRepository: AuthUserRepository,
   val referralRepository: ReferralRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -56,7 +56,6 @@ class AppointmentsService(
     }
   }
 
-  @Transactional
   fun updateAppointment(
     actionPlanId: UUID,
     sessionNumber: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -15,8 +15,10 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityNotFoundException
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class AppointmentsService(
   val actionPlanAppointmentRepository: ActionPlanAppointmentRepository,
   val actionPlanRepository: ActionPlanRepository,
@@ -54,6 +56,7 @@ class AppointmentsService(
     }
   }
 
+  @Transactional
   fun updateAppointment(
     actionPlanId: UUID,
     sessionNumber: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -8,9 +8,11 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.Communit
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanAppointment
 import java.time.OffsetDateTime
 import java.util.UUID
+import javax.transaction.Transactional
 import javax.validation.constraints.NotNull
 
 @Service
+@Transactional
 class CommunityAPIBookingService(
   @Value("\${appointments.bookings.enabled}") private val bookingsEnabled: Boolean,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralService.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import mu.KLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.transaction.Transactional
+import javax.validation.constraints.NotNull
+
+@Service
+@Transactional
+class CommunityAPIReferralService(
+  @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
+  @Value("\${interventions-ui.locations.sent-referral}") private val interventionsUISentReferralLocation: String,
+  @Value("\${community-api.locations.sent-referral}") private val communityAPISentReferralLocation: String,
+  @Value("\${community-api.integration-context}") private val integrationContext: String,
+  val communityAPIClient: CommunityAPIClient,
+) : CommunityAPIService {
+  companion object : KLogging()
+
+  fun send(referral: Referral) {
+    val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
+      .path(interventionsUISentReferralLocation)
+      .buildAndExpand(referral.id)
+      .toString()
+
+    postReferralStartRequest(referral, url)
+  }
+
+  private fun postReferralStartRequest(referral: Referral, url: String) {
+    val referRequest = ReferralSentRequest(
+      referral.intervention.dynamicFrameworkContract.contractType.code,
+      referral.sentAt!!,
+      referral.relevantSentenceId!!,
+      referral.id,
+      getNotes(referral, url, "Referral Sent"),
+    )
+
+    val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPISentReferralLocation)
+      .buildAndExpand(referral.serviceUserCRN, integrationContext)
+      .toString()
+
+    communityAPIClient.makeSyncPostRequest(communityApiSentReferralPath, referRequest, ReferralSentResponseDTO::class.java)
+  }
+}
+
+data class ReferralSentRequest(
+  val contractType: String,
+  val startedAt: OffsetDateTime,
+  val sentenceId: Long,
+  val referralId: UUID,
+  val notes: String,
+)
+
+data class ReferralSentResponseDTO(
+  @NotNull val nsiId: Long
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -42,12 +42,10 @@ class CommunityAPIReferralEventService(
   override fun onApplicationEvent(event: ReferralEvent) {
     when (event.type) {
       ReferralEventType.SENT -> {
-        val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
-          .path(interventionsUISentReferralLocation)
-          .buildAndExpand(event.referral.id)
-          .toString()
-
-        postReferralStartRequest(event, url)
+        // Has become a synchronous call so no action required here
+        // This is due to the link to delius not being robust at the moment
+        // As soon as it is made resilient this route will be reinstated
+        // Functionality moved to CommunityApiReferralService
       }
       ReferralEventType.CANCELLED,
       -> {
@@ -70,22 +68,6 @@ class CommunityAPIReferralEventService(
       }
       else -> {}
     }
-  }
-
-  private fun postReferralStartRequest(event: ReferralEvent, url: String) {
-    val referRequest = ReferRequest(
-      event.referral.intervention.dynamicFrameworkContract.contractType.code,
-      event.referral.sentAt!!,
-      event.referral.relevantSentenceId!!,
-      event.referral.id,
-      getNotes(event.referral, url, "Referral Sent"),
-    )
-
-    val communityApiSentReferralPath = UriComponentsBuilder.fromPath(communityAPISentReferralLocation)
-      .buildAndExpand(event.referral.serviceUserCRN, integrationContext)
-      .toString()
-
-    communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referRequest)
   }
 
   private fun postReferralEndRequest(event: ReferralEvent, url: String) {
@@ -228,14 +210,6 @@ class CommunityAPIAppointmentEventService(
     }
   }
 }
-
-data class ReferRequest(
-  val contractType: String,
-  val startedAt: OffsetDateTime,
-  val sentenceId: Long,
-  val referralId: UUID,
-  val notes: String,
-)
 
 data class ReferralEndRequest(
   val contractType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DynamicFrameworkContractService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DynamicFrameworkContractService.kt
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class DynamicFrameworkContractService(val referralRepository: ReferralRepository) {
   fun getDynamicFrameworkContractByReferralId(id: UUID): DynamicFrameworkContract? {
     return referralRepository.findByIdOrNull(id)?.intervention?.dynamicFrameworkContract

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -12,8 +12,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.EntityNotFoundException
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class EndOfServiceReportService(
   val authUserRepository: AuthUserRepository,
   val referralRepository: ReferralRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
@@ -8,6 +8,7 @@ import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import javax.transaction.Transactional
 
 class UnverifiedEmailException : RuntimeException()
 
@@ -38,6 +39,7 @@ private data class UserDetailResponse(
 )
 
 @Service
+@Transactional
 class HMPPSAuthService(
   @Value("\${hmppsauth.api.locations.auth-user-groups}") private val authUserGroupsLocation: String,
   @Value("\${hmppsauth.api.locations.auth-user-detail}") private val authUserDetailLocation: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionService.kt
@@ -9,8 +9,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PCCRegi
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.PCCRegionRepository
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class InterventionService(
   val pccRegionRepository: PCCRegionRepository,
   val interventionRepository: InterventionRepository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import java.net.URI
 import java.util.UUID
+import javax.transaction.Transactional
 
 interface NotifyService {
   fun generateResourceUrl(baseURL: String, path: String, id: UUID): URI {
@@ -24,6 +25,7 @@ interface NotifyService {
 }
 
 @Service
+@Transactional
 class NotifyActionPlanService(
   @Value("\${notify.templates.action-plan-submitted}") private val actionPlanSubmittedTemplateID: String,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
@@ -53,6 +55,7 @@ class NotifyActionPlanService(
 }
 
 @Service
+@Transactional
 class NotifyEndOfServiceReportService(
   @Value("\${notify.templates.end-of-service-report-submitted}") private val endOfServiceReportSubmittedTemplateID: String,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
@@ -82,6 +85,7 @@ class NotifyEndOfServiceReportService(
 }
 
 @Service
+@Transactional
 class NotifyAppointmentService(
   @Value("\${notify.templates.appointment-not-attended}") private val appointmentNotAttendedTemplateID: String,
   @Value("\${notify.templates.concerning-behaviour}") private val concerningBehaviourTemplateID: String,
@@ -130,6 +134,7 @@ class NotifyAppointmentService(
 }
 
 @Service
+@Transactional
 class NotifyReferralService(
   @Value("\${notify.templates.referral-sent}") private val referralSentTemplateID: String,
   @Value("\${notify.templates.referral-assigned}") private val referralAssignedTemplateID: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import java.net.URI
 import java.util.UUID
-import javax.transaction.Transactional
 
 interface NotifyService {
   fun generateResourceUrl(baseURL: String, path: String, id: UUID): URI {
@@ -25,7 +24,6 @@ interface NotifyService {
 }
 
 @Service
-@Transactional
 class NotifyActionPlanService(
   @Value("\${notify.templates.action-plan-submitted}") private val actionPlanSubmittedTemplateID: String,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
@@ -55,7 +53,6 @@ class NotifyActionPlanService(
 }
 
 @Service
-@Transactional
 class NotifyEndOfServiceReportService(
   @Value("\${notify.templates.end-of-service-report-submitted}") private val endOfServiceReportSubmittedTemplateID: String,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
@@ -85,7 +82,6 @@ class NotifyEndOfServiceReportService(
 }
 
 @Service
-@Transactional
 class NotifyAppointmentService(
   @Value("\${notify.templates.appointment-not-attended}") private val appointmentNotAttendedTemplateID: String,
   @Value("\${notify.templates.concerning-behaviour}") private val concerningBehaviourTemplateID: String,
@@ -134,7 +130,6 @@ class NotifyAppointmentService(
 }
 
 @Service
-@Transactional
 class NotifyReferralService(
   @Value("\${notify.templates.referral-sent}") private val referralSentTemplateID: String,
   @Value("\${notify.templates.referral-assigned}") private val referralAssignedTemplateID: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/PCCRegionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/PCCRegionService.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PCCRegion
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.PCCRegionRepository
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class PCCRegionService(val repository: PCCRegionRepository) {
   fun getAllPCCRegions(): List<PCCRegion> {
     return repository.findAll().toList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -12,8 +12,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Act
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.time.OffsetDateTime
 import java.util.Objects.nonNull
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class ReferralConcluder(
   val referralRepository: ReferralRepository,
   val actionPlanAppointmentRepository: ActionPlanAppointmentRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -133,8 +133,8 @@ class ReferralService(
 
   fun sendDraftReferral(referral: Referral, user: AuthUser): Referral {
     referral.sentAt = OffsetDateTime.now()
-    referral.referenceNumber = generateReferenceNumber(referral)
     referral.sentBy = authUserRepository.save(user)
+    referral.referenceNumber = generateReferenceNumber(referral)
 
     /*
      * This is a temporary solution until a robust asynchronous link is created between Interventions

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -12,12 +12,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
-import javax.transaction.Transactional
 
 interface SNSService
 
 @Service
-@Transactional
 class SNSActionPlanService(
   private val snsPublisher: SNSPublisher,
 ) : ApplicationListener<ActionPlanEvent>, SNSService {
@@ -40,7 +38,6 @@ class SNSActionPlanService(
 }
 
 @Service
-@Transactional
 class SNSReferralService(
   private val snsPublisher: SNSPublisher,
 ) : ApplicationListener<ReferralEvent>, SNSService {
@@ -73,7 +70,6 @@ class SNSReferralService(
 }
 
 @Service
-@Transactional
 class SNSAppointmentService(
   private val snsPublisher: SNSPublisher,
 ) : ApplicationListener<AppointmentEvent>, SNSService {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -12,10 +12,12 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import javax.transaction.Transactional
 
 interface SNSService
 
 @Service
+@Transactional
 class SNSActionPlanService(
   private val snsPublisher: SNSPublisher,
 ) : ApplicationListener<ActionPlanEvent>, SNSService {
@@ -38,6 +40,7 @@ class SNSActionPlanService(
 }
 
 @Service
+@Transactional
 class SNSReferralService(
   private val snsPublisher: SNSPublisher,
 ) : ApplicationListener<ReferralEvent>, SNSService {
@@ -70,6 +73,7 @@ class SNSReferralService(
 }
 
 @Service
+@Transactional
 class SNSAppointmentService(
   private val snsPublisher: SNSPublisher,
 ) : ApplicationListener<AppointmentEvent>, SNSService {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ServiceCategoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ServiceCategoryService.kt
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceCategory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class ServiceCategoryService(val repository: ServiceCategoryRepository) {
   fun getServiceCategoryByID(id: UUID): ServiceCategory? {
     return repository.findByIdOrNull(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ServiceProviderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ServiceProviderService.kt
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.util.UUID
+import javax.transaction.Transactional
 
 @Service
+@Transactional
 class ServiceProviderService(val referralRepository: ReferralRepository) {
   fun getServiceProviderByReferralId(id: UUID): ServiceProvider? {
     return referralRepository.findByIdOrNull(id)?.intervention?.dynamicFrameworkContract?.primeProvider

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIActionPlanEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIActionPlanEventServiceTest.kt
@@ -4,31 +4,35 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType.SUBMITTED
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType.SUBMITTED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
-class CommunityAPIEndOfServiceReportServiceTest {
+class CommunityAPIActionPlanEventServiceTest {
 
   private val communityAPIClient = mock<CommunityAPIClient>()
 
   private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
   private val submittedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
 
-  val communityAPIService = CommunityAPIEndOfServiceReportEventService(
+  private val actionPlanFactory = ActionPlanFactory()
+  private val referralFactory = ReferralFactory()
+
+  val communityAPIService = CommunityAPIActionPlanEventService(
     "http://testUrl",
-    "/probation-practitioner/end-of-service-report/{id}",
+    "/probation-practitioner/submit-action-plan/{id}",
     "/secure/offenders/crn/{crn}/sentence/{sentenceId}/notifications/context/{contextName}",
     "commissioned-rehabilitation-services",
     communityAPIClient
   )
 
   @Test
-  fun `notify submitted end of service report`() {
+  fun `notify submitted action plan`() {
 
     val event = getEvent(SUBMITTED)
     communityAPIService.onApplicationEvent(event)
@@ -38,31 +42,30 @@ class CommunityAPIEndOfServiceReportServiceTest {
       NotificationCreateRequestDTO(
         "ACC",
         sentAtDefault,
-        event.endOfServiceReport.referral.id,
+        event.actionPlan.referral.id,
         submittedAtDefault,
-        "End of Service Report Submitted for Accommodation Referral XX1234 with Prime Provider Harmony Living\n" +
-          "http://testUrl/probation-practitioner/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+        "Action Plan Submitted for Accommodation Referral XX1234 with Prime Provider Harmony Living\n" +
+          "http://testUrl/probation-practitioner/submit-action-plan/${event.actionPlan.referral.id}",
       )
     )
   }
 
   private fun getEvent(
-    endOfServiceReportEventType: EndOfServiceReportEventType
-  ): EndOfServiceReportEvent =
-    EndOfServiceReportEvent(
+    ActionPlanEventType: ActionPlanEventType
+  ): ActionPlanEvent =
+    ActionPlanEvent(
       "source",
-      endOfServiceReportEventType,
-      SampleData.sampleEndOfServiceReport(
+      ActionPlanEventType,
+      actionPlanFactory.create(
         id = UUID.fromString("120b1a45-8ac7-4920-b05b-acecccf4734b"),
         submittedAt = submittedAtDefault,
-        referral = SampleData.sampleReferral(
-          crn = "X123456",
+        referral = referralFactory.createSent(
+          serviceUserCRN = "X123456",
           relevantSentenceId = 1234L,
-          serviceProviderName = "Harmony Living",
           sentAt = sentAtDefault,
           referenceNumber = "XX1234"
         ),
       ),
-      "http://localhost:8080/end-of-service-report/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
+      "http://localhost:8080/submit-action-plan/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIAppointmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIAppointmentEventServiceTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleD
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class CommunityAPIAppointmentServiceTest {
+class CommunityAPIAppointmentEventServiceTest {
 
   private val communityAPIClient = mock<CommunityAPIClient>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
@@ -1,0 +1,132 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+class CommunityAPIReferralEventServiceTest {
+
+  private val communityAPIClient = mock<CommunityAPIClient>()
+
+  private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
+  private val concludedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
+
+  private val communityAPIService = CommunityAPIReferralEventService(
+    "http://testUrl",
+    "/referral/sent/{id}",
+    "/referral/progress/{id}",
+    "/referral/end-of-service-report/{id}",
+    "secure/offenders/crn/{crn}/referral/start/context/{contextName}",
+    "secure/offenders/crn/{crn}/referral/end/context/{contextName}",
+    "commissioned-rehabilitation-services",
+    communityAPIClient
+  )
+
+  @Test
+  fun `does not notify sent referral`() {
+
+    val event = getEvent(ReferralEventType.SENT)
+    communityAPIService.onApplicationEvent(event)
+
+    verifyZeroInteractions(communityAPIClient)
+  }
+
+  @Test
+  fun `notify cancelled referral`() {
+
+    val event = getEvent(ReferralEventType.CANCELLED, concludedAtDefault)
+    communityAPIService.onApplicationEvent(event)
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      ReferralEndRequest(
+        "ACC",
+        sentAtDefault,
+        concludedAtDefault,
+        123456789,
+        event.referral.id,
+        "CANCELLED",
+        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
+          "http://testUrl/referral/progress/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
+      )
+    )
+  }
+
+  @Test
+  fun `notify prematurely ended referral`() {
+
+    val event = getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault, endOfServiceReport)
+    communityAPIService.onApplicationEvent(event)
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      ReferralEndRequest(
+        "ACC",
+        sentAtDefault,
+        concludedAtDefault,
+        123456789,
+        event.referral.id,
+        "PREMATURELY_ENDED",
+        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
+          "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+  }
+
+  @Test
+  fun `notify completed referral`() {
+
+    val event = getEvent(ReferralEventType.COMPLETED, concludedAtDefault, endOfServiceReport)
+    communityAPIService.onApplicationEvent(event)
+
+    verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      ReferralEndRequest(
+        "ACC",
+        sentAtDefault,
+        concludedAtDefault,
+        123456789,
+        event.referral.id,
+        "COMPLETED",
+        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
+          "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+  }
+
+  private fun getEvent(
+    referralEventType: ReferralEventType,
+    concludedAt: OffsetDateTime? = null,
+    endOfServiceReport: EndOfServiceReport? = null
+  ): ReferralEvent =
+    ReferralEvent(
+      "source",
+      referralEventType,
+      SampleData.sampleReferral(
+        id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
+        referenceNumber = "HAS71263",
+        crn = "X123456",
+        relevantSentenceId = 123456789,
+        serviceProviderName = "Harmony Living",
+        sentAt = sentAtDefault,
+        concludedAt = concludedAt,
+        endOfServiceReport = endOfServiceReport,
+      ),
+      "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
+    )
+
+  private val endOfServiceReport =
+    SampleData.sampleEndOfServiceReport(
+      id = UUID.fromString("120b1a45-8ac7-4920-b05b-acecccf4734b"),
+      referral = SampleData.sampleReferral(crn = "X123456", serviceProviderName = "Harmony Living"),
+    )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralServiceTest.kt
@@ -4,9 +4,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -17,125 +16,47 @@ class CommunityAPIReferralServiceTest {
   private val communityAPIClient = mock<CommunityAPIClient>()
 
   private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
-  private val concludedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
 
-  val communityAPIService = CommunityAPIReferralEventService(
+  private val communityAPIReferralService = CommunityAPIReferralService(
     "http://testUrl",
     "/referral/sent/{id}",
-    "/referral/progress/{id}",
-    "/referral/end-of-service-report/{id}",
     "secure/offenders/crn/{crn}/referral/start/context/{contextName}",
-    "secure/offenders/crn/{crn}/referral/end/context/{contextName}",
     "commissioned-rehabilitation-services",
     communityAPIClient
   )
 
   @Test
-  fun `notify sent referral`() {
+  fun `Sends referral`() {
 
-    val event = getEvent(ReferralEventType.SENT)
-    communityAPIService.onApplicationEvent(event)
+    val referral = getReferral()
+    communityAPIReferralService.send(referral)
 
-    verify(communityAPIClient).makeAsyncPostRequest(
+    verify(communityAPIClient).makeSyncPostRequest(
       "secure/offenders/crn/X123456/referral/start/context/commissioned-rehabilitation-services",
-      ReferRequest(
+      ReferralSentRequest(
         "ACC",
         sentAtDefault,
         123456789,
-        event.referral.id,
+        referral.id,
         "Referral Sent for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/referral/sent/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
-      )
+      ),
+      ReferralSentResponseDTO::class.java
     )
   }
 
-  @Test
-  fun `notify cancelled referral`() {
-
-    val event = getEvent(ReferralEventType.CANCELLED, concludedAtDefault)
-    communityAPIService.onApplicationEvent(event)
-
-    verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
-      ReferralEndRequest(
-        "ACC",
-        sentAtDefault,
-        concludedAtDefault,
-        123456789,
-        event.referral.id,
-        "CANCELLED",
-        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
-          "http://testUrl/referral/progress/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
-      )
-    )
-  }
-
-  @Test
-  fun `notify prematurely ended referral`() {
-
-    val event = getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault, endOfServiceReport)
-    communityAPIService.onApplicationEvent(event)
-
-    verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
-      ReferralEndRequest(
-        "ACC",
-        sentAtDefault,
-        concludedAtDefault,
-        123456789,
-        event.referral.id,
-        "PREMATURELY_ENDED",
-        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
-          "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
-      )
-    )
-  }
-
-  @Test
-  fun `notify completed referral`() {
-
-    val event = getEvent(ReferralEventType.COMPLETED, concludedAtDefault, endOfServiceReport)
-    communityAPIService.onApplicationEvent(event)
-
-    verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
-      ReferralEndRequest(
-        "ACC",
-        sentAtDefault,
-        concludedAtDefault,
-        123456789,
-        event.referral.id,
-        "COMPLETED",
-        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
-          "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
-      )
-    )
-  }
-
-  private fun getEvent(
-    referralEventType: ReferralEventType,
+  private fun getReferral(
     concludedAt: OffsetDateTime? = null,
     endOfServiceReport: EndOfServiceReport? = null
-  ): ReferralEvent =
-    ReferralEvent(
-      "source",
-      referralEventType,
-      SampleData.sampleReferral(
-        id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
-        referenceNumber = "HAS71263",
-        crn = "X123456",
-        relevantSentenceId = 123456789,
-        serviceProviderName = "Harmony Living",
-        sentAt = sentAtDefault,
-        concludedAt = concludedAt,
-        endOfServiceReport = endOfServiceReport,
-      ),
-      "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
-    )
-
-  private val endOfServiceReport =
-    SampleData.sampleEndOfServiceReport(
-      id = UUID.fromString("120b1a45-8ac7-4920-b05b-acecccf4734b"),
-      referral = SampleData.sampleReferral(crn = "X123456", serviceProviderName = "Harmony Living"),
+  ): Referral =
+    SampleData.sampleReferral(
+      id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
+      referenceNumber = "HAS71263",
+      crn = "X123456",
+      relevantSentenceId = 123456789,
+      serviceProviderName = "Harmony Living",
+      sentAt = sentAtDefault,
+      concludedAt = concludedAt,
+      endOfServiceReport = endOfServiceReport,
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -77,6 +77,7 @@ class ReferralServiceTest @Autowired constructor(
   private val userTypeChecker = UserTypeChecker()
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper = mock()
   private val referralAccessFilter: ReferralAccessFilter = mock()
+  private val communityAPIReferralService: CommunityAPIReferralService = mock()
 
   private val referralService = ReferralService(
     referralRepository,
@@ -92,6 +93,7 @@ class ReferralServiceTest @Autowired constructor(
     userTypeChecker,
     serviceProviderAccessScopeMapper,
     referralAccessFilter,
+    communityAPIReferralService,
   )
 
   // reset before each test
@@ -377,6 +379,7 @@ class ReferralServiceTest @Autowired constructor(
     val user = AuthUser("user_id", "delius", "user_name")
     val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
     referralService.sendDraftReferral(draftReferral, user)
+    verify(communityAPIReferralService).send(draftReferral)
     verify(referralEventPublisher).referralSentEvent(draftReferral)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -54,6 +54,7 @@ class ReferralServiceUnitTest {
   private val referralAccessChecker: ReferralAccessChecker = mock()
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper = mock()
   private val referralAccessFilter: ReferralAccessFilter = mock()
+  private val communityAPIReferralService: CommunityAPIReferralService = mock()
   private val userTypeChecker: UserTypeChecker = mock()
 
   private val referralFactory = ReferralFactory()
@@ -68,7 +69,7 @@ class ReferralServiceUnitTest {
     referralRepository, authUserRepository, interventionRepository, referralConcluder,
     referralEventPublisher, referralReferenceGenerator, cancellationReasonRepository,
     actionPlanAppointmentRepository, serviceCategoryRepository, referralAccessChecker, userTypeChecker,
-    serviceProviderAccessScopeMapper, referralAccessFilter,
+    serviceProviderAccessScopeMapper, referralAccessFilter, communityAPIReferralService,
   )
 
   @Test


### PR DESCRIPTION
**What does this pull request do?**
This PR moves the "Referral Sent" notification to Delius from being an async process to being synchronous, such that, if the call is not successful then Interventions will rollback the transaction.

To ensure the rollback functions correctly, services are annotated as Transactional. 

**What is the intent behind these changes?**
The reason for this change is to make the link between Interventions and Delius more reliable and thus keep Delius in sync. There are plans to make the notification async and until this is done, this PR will remain in place.