### PR TITLE
IC-1835 Augment Exception response and add X-Request-Id to MDC

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -9,6 +9,7 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.reactive.function.client.WebClientRequestException

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -12,7 +12,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
-import org.springframework.web.reactive.function.client.WebClientRequestException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityNotFoundException
@@ -110,22 +109,22 @@ class ErrorConfiguration(private val telemetryClient: TelemetryClient) {
 
   @ExceptionHandler(WebClientRequestException::class)
   fun handleWebClientRequestException(e: WebClientRequestException): ResponseEntity<ErrorResponse> {
-    logger.info("web client request exception", e)
-    return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "web client request exception", e.message, userMessageForWebClientException(HttpStatus.INTERNAL_SERVER_ERROR))
+    logger.info("Call to dependency request exception", e)
+    return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Call to dependency request exception", e.message, userMessageForWebClientException(HttpStatus.INTERNAL_SERVER_ERROR))
   }
 
   @ExceptionHandler(WebClientResponseException::class)
   fun handleWebClientResponseException(e: WebClientResponseException): ResponseEntity<ErrorResponse> {
-    logger.info("web client response exception", e)
-    return errorResponse(e.statusCode, "web client response exception", e.responseBodyAsString, userMessageForWebClientException(e.statusCode))
+    logger.info("Call to dependency response exception", e)
+    return errorResponse(e.statusCode, "Call to dependency response exception", e.responseBodyAsString, userMessageForWebClientException(e.statusCode))
   }
 
   fun userMessageForWebClientException(status: HttpStatus?): String? {
     return when {
       status == null -> null
       status == HttpStatus.CONFLICT -> null
-      status.is4xxClientError -> "A problem has been encountered. Please contact Support"
-      status.is5xxServerError -> "Delius is experiencing issues. Please try again later and if the issue persists contact Support"
+      status.is4xxClientError -> "Problem has been encountered. Please contact Support"
+      status.is5xxServerError -> "System is experiencing issues. Please try again later and if the issue persists contact Support"
       else -> null
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityNotFoundException
@@ -39,6 +40,7 @@ data class ErrorResponse(
   val status: Int,
   val error: String,
   val message: String?,
+  val userMessage: String?,
   val validationErrors: List<FieldError>? = null,
   val accessErrors: List<String>? = null,
 )
@@ -105,16 +107,33 @@ class ErrorConfiguration(private val telemetryClient: TelemetryClient) {
     return errorResponse(HttpStatus.CONFLICT, "entity already exists", e.message)
   }
 
+  @ExceptionHandler(WebClientRequestException::class)
+  fun handleWebClientRequestException(e: WebClientRequestException): ResponseEntity<ErrorResponse> {
+    logger.info("web client request exception", e)
+    return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "web client request exception", e.message, userMessageForWebClientException(HttpStatus.INTERNAL_SERVER_ERROR))
+  }
+
   @ExceptionHandler(WebClientResponseException::class)
   fun handleWebClientResponseException(e: WebClientResponseException): ResponseEntity<ErrorResponse> {
-    logger.info("web client exception", e)
-    return errorResponse(e.statusCode, "web client exception", e.responseBodyAsString)
+    logger.info("web client response exception", e)
+    return errorResponse(e.statusCode, "web client response exception", e.responseBodyAsString, userMessageForWebClientException(e.statusCode))
+  }
+
+  fun userMessageForWebClientException(status: HttpStatus?): String? {
+    return when {
+      status == null -> null
+      status == HttpStatus.CONFLICT -> null
+      status.is4xxClientError -> "A problem has been encountered. Please contact Support"
+      status.is5xxServerError -> "Delius is experiencing issues. Please try again later and if the issue persists contact Support"
+      else -> null
+    }
   }
 
   private fun errorResponse(
     status: HttpStatus,
     summary: String,
     description: String?,
+    userMessage: String? = null,
     validationErrors: List<FieldError>? = null,
     accessErrors: List<String>? = null,
   ): ResponseEntity<ErrorResponse> {
@@ -125,6 +144,7 @@ class ErrorConfiguration(private val telemetryClient: TelemetryClient) {
           status = status.value(),
           error = summary,
           message = description,
+          userMessage = userMessage,
           validationErrors = validationErrors,
           accessErrors = accessErrors,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/filters/MdcLogEnhancerFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/filters/MdcLogEnhancerFilter.kt
@@ -13,11 +13,13 @@ class MdcLogEnhancerFilter : OncePerRequestFilter() {
     // this is the place to add more request specific log fields...
 
     MDC.put("hostname", req.localAddr)
+    MDC.put("req_id", req.getHeader("X-Request-Id"))
     try {
       chain.doFilter(req, res)
     } finally {
       // and don't forget to clear them out at the end of each request!
       MDC.remove("hostname")
+      MDC.remove("req_id")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfigurationTest.kt
@@ -30,9 +30,9 @@ internal class ErrorConfigurationTest {
 
     val responseBody = response.body
     assertThat(responseBody.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
-    assertThat(responseBody.error).isEqualTo("web client request exception")
+    assertThat(responseBody.error).isEqualTo("Call to dependency request exception")
     assertThat(responseBody.message).isEqualTo("An Error; nested exception is java.lang.IllegalStateException: An Error")
-    assertThat(responseBody.userMessage).isEqualTo("Delius is experiencing issues. Please try again later and if the issue persists contact Support")
+    assertThat(responseBody.userMessage).isEqualTo("System is experiencing issues. Please try again later and if the issue persists contact Support")
   }
 
   @Test
@@ -44,9 +44,9 @@ internal class ErrorConfigurationTest {
 
     val responseBody = response.body
     assertThat(responseBody.status).isEqualTo(BAD_REQUEST.value())
-    assertThat(responseBody.error).isEqualTo("web client response exception")
+    assertThat(responseBody.error).isEqualTo("Call to dependency response exception")
     assertThat(responseBody.message).isEqualTo("An Error")
-    assertThat(responseBody.userMessage).isEqualTo("A problem has been encountered. Please contact Support")
+    assertThat(responseBody.userMessage).isEqualTo("Problem has been encountered. Please contact Support")
   }
 
   @Test
@@ -55,9 +55,9 @@ internal class ErrorConfigurationTest {
     assertThat(errorConfiguration.userMessageForWebClientException(null)).isNull()
     assertThat(errorConfiguration.userMessageForWebClientException(CONFLICT)).isNull()
     assertThat(errorConfiguration.userMessageForWebClientException(BAD_REQUEST))
-      .isEqualTo("A problem has been encountered. Please contact Support")
+      .isEqualTo("Problem has been encountered. Please contact Support")
     assertThat(errorConfiguration.userMessageForWebClientException(SERVICE_UNAVAILABLE))
-      .isEqualTo("Delius is experiencing issues. Please try again later and if the issue persists contact Support")
+      .isEqualTo("System is experiencing issues. Please try again later and if the issue persists contact Support")
     assertThat(errorConfiguration.userMessageForWebClientException(MOVED_PERMANENTLY)).isNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfigurationTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
+
+import com.microsoft.applicationinsights.TelemetryClient
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod.POST
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.CONFLICT
+import org.springframework.http.HttpStatus.MOVED_PERMANENTLY
+import org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.net.URI
+import java.nio.charset.Charset
+
+internal class ErrorConfigurationTest {
+
+  private val telemetryClient = mock<TelemetryClient>()
+  private val errorConfiguration = ErrorConfiguration(telemetryClient)
+
+  @Test
+  fun `augments web client request exception`() {
+
+    val exception = WebClientRequestException(IllegalStateException("An Error"), POST, URI.create("uri"), HttpHeaders.EMPTY)
+
+    val response = errorConfiguration.handleWebClientRequestException(exception)
+
+    val responseBody = response.body
+    assertThat(responseBody.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
+    assertThat(responseBody.error).isEqualTo("web client request exception")
+    assertThat(responseBody.message).isEqualTo("An Error; nested exception is java.lang.IllegalStateException: An Error")
+    assertThat(responseBody.userMessage).isEqualTo("Delius is experiencing issues. Please try again later and if the issue persists contact Support")
+  }
+
+  @Test
+  fun `augments web client response exception`() {
+
+    val exception = WebClientResponseException(BAD_REQUEST.value(), "Reason Phrase", HttpHeaders.EMPTY, "An Error".toByteArray(), Charset.defaultCharset())
+
+    val response = errorConfiguration.handleWebClientResponseException(exception)
+
+    val responseBody = response.body
+    assertThat(responseBody.status).isEqualTo(BAD_REQUEST.value())
+    assertThat(responseBody.error).isEqualTo("web client response exception")
+    assertThat(responseBody.message).isEqualTo("An Error")
+    assertThat(responseBody.userMessage).isEqualTo("A problem has been encountered. Please contact Support")
+  }
+
+  @Test
+  fun `user message is mapped correctly`() {
+
+    assertThat(errorConfiguration.userMessageForWebClientException(null)).isNull()
+    assertThat(errorConfiguration.userMessageForWebClientException(CONFLICT)).isNull()
+    assertThat(errorConfiguration.userMessageForWebClientException(BAD_REQUEST))
+      .isEqualTo("A problem has been encountered. Please contact Support")
+    assertThat(errorConfiguration.userMessageForWebClientException(SERVICE_UNAVAILABLE))
+      .isEqualTo("Delius is experiencing issues. Please try again later and if the issue persists contact Support")
+    assertThat(errorConfiguration.userMessageForWebClientException(MOVED_PERMANENTLY)).isNull()
+  }
+}


### PR DESCRIPTION
## What does this pull request do?
This change allows for the exception logged in sentry to be mapped to a UI request via X-Request-Id. Also, community-api exceptions are augmented with a new field called user message in specific scenarios for display.

It has been requested by the UX team that when this field is display can the page also accord with
https://design-system.service.gov.uk/patterns/service-unavailable-pages/

## What is the intent behind these changes?
Aids the investigation process and provides a nicer message to the user given problems arising.

## Examples
Delius unavailable
```
{
    "status": 500,
    "error": "Call to dependency response exception",
    "message": "{\"timestamp\":\"2021-06-16T10:32:11.351+00:00\",\"status\":500,\"error\":\"Internal Server Error\",\"path\":\"/secure/offenders/crn/X014122/referral/start/context/commissioned-rehabilitation-services\"}",
    "userMessage": "System is experiencing issues. Please try again later and if the issue persists contact Support"
}
```
Community-api unavailable
```
{
    "status": 500,
    "error": "Call to dependency request exception",
    "message": "Connection refused: localhost/127.0.0.1:8090; nested exception is io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:8090",
    "userMessage": "System is experiencing issues. Please try again later and if the issue persists contact Support"
}
```
Community-api data problems
```
{
    "status": 400,
    "error": "Call to dependency response exception",
    "message": "{\"status\":400,\"developerMessage\":\"Cannot find NSI for CRN: X014122 Sentence: 2500057056 and ContractType ACC\"}",
    "userMessage": "Problem has been encountered. Please contact Support"
}
```
Delius-api data/rule violation
```
{
    "status": 400,
    "error": "Call to dependency response exception",
    "message": "{\"status\":400,\"errorCode\":null,\"userMessage\":\"Contact already has an outcome and can not be replaced\",\"developerMessage\":\"Contact already has an outcome and can not be replaced\",\"moreInfo\":null}",
    "userMessage": "Problem has been encountered. Please contact Support"
}
```
Delius-api conflict
```
{
    "status": 409,
    "error": "Call to dependency response exception",
    "message": "{\"status\":409,\"errorCode\":null,\"userMessage\":\"Conflict: Contact type 'CRSAPT' is an attendance type so must not clash with any other attendance contacts but clashes with contacts with ids '2500294148'\",\"developerMessage\":\"Contact type 'CRSAPT' is an attendance type so must not clash with any other attendance contacts but clashes with contacts with ids '2500294148'\",\"moreInfo\":null}"
}
```