### PR TITLE
Disable all emails, temporarily

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,3 +20,4 @@ env:
   INTERVENTIONSUI_BASEURL: "https://refer-monitor-intervention.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.probation.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "prod"
+  NOTIFY_ENABLED: false


### PR DESCRIPTION
## What does this pull request do?

Disable all emails on production


## What is the intent behind these changes?

1. We need to change the referral notification email from "one address per provider" to "one address per intervention"
2. We do not yet have all email addresses on file

So in interest of keeping things rolling, we're turning of all emails until we have the above and/or start onboarding providers