### PR TITLE
Make service caterogies ordered in draft referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -39,7 +39,7 @@ data class DraftReferralDTO(
         id = referral.id,
         createdAt = referral.createdAt,
         completionDeadline = referral.completionDeadline,
-        complexityLevels = referral.complexityLevelIds?.map { ReferralComplexityLevel(it.key, it.value) },
+        complexityLevels = referral.complexityLevelIds?.map { ReferralComplexityLevel(it.key, it.value) }?.sortedBy { it.serviceCategoryId },
         furtherInformation = referral.furtherInformation,
         additionalNeedsInformation = referral.additionalNeedsInformation,
         accessibilityNeeds = referral.accessibilityNeeds,
@@ -49,13 +49,14 @@ data class DraftReferralDTO(
         whenUnavailable = referral.whenUnavailable,
         additionalRiskInformation = referral.additionalRiskInformation,
         maximumEnforceableDays = referral.maximumEnforceableDays,
-        desiredOutcomes = referral.selectedDesiredOutcomes?.groupBy { it.serviceCategoryId }?.map { (serviceCategoryId, desiredoutcomes) -> SelectedDesiredOutcomesDTO(serviceCategoryId, desiredoutcomes.map { it.desiredOutcomeId }) },
+        desiredOutcomes = referral.selectedDesiredOutcomes?.groupBy { it.serviceCategoryId }?.toSortedMap()
+          ?.map { (serviceCategoryId, desiredoutcomes) -> SelectedDesiredOutcomesDTO(serviceCategoryId, desiredoutcomes.map { it.desiredOutcomeId }.sorted()) },
         serviceUser = ServiceUserDTO.from(referral.serviceUserCRN, referral.serviceUserData),
         serviceProvider = ServiceProviderDTO.from(contract.primeProvider),
         relevantSentenceId = referral.relevantSentenceId,
         // TODO: remove this once cohort referrals changes are complete
         serviceCategoryId = if (referral.selectedServiceCategories?.isNotEmpty() == true) referral.selectedServiceCategories!!.elementAt(0).id else null,
-        serviceCategoryIds = referral.selectedServiceCategories?.map { it.id },
+        serviceCategoryIds = referral.selectedServiceCategories?.map { it.id }?.sorted(),
         interventionId = referral.intervention.id,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
@@ -1,17 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.boot.test.json.JacksonTester
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
 @JsonTest
 class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftReferralDTO>) {
+  private val referralFactory = ReferralFactory()
+  private val serviceCategoryFactory = ServiceCategoryFactory()
   @Test
   fun `test serialization of newly created referral`() {
     val referral = SampleData.sampleReferral(
@@ -86,5 +92,72 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
     """
     )
     assertThat(draftReferral.relevantSentenceId).isEqualTo(123456789)
+  }
+
+  @Nested
+  inner class Ordering {
+    val uuid1 = UUID.fromString("10000000-0106-4bcf-9da4-2a3c8c062114")
+    val uuid2 = UUID.fromString("20000000-0106-4bcf-9da4-2a3c8c062114")
+    val uuid3 = UUID.fromString("30000000-0106-4bcf-9da4-2a3c8c062114")
+    val uuid4 = UUID.fromString("40000000-0106-4bcf-9da4-2a3c8c062114")
+    val uuid5 = UUID.fromString("50000000-0106-4bcf-9da4-2a3c8c062114")
+    val uuid6 = UUID.fromString("60000000-0106-4bcf-9da4-2a3c8c062114")
+    @Test
+    fun `service category ids are always the same order`() {
+      val serviceCat1 = serviceCategoryFactory.create(id = uuid1)
+      val serviceCat2 = serviceCategoryFactory.create(id = uuid2)
+      val serviceCat3 = serviceCategoryFactory.create(id = uuid3)
+      val serviceCat4 = serviceCategoryFactory.create(id = uuid4)
+      val serviceCat5 = serviceCategoryFactory.create(id = uuid5)
+      val referral = referralFactory.createDraft(selectedServiceCategories = setOf(serviceCat5, serviceCat3, serviceCat4, serviceCat2, serviceCat1))
+      val referralDTO = DraftReferralDTO.from(referral)
+
+      assertThat(referralDTO.serviceCategoryIds).hasSize(5)
+      assertThat(referralDTO.serviceCategoryIds!!.elementAt(0)).isEqualTo(serviceCat1.id)
+      assertThat(referralDTO.serviceCategoryIds!!.elementAt(1)).isEqualTo(serviceCat2.id)
+      assertThat(referralDTO.serviceCategoryIds!!.elementAt(2)).isEqualTo(serviceCat3.id)
+      assertThat(referralDTO.serviceCategoryIds!!.elementAt(3)).isEqualTo(serviceCat4.id)
+      assertThat(referralDTO.serviceCategoryIds!!.elementAt(4)).isEqualTo(serviceCat5.id)
+    }
+
+    @Test
+    fun `complexity levels are always in the same order`() {
+      val map: MutableMap<UUID, UUID> = mutableMapOf(uuid5 to uuid5, uuid3 to uuid3, uuid4 to uuid4, uuid2 to uuid2, uuid1 to uuid1)
+      val referral = referralFactory.createDraft(complexityLevelIds = map)
+      val referralDTO = DraftReferralDTO.from(referral)
+
+      assertThat(referralDTO.complexityLevels).hasSize(5)
+      assertThat(referralDTO.complexityLevels!!.elementAt(0).serviceCategoryId).isEqualTo(uuid1)
+      assertThat(referralDTO.complexityLevels!!.elementAt(1).serviceCategoryId).isEqualTo(uuid2)
+      assertThat(referralDTO.complexityLevels!!.elementAt(2).serviceCategoryId).isEqualTo(uuid3)
+      assertThat(referralDTO.complexityLevels!!.elementAt(3).serviceCategoryId).isEqualTo(uuid4)
+      assertThat(referralDTO.complexityLevels!!.elementAt(4).serviceCategoryId).isEqualTo(uuid5)
+    }
+
+    @Test
+    fun `desired outcomes are always in the same order`() {
+      val desiredOutcome1 = DesiredOutcome(id = uuid1, "", serviceCategoryId = uuid1)
+      val desiredOutcome2 = DesiredOutcome(id = uuid2, "", serviceCategoryId = uuid1)
+      val desiredOutcome3 = DesiredOutcome(id = uuid3, "", serviceCategoryId = uuid1)
+
+      val desiredOutcome4 = DesiredOutcome(id = uuid4, "", serviceCategoryId = uuid2)
+      val desiredOutcome5 = DesiredOutcome(id = uuid5, "", serviceCategoryId = uuid2)
+      val desiredOutcome6 = DesiredOutcome(id = uuid6, "", serviceCategoryId = uuid2)
+      val referral = referralFactory.createDraft(desiredOutcomes = listOf(desiredOutcome5, desiredOutcome3, desiredOutcome4, desiredOutcome2, desiredOutcome1, desiredOutcome6))
+      val referralDTO = DraftReferralDTO.from(referral)
+
+      assertThat(referralDTO.desiredOutcomes).hasSize(2)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(0).serviceCategoryId).isEqualTo(uuid1)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(0).desiredOutcomesIds).hasSize(3)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(0).desiredOutcomesIds!!.elementAt(0)).isEqualTo(uuid1)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(0).desiredOutcomesIds!!.elementAt(1)).isEqualTo(uuid2)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(0).desiredOutcomesIds!!.elementAt(2)).isEqualTo(uuid3)
+
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(1).serviceCategoryId).isEqualTo(uuid2)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(1).desiredOutcomesIds).hasSize(3)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(1).desiredOutcomesIds!!.elementAt(0)).isEqualTo(uuid4)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(1).desiredOutcomesIds!!.elementAt(1)).isEqualTo(uuid5)
+      assertThat(referralDTO.desiredOutcomes!!.elementAt(1).desiredOutcomesIds!!.elementAt(2)).isEqualTo(uuid6)
+    }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Makes service category ordered in draft referral DTO

## What is the intent behind these changes?

REST resources must be **idempotent**. To achieve this we need to make the service categories always return in the same order for each REST call.


## Further Info
The selected service categories is a Set on the database object so there is no guaranteed order. 

I've ordered complexityLevel and desiredOutcomes based as well to keep them consistent with the service categories even though they should always return in the same order.

This change ultimately comes about because the order in which the UI gets the service categories is always different in each call, which causes weirdness on make a referral form.