### PR TITLE
add selected categories on referral creation

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -89,6 +89,10 @@ class SetupAssistant(
     authUserRepository.deleteAll()
   }
 
+  fun serviceCategory(id: UUID): ServiceCategory {
+    return serviceCategoryRepository.findById(id).get()
+  }
+
   fun randomServiceCategory(): ServiceCategory {
     return serviceCategories.random().value
   }
@@ -155,6 +159,7 @@ class SetupAssistant(
     createdBy: AuthUser = createPPUser(),
     createdAt: OffsetDateTime = OffsetDateTime.now(),
     serviceUserCRN: String = "X123456",
+    selectedServiceCategories: Set<ServiceCategory>? = null,
   ): Referral {
     return referralRepository.save(
       referralFactory.createDraft(
@@ -163,6 +168,7 @@ class SetupAssistant(
         createdAt = createdAt,
         createdBy = createdBy,
         serviceUserCRN = serviceUserCRN,
+        selectedServiceCategories = selectedServiceCategories
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
@@ -70,7 +70,10 @@ class ReferralContracts(private val setupAssistant: SetupAssistant) {
   fun `create a new draft referral with women's service type and 'HARMONY_LIVING' service provider`() {
     val contract = setupAssistant.createDynamicFrameworkContract(contractType = setupAssistant.contractTypes["WOS"]!!, primeProviderId = "HARMONY_LIVING")
     val intervention = setupAssistant.createIntervention(dynamicFrameworkContract = contract)
-    setupAssistant.createDraftReferral(id = UUID.fromString("d496e4a7-7cc1-44ea-ba67-c295084f1962"), intervention = intervention)
+    setupAssistant.createDraftReferral(
+      id = UUID.fromString("d496e4a7-7cc1-44ea-ba67-c295084f1962"), intervention = intervention,
+      selectedServiceCategories = setOf(setupAssistant.serviceCategory(UUID.fromString("428ee70f-3001-4399-95a6-ad25eaaede16")))
+    )
   }
 
   @State(


### PR DESCRIPTION
## What does this pull request do?

Adds a selected category to pact test referral setup

## What is the intent behind these changes?

Fix pact tests failing by no selected service category 
