### PR TITLE
Set the report path using the generate extract path function

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -29,7 +29,7 @@ spec:
             {{ if (and .Values.env_details.contains_live_data (not .data_protection_impact_assessment_signed_off)) }}
             args: ["sh", "-c", "psql -c 'SELECT 1' && mkdir -p 'export/csv' && touch 'export/csv/signed_off_DPIA_required.csv' && transfer_local_to_s3.sh"]
             {{ else }}
-            args: ["sh", "-c", "mkdir -p 'export/csv/reports' && psql --file=/reports/crs_performance_report.sql > 'export/csv/reports/crs_performance_report.csv' && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
+            args: ["sh", "-c", "report_path=$(generate_extract_path.py --database 'reports' --table 'crs_performance_report') && mkdir -p '$report_path' && psql --file=/reports/crs_performance_report.sql > '$report_path''/crs_performance_report.csv' && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
             {{ end }}
             volumeMounts:
             - name: data-extractor-reports


### PR DESCRIPTION
## What does this pull request do?

It creates the directory path for the reports using the generate_extract_path module. 

## What is the intent behind these changes?

This is to conform the extract location for the reports into the same directory structure as the other extracts.

