### PR TITLE
IC-1593 apply access restrictions for PPs accessing referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessChecker.kt
@@ -5,14 +5,13 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
 
 @Component
 class ReferralAccessChecker(
   private val userTypeChecker: UserTypeChecker,
   private val eligibleProviderMapper: EligibleProviderMapper,
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper,
-  private val communityApiOffenderService: CommunityAPIOffenderService,
+  private val serviceUserAccessChecker: ServiceUserAccessChecker,
 ) {
   private val errorMessage = "user does not have access to referral"
 
@@ -43,9 +42,7 @@ class ReferralAccessChecker(
   }
 
   private fun forProbationPractitionerUser(referral: Referral, user: AuthUser, authentication: JwtAuthenticationToken) {
-    val hasAccess = communityApiOffenderService.checkIfAuthenticatedDeliusUserHasAccessToOffender(authentication, referral.serviceUserCRN)
-    if (!hasAccess) {
-      throw AccessError(errorMessage, listOf("probation practitioner is excluded from access to this service user"))
-    }
+    // check if the PP is allowed to access this service user's records
+    serviceUserAccessChecker.forProbationPractitionerUser(referral.serviceUserCRN, authentication)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceUserAccessChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceUserAccessChecker.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
+
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
+
+@Component
+class ServiceUserAccessChecker(
+  private val communityApiOffenderService: CommunityAPIOffenderService,
+) {
+  private val errorMessage = "user is not allowed to access records related to this service user"
+
+  fun forProbationPractitionerUser(crn: String, authentication: JwtAuthenticationToken) {
+    val accessResult =
+      communityApiOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authentication, crn)
+    if (!accessResult.canAccess) {
+      throw AccessError(errorMessage, listOfNotNull(accessResult.exclusionMessage, accessResult.restrictionMessage))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceUserAccessChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceUserAccessChecker.kt
@@ -15,7 +15,7 @@ class ServiceUserAccessChecker(
     val accessResult =
       communityApiOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authentication, crn)
     if (!accessResult.canAccess) {
-      throw AccessError(errorMessage, listOfNotNull(accessResult.exclusionMessage, accessResult.restrictionMessage))
+      throw AccessError(errorMessage, accessResult.messages)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
@@ -58,6 +58,17 @@ class CommunityAPIClient(
       .block()
   }
 
+  fun <T : Any> makeSyncGetRequest(uri: String, responseBodyClass: Class<T>): T {
+    return communityApiWebClient.get().uri(uri)
+      .retrieve()
+      .bodyToMono(responseBodyClass)
+      .onErrorMap { e ->
+        handleResponse(e, "")
+        e
+      }
+      .block()
+  }
+
   fun handleResponse(e: Throwable, requestBody: Any): String {
     val responseBodyAsString = when (e) {
       is BadRequest -> e.responseBodyAsString

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
 
 import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest
@@ -12,6 +13,14 @@ class CommunityAPIClient(
   private val communityApiWebClient: WebClient,
 ) {
   companion object : KLogging()
+
+  fun withCustomAuth(authentication: JwtAuthenticationToken): CommunityAPIClient {
+    return CommunityAPIClient(
+      communityApiWebClient.mutate()
+        .defaultHeaders { headers -> headers.setBearerAuth(authentication.token.tokenValue) }
+        .build()
+    )
+  }
 
   fun makeAsyncPostRequest(uri: String, requestBody: Any) {
     communityApiWebClient.post().uri(uri)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -110,6 +110,7 @@ class ReferralController(
         user,
         createReferralRequestDTO.serviceUserCrn,
         createReferralRequestDTO.interventionId,
+        authentication,
       )
     } catch (e: EntityNotFoundException) {
       throw ServerWebInputException("invalid intervention id [id=${createReferralRequestDTO.interventionId}]")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -177,13 +177,13 @@ class ReferralController(
 
   private fun getDraftReferralForAuthenticatedUser(authentication: JwtAuthenticationToken, id: UUID): Referral {
     val user = userMapper.fromToken(authentication)
-    return referralService.getDraftReferralForUser(id, user)
+    return referralService.getDraftReferralForUser(id, user, authentication)
       ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "draft referral not found [id=$id]")
   }
 
   private fun getSentReferralForAuthenticatedUser(authentication: JwtAuthenticationToken, id: UUID): Referral {
     val user = userMapper.fromToken(authentication)
-    return referralService.getSentReferralForUser(id, user)
+    return referralService.getSentReferralForUser(id, user, authentication)
       ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$id]")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -46,11 +46,9 @@ class ReferralController(
     @RequestBody referralAssignment: ReferralAssignmentDTO,
     authentication: JwtAuthenticationToken,
   ): SentReferralDTO {
+    val sentReferral = getSentReferralForAuthenticatedUser(authentication, id)
+
     val assignedBy = userMapper.fromToken(authentication)
-
-    val sentReferral = referralService.getSentReferralForUser(id, assignedBy)
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$id]")
-
     val assignedTo = AuthUser(
       id = referralAssignment.assignedTo.userId,
       authSource = referralAssignment.assignedTo.authSource,
@@ -65,8 +63,7 @@ class ReferralController(
   fun sendDraftReferral(@PathVariable id: UUID, authentication: JwtAuthenticationToken): ResponseEntity<SentReferralDTO> {
     val user = userMapper.fromToken(authentication)
 
-    val draftReferral = referralService.getDraftReferralForUser(id, user)
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "draft referral not found [id=$id]")
+    val draftReferral = getDraftReferralForAuthenticatedUser(authentication, id)
 
     val sentReferral = referralService.sendDraftReferral(draftReferral, user)
 
@@ -83,10 +80,7 @@ class ReferralController(
 
   @GetMapping("/sent-referral/{id}")
   fun getSentReferral(@PathVariable id: UUID, authentication: JwtAuthenticationToken): SentReferralDTO {
-    val user = userMapper.fromToken(authentication)
-    return referralService.getSentReferralForUser(id, user)
-      ?.let { SentReferralDTO.from(it) }
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$id]")
+    return SentReferralDTO.from(getSentReferralForAuthenticatedUser(authentication, id))
   }
 
   @GetMapping("/sent-referrals")
@@ -99,13 +93,11 @@ class ReferralController(
 
   @PostMapping("/sent-referral/{id}/end")
   fun endSentReferral(@PathVariable id: UUID, @RequestBody endReferralRequest: EndReferralRequestDTO, authentication: JwtAuthenticationToken): SentReferralDTO {
-    val user = userMapper.fromToken(authentication)
-
-    val sentReferral = referralService.getSentReferralForUser(id, user)
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "referral not found [id=$id]")
+    val sentReferral = getSentReferralForAuthenticatedUser(authentication, id)
 
     val cancellationReason = cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(endReferralRequest.reasonCode)
 
+    val user = userMapper.fromToken(authentication)
     return SentReferralDTO.from(referralService.requestReferralEnd(sentReferral, user, cancellationReason, endReferralRequest.comments))
   }
 
@@ -136,10 +128,7 @@ class ReferralController(
 
   @GetMapping("/draft-referral/{id}")
   fun getDraftReferralByID(@PathVariable id: UUID, authentication: JwtAuthenticationToken): DraftReferralDTO {
-    val user = userMapper.fromToken(authentication)
-    return referralService.getDraftReferralForUser(id, user)
-      ?.let { DraftReferralDTO.from(it) }
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "draft referral not found [id=$id]")
+    return DraftReferralDTO.from(getDraftReferralForAuthenticatedUser(authentication, id))
   }
 
   @PatchMapping("/draft-referral/{id}")
@@ -190,5 +179,11 @@ class ReferralController(
     val user = userMapper.fromToken(authentication)
     return referralService.getDraftReferralForUser(id, user)
       ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "draft referral not found [id=$id]")
+  }
+
+  private fun getSentReferralForAuthenticatedUser(authentication: JwtAuthenticationToken, id: UUID): Referral {
+    val user = userMapper.fromToken(authentication)
+    return referralService.getSentReferralForUser(id, user)
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$id]")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -41,8 +41,7 @@ class CommunityAPIOffenderService(
     val response = client.makeSyncGetRequest(userAccessPath, UserAccessResponse::class.java)
     return ServiceUserAccessResult(
       !(response.userExcluded || response.userRestricted),
-      response.exclusionMessage,
-      response.restrictionMessage,
+      listOfNotNull(response.exclusionMessage, response.restrictionMessage),
     )
   }
 }
@@ -265,6 +264,5 @@ data class UserAccessResponse(
 
 data class ServiceUserAccessResult(
   val canAccess: Boolean,
-  val exclusionMessage: String?,
-  val restrictionMessage: String?,
+  val messages: List<String>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -32,14 +32,18 @@ class CommunityAPIOffenderService(
   @Value("\${community-api.locations.offender-access}") private val offenderAccessLocation: String,
   private val communityAPIClient: CommunityAPIClient,
 ) {
-  fun checkIfAuthenticatedDeliusUserHasAccessToOffender(authentication: JwtAuthenticationToken, crn: String): Boolean {
+  fun checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authentication: JwtAuthenticationToken, crn: String): ServiceUserAccessResult {
     val userAccessPath = UriComponentsBuilder.fromPath(offenderAccessLocation)
       .buildAndExpand(crn)
       .toString()
 
     val client = communityAPIClient.withCustomAuth(authentication)
     val response = client.makeSyncGetRequest(userAccessPath, UserAccessResponse::class.java)
-    return !(response.userExcluded || response.userRestricted)
+    return ServiceUserAccessResult(
+      !(response.userExcluded || response.userRestricted),
+      response.exclusionMessage,
+      response.restrictionMessage,
+    )
   }
 }
 
@@ -255,6 +259,12 @@ data class AppointmentOutcomeRequest(
 data class UserAccessResponse(
   val userExcluded: Boolean,
   val userRestricted: Boolean,
+  val exclusionMessage: String?,
+  val restrictionMessage: String?,
+)
+
+data class ServiceUserAccessResult(
+  val canAccess: Boolean,
   val exclusionMessage: String?,
   val restrictionMessage: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import mu.KotlinLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
@@ -55,24 +56,24 @@ class ReferralService(
     private const val maxReferenceNumberTries = 10
   }
 
-  fun getSentReferralForUser(id: UUID, user: AuthUser): Referral? {
+  fun getSentReferralForUser(id: UUID, user: AuthUser, authentication: JwtAuthenticationToken): Referral? {
     val referral = referralRepository.findByIdAndSentAtIsNotNull(id)
 
     referral?.let {
-      referralAccessChecker.forUser(it, user)
+      referralAccessChecker.forUser(it, user, authentication)
     }
 
     return referral
   }
 
-  fun getDraftReferralForUser(id: UUID, user: AuthUser): Referral? {
+  fun getDraftReferralForUser(id: UUID, user: AuthUser, authentication: JwtAuthenticationToken): Referral? {
     if (!userTypeChecker.isProbationPractitionerUser(user)) {
       throw AccessError("user does not have access to referral", listOf("only probation practitioners can access draft referrals"))
     }
 
     val referral = referralRepository.findByIdAndSentAtIsNull(id)
     referral?.let {
-      referralAccessChecker.forUser(it, user)
+      referralAccessChecker.forUser(it, user, authentication)
     }
     return referral
   }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,7 +9,7 @@ interventions-ui:
   baseurl: http://localhost:3000
 
 community-api:
-  baseurl: http://localhost:8081
+  baseurl: http://localhost:8091
 
 aws:
   sns:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,6 +99,7 @@ community-api:
     reschedule-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/reschedule/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
     notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
+    offender-access: "/secure/offenders/crn/{crn}/userAccess"
   appointments:
     office-location: CRSEXTL
   integration-context: commissioned-rehabilitation-services

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -45,7 +45,7 @@ internal class ReferralControllerTest {
   @Test
   fun `createDraftReferral handles EntityNotFound exceptions from InterventionsService`() {
     val token = tokenFactory.create()
-    whenever(referralService.createDraftReferral(any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())).thenThrow(EntityNotFoundException::class.java)
+    whenever(referralService.createDraftReferral(any(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())).thenThrow(EntityNotFoundException::class.java)
     assertThrows<ServerWebInputException> {
       referralController.createDraftReferral(CreateReferralRequestDTO("CRN20", UUID.randomUUID()), token)
     }
@@ -59,7 +59,7 @@ internal class ReferralControllerTest {
 
     @Test
     fun `getSentReferral returns not found if sent referral does not exist`() {
-      whenever(referralService.getSentReferralForUser(eq(referral.id), any())).thenReturn(null)
+      whenever(referralService.getSentReferralForUser(eq(referral.id), any(), any())).thenReturn(null)
       val e = assertThrows<ResponseStatusException> {
         referralController.getSentReferral(
           referral.id,
@@ -72,7 +72,7 @@ internal class ReferralControllerTest {
 
     @Test
     fun `getSentReferral returns a sent referral if it exists`() {
-      whenever(referralService.getSentReferralForUser(eq(referral.id), any())).thenReturn(referral)
+      whenever(referralService.getSentReferralForUser(eq(referral.id), any(), any())).thenReturn(referral)
       val sentReferral = referralController.getSentReferral(
         referral.id,
         token,
@@ -83,7 +83,7 @@ internal class ReferralControllerTest {
 
   @Test
   fun `assignSentReferral returns 404 if referral does not exist`() {
-    whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(null)
+    whenever(referralService.getSentReferralForUser(any(), any(), any())).thenReturn(null)
     val e = assertThrows<ResponseStatusException> {
       referralController.assignSentReferral(
         UUID.randomUUID(),
@@ -98,7 +98,7 @@ internal class ReferralControllerTest {
   fun `assignSentReferral uses incoming jwt for 'assignedBy' argument, and request body for 'assignedTo'`() {
     val referral = referralFactory.createSent()
     val assignedToUser = authUserFactory.create(id = "to")
-    whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+    whenever(referralService.getSentReferralForUser(any(), any(), any())).thenReturn(referral)
     whenever(referralService.assignSentReferral(any(), any(), any())).thenReturn(referral)
     referralController.assignSentReferral(
       UUID.randomUUID(),
@@ -120,7 +120,7 @@ internal class ReferralControllerTest {
     val cancellationReason = CancellationReason("AAA", "description")
 
     whenever(cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(any())).thenReturn(cancellationReason)
-    whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+    whenever(referralService.getSentReferralForUser(any(), any(), any())).thenReturn(referral)
 
     val user = AuthUser("CRN123", "auth", "user")
     val token = tokenFactory.create(user.id, user.authSource, user.userName)
@@ -136,7 +136,7 @@ internal class ReferralControllerTest {
     val cancellationReason = CancellationReason("AAA", "description")
 
     whenever(cancellationReasonMapper.mapCancellationReasonIdToCancellationReason(any())).thenReturn(cancellationReason)
-    whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(null)
+    whenever(referralService.getSentReferralForUser(any(), any(), any())).thenReturn(null)
 
     val token = tokenFactory.create()
     val e = assertThrows<ResponseStatusException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
@@ -22,17 +22,25 @@ enum class Request {
 }
 
 class RequestFactory(private val webTestClient: WebTestClient, private val setupAssistant: SetupAssistant) {
-  fun create(request: Request, token: String?, vararg urlParams: String): WebTestClient.RequestHeadersSpec<*> {
+  fun create(request: Request, token: String?, vararg urlParams: String, body: Any? = null): WebTestClient.RequestHeadersSpec<*> {
     val spec = when (request) {
-      Request.CreateDraftReferral -> webTestClient.post().uri("/draft-referral").bodyValue(CreateReferralRequestDTO("X123456", UUID.randomUUID()))
+      Request.CreateDraftReferral -> webTestClient.post().uri("/draft-referral").bodyValue(
+        if (body != null) body as CreateReferralRequestDTO else CreateReferralRequestDTO("X123456", UUID.randomUUID())
+      )
 
       Request.GetDraftReferral -> webTestClient.get().uri("/draft-referral/${urlParams[0]}")
-      Request.UpdateDraftReferral -> webTestClient.patch().uri("/draft-referral/${urlParams[0]}").bodyValue(DraftReferralDTO())
+      Request.UpdateDraftReferral -> webTestClient.patch().uri("/draft-referral/${urlParams[0]}").bodyValue(
+        if (body != null) body as DraftReferralDTO else DraftReferralDTO()
+      )
       Request.SendDraftReferral -> webTestClient.post().uri("/draft-referral/${urlParams[0]}/send")
 
       Request.GetSentReferral -> webTestClient.get().uri("/sent-referral/${urlParams[0]}")
-      Request.AssignSentReferral -> webTestClient.post().uri("/sent-referral/${urlParams[0]}/assign").bodyValue(ReferralAssignmentDTO(AuthUserDTO.from(setupAssistant.createSPUser())))
-      Request.EndSentReferral -> webTestClient.post().uri("/sent-referral/${urlParams[0]}/end").bodyValue(EndReferralRequestDTO(setupAssistant.randomCancellationReason().code, "comments"))
+      Request.AssignSentReferral -> webTestClient.post().uri("/sent-referral/${urlParams[0]}/assign").bodyValue(
+        if (body != null) body as ReferralAssignmentDTO else ReferralAssignmentDTO(AuthUserDTO.from(setupAssistant.createSPUser()))
+      )
+      Request.EndSentReferral -> webTestClient.post().uri("/sent-referral/${urlParams[0]}/end").bodyValue(
+        if (body != null) body as EndReferralRequestDTO else EndReferralRequestDTO(setupAssistant.randomCancellationReason().code, "comments")
+      )
 
       Request.GetDraftReferrals -> webTestClient.get().uri("/draft-referrals")
       Request.GetSentReferrals -> webTestClient.get().uri("/sent-referrals")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -55,11 +55,11 @@ class SingleReferralEndpoints : IntegrationTestBase() {
   private fun setLimitedAccessCRNs(vararg crns: String) {
     // order is important here! it's LIFO so generic matchers first, followed by specific CRNs
     whenever(mockCommunityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any()))
-      .thenReturn(ServiceUserAccessResult(true, null, null))
+      .thenReturn(ServiceUserAccessResult(true, listOf()))
 
     crns.forEach {
       whenever(mockCommunityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), eq(it)))
-        .thenReturn(ServiceUserAccessResult(false, "exclusion message", "restriction message"))
+        .thenReturn(ServiceUserAccessResult(false, listOf("exclusion message", "restriction message")))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -1,20 +1,29 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.authorization
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.boot.test.mock.mockito.MockBean
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceUserAccessResult
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
 import java.util.UUID
 
 class SingleReferralEndpoints : IntegrationTestBase() {
   @MockBean lateinit var mockHmppsAuthService: HMPPSAuthService
+  @MockBean lateinit var mockCommunityAPIOffenderService: CommunityAPIOffenderService
+  @MockBean lateinit var mockCommunityApiReferralService: CommunityAPIReferralService
 
   private lateinit var requestFactory: RequestFactory
 
@@ -43,12 +52,77 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     whenever(mockHmppsAuthService.getUserGroups(user)).thenReturn(groups)
   }
 
+  private fun setLimitedAccessCRNs(vararg crns: String) {
+    // order is important here! it's LIFO so generic matchers first, followed by specific CRNs
+    whenever(mockCommunityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any()))
+      .thenReturn(ServiceUserAccessResult(true, null, null))
+
+    crns.forEach {
+      whenever(mockCommunityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), eq(it)))
+        .thenReturn(ServiceUserAccessResult(false, "exclusion message", "restriction message"))
+    }
+  }
+
   private fun createSentReferral(contract: DynamicFrameworkContract): Referral {
     return setupAssistant.createSentReferral(intervention = setupAssistant.createIntervention(dynamicFrameworkContract = contract))
   }
 
   private fun createEncodedTokenForUser(user: AuthUser): String {
     return tokenFactory.createEncodedToken(userID = user.id, userName = user.userName, authSource = user.authSource)
+  }
+
+  @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
+  @MethodSource("draftReferralRequests")
+  fun `pp user cannot access limited access offender referrals`(request: Request) {
+    val user = setupAssistant.createPPUser()
+    val token = createEncodedTokenForUser(user)
+
+    setLimitedAccessCRNs("X999999")
+    val referral1 = setupAssistant.createDraftReferral(serviceUserCRN = "X000000")
+    val referral2 = setupAssistant.createDraftReferral(serviceUserCRN = "X999999")
+
+    requestFactory.create(request, token, referral1.id.toString())
+      .exchange()
+      .expectStatus()
+      .is2xxSuccessful
+
+    requestFactory.create(request, token, referral2.id.toString())
+      .exchange()
+      .expectStatus().isForbidden
+      .expectBody().json(
+        """
+        {"accessErrors": [
+        "exclusion message",
+        "restriction message"
+        ]}
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `pp user cannot create referrals for limited access offenders`() {
+    val user = setupAssistant.createPPUser()
+    val token = createEncodedTokenForUser(user)
+    val intervention = setupAssistant.createIntervention()
+
+    setLimitedAccessCRNs("X5555555")
+
+    requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X1233456", intervention.id))
+      .exchange()
+      .expectStatus()
+      .is2xxSuccessful
+
+    requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X5555555", intervention.id))
+      .exchange()
+      .expectStatus().isForbidden
+      .expectBody().json(
+        """
+        {"accessErrors": [
+        "exclusion message",
+        "restriction message"
+        ]}
+        """.trimIndent()
+      )
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
@@ -5,19 +5,26 @@ import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceUserAccessResult
 
 @PactBroker
 @Provider("Interventions Service")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class PactTest : IntegrationTestBase() {
   @MockBean private lateinit var hmppsAuthService: HMPPSAuthService
+  @MockBean private lateinit var communityAPIOffenderService: CommunityAPIOffenderService
+  @MockBean private lateinit var communityAPIReferralService: CommunityAPIReferralService
 
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
@@ -27,6 +34,9 @@ class PactTest : IntegrationTestBase() {
 
   @BeforeEach
   fun `before each`(context: PactVerificationContext) {
+    whenever(communityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any()))
+      .thenReturn(ServiceUserAccessResult(true, emptyList()))
+
     context.addStateChangeHandlers(
       ActionPlanContracts(setupAssistant),
       InterventionContracts(setupAssistant),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -15,6 +15,7 @@ import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceProviderAccessScopeMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceUserAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
@@ -56,6 +57,7 @@ class ReferralServiceUnitTest {
   private val referralAccessFilter: ReferralAccessFilter = mock()
   private val communityAPIReferralService: CommunityAPIReferralService = mock()
   private val userTypeChecker: UserTypeChecker = mock()
+  private val serviceUserAccessChecker: ServiceUserAccessChecker = mock()
 
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
@@ -69,7 +71,7 @@ class ReferralServiceUnitTest {
     referralRepository, authUserRepository, interventionRepository, referralConcluder,
     referralEventPublisher, referralReferenceGenerator, cancellationReasonRepository,
     actionPlanAppointmentRepository, serviceCategoryRepository, referralAccessChecker, userTypeChecker,
-    serviceProviderAccessScopeMapper, referralAccessFilter, communityAPIReferralService,
+    serviceProviderAccessScopeMapper, referralAccessFilter, communityAPIReferralService, serviceUserAccessChecker,
   )
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

checks if the PP user has access to an SU before allowing them to view a referral.

please review commit by commit to have a look at the small changes to community api client code and referral controller.

## What is the intent behind these changes?

"block access for PP 'limited access offenders' (LAOs)"
