### PR TITLE
Set risk data to "invalid" on older sent referrals

### DIFF
--- a/src/main/resources/db/migration/V1_55_1__default_supplementary_risk_id.sql
+++ b/src/main/resources/db/migration/V1_55_1__default_supplementary_risk_id.sql
@@ -1,0 +1,3 @@
+UPDATE referral
+    SET supplementary_risk_id = '00000000-0000-0000-0000-000000000000'
+    WHERE supplementary_risk_id IS NULL AND sent_at IS NOT NULL;


### PR DESCRIPTION

## What does this pull request do?

Set risk data to "invalid" on older sent referrals

## What is the intent behind these changes?

The assumption is that `supplementary_risk_id` must exist when the referral is sent

This might be a good use case to analyse later, to understand if we
should represent sent-only data in a separate table (so that it can
have the constraint representing the state)
