### PR TITLE
Deploy to prod after successful preprod deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,16 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-interventions-service-preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          slack_notification: true
+          slack_channel_name: "interventions-alerts"
+          requires:
+            - deploy_preprod
+          context:
+            - hmpps-common-vars
+            - hmpps-interventions-service-prod
 
   nightly:
     triggers:


### PR DESCRIPTION
## What does this pull request do?

Adds deployment (no manual approval needed) to prod after successful preprod deploy

## What is the intent behind these changes?

To make sure we can deploy