### PR TITLE
Final changes to get the contract tests green

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
+import com.fasterxml.jackson.annotation.JsonView
 import mu.KLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SelectedDesire
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryFullDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SetComplexityLevelRequestDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.Views
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
@@ -40,6 +42,7 @@ class ReferralController(
 ) {
   companion object : KLogging()
 
+  @JsonView(Views.SentReferral::class)
   @PostMapping("/sent-referral/{id}/assign")
   fun assignSentReferral(
     @PathVariable id: UUID,
@@ -59,6 +62,7 @@ class ReferralController(
     )
   }
 
+  @JsonView(Views.SentReferral::class)
   @PostMapping("/draft-referral/{id}/send")
   fun sendDraftReferral(@PathVariable id: UUID, authentication: JwtAuthenticationToken): ResponseEntity<SentReferralDTO> {
     val user = userMapper.fromToken(authentication)
@@ -78,11 +82,13 @@ class ReferralController(
       .body(SentReferralDTO.from(sentReferral))
   }
 
+  @JsonView(Views.SentReferral::class)
   @GetMapping("/sent-referral/{id}")
   fun getSentReferral(@PathVariable id: UUID, authentication: JwtAuthenticationToken): SentReferralDTO {
     return SentReferralDTO.from(getSentReferralForAuthenticatedUser(authentication, id))
   }
 
+  @JsonView(Views.SentReferral::class)
   @GetMapping("/sent-referrals")
   fun getSentReferrals(
     authentication: JwtAuthenticationToken,
@@ -91,6 +97,7 @@ class ReferralController(
     return referralService.getSentReferralsForUser(user).map { SentReferralDTO.from(it) }
   }
 
+  @JsonView(Views.SentReferral::class)
   @PostMapping("/sent-referral/{id}/end")
   fun endSentReferral(@PathVariable id: UUID, @RequestBody endReferralRequest: EndReferralRequestDTO, authentication: JwtAuthenticationToken): SentReferralDTO {
     val sentReferral = getSentReferralForAuthenticatedUser(authentication, id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -1,15 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
+import com.fasterxml.jackson.annotation.JsonView
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
+
+object Views {
+  interface DraftReferral
+  interface SentReferral
+}
 
 data class ReferralComplexityLevel(
   val serviceCategoryId: UUID,
   val complexityLevelId: UUID,
 )
 
+@JsonView(Views.DraftReferral::class, Views.SentReferral::class)
 data class DraftReferralDTO(
   val id: UUID? = null,
   val createdAt: OffsetDateTime? = null,
@@ -24,7 +31,15 @@ data class DraftReferralDTO(
   val interpreterLanguage: String? = null,
   val hasAdditionalResponsibilities: Boolean? = null,
   val whenUnavailable: String? = null,
-  val additionalRiskInformation: String? = null,
+
+  // the risk information is a special field; it's set on the draft referral,
+  // but as soon as the referral is sent we store the risk information in
+  // 'assess risks and needs' and no longer store it in our database.
+  // it is not sent with SentReferralDTO, which nests this DTO.
+  // NOTE: it is the responsibility of the controller methods to set the
+  // JsonView when returning SentReferralDTOs!
+  @JsonView(Views.DraftReferral::class) val additionalRiskInformation: String? = null,
+
   val maximumEnforceableDays: Int? = null,
   val desiredOutcomes: List<SelectedDesiredOutcomesDTO>? = null,
   val serviceUser: ServiceUserDTO? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -39,7 +39,9 @@ data class DraftReferralDTO(
         id = referral.id,
         createdAt = referral.createdAt,
         completionDeadline = referral.completionDeadline,
-        complexityLevels = referral.complexityLevelIds?.map { ReferralComplexityLevel(it.key, it.value) }?.sortedBy { it.serviceCategoryId },
+        complexityLevels = referral.complexityLevelIds?.ifEmpty { null }
+          ?.map { ReferralComplexityLevel(it.key, it.value) }
+          ?.sortedBy { it.serviceCategoryId },
         furtherInformation = referral.furtherInformation,
         additionalNeedsInformation = referral.additionalNeedsInformation,
         accessibilityNeeds = referral.accessibilityNeeds,
@@ -49,14 +51,23 @@ data class DraftReferralDTO(
         whenUnavailable = referral.whenUnavailable,
         additionalRiskInformation = referral.additionalRiskInformation,
         maximumEnforceableDays = referral.maximumEnforceableDays,
-        desiredOutcomes = referral.selectedDesiredOutcomes?.groupBy { it.serviceCategoryId }?.toSortedMap()
-          ?.map { (serviceCategoryId, desiredoutcomes) -> SelectedDesiredOutcomesDTO(serviceCategoryId, desiredoutcomes.map { it.desiredOutcomeId }.sorted()) },
+        desiredOutcomes = referral.selectedDesiredOutcomes?.ifEmpty { null }
+          ?.groupBy { it.serviceCategoryId }
+          ?.toSortedMap()
+          ?.map { (serviceCategoryId, desiredOutcomes) ->
+            SelectedDesiredOutcomesDTO(
+              serviceCategoryId,
+              desiredOutcomes.map { it.desiredOutcomeId }.sorted()
+            )
+          },
         serviceUser = ServiceUserDTO.from(referral.serviceUserCRN, referral.serviceUserData),
         serviceProvider = ServiceProviderDTO.from(contract.primeProvider),
         relevantSentenceId = referral.relevantSentenceId,
         // TODO: remove this once cohort referrals changes are complete
-        serviceCategoryId = if (referral.selectedServiceCategories?.isNotEmpty() == true) referral.selectedServiceCategories!!.elementAt(0).id else null,
-        serviceCategoryIds = referral.selectedServiceCategories?.map { it.id }?.sorted(),
+        serviceCategoryId = referral.selectedServiceCategories?.firstOrNull()?.id,
+        serviceCategoryIds = referral.selectedServiceCategories?.ifEmpty { null }
+          ?.map { it.id }
+          ?.sorted(),
         interventionId = referral.intervention.id,
       )
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
     max-in-memory-size: 10MB
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
+    mapper:
+      default-view-inclusion: true
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
   security:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTOTest.kt
@@ -142,6 +142,44 @@ class DraftReferralDTOTest(@Autowired private val json: JacksonTester<DraftRefer
     assertThat(draftReferral.relevantSentenceId).isEqualTo(123456789)
   }
 
+  @Nested inner class RiskInformation {
+    // this field has some funky JsonView annotations going on,
+    // so double check it's working as expected
+
+    @Test
+    fun `test serialization of additionalRiskInformation in draft referrals`() {
+      val referral = referralFactory.createDraft(id = UUID.fromString("3b9ed289-8412-41a9-8291-45e33e60276c"))
+
+      val out = json.write(DraftReferralDTO.from(referral))
+      assertThat(out).isEqualToJson(
+        """
+        {
+          "id": "3b9ed289-8412-41a9-8291-45e33e60276c",
+          "completionDeadline": null,
+          "additionalRiskInformation": null
+        }
+        """
+      )
+    }
+
+    @Test
+    fun `test serialization of additionalRiskInformation in sent referrals`() {
+      val referral = referralFactory.createSent(id = UUID.fromString("3b9ed289-8412-41a9-8291-45e33e60276c"))
+
+      val out = json.forView(Views.SentReferral::class.java)
+        .write(DraftReferralDTO.from(referral))
+      assertThat(out).isEqualToJson(
+        """
+        {
+          "id": "3b9ed289-8412-41a9-8291-45e33e60276c",
+          "completionDeadline": null
+        }
+        """
+      )
+      assertThat(out).doesNotHaveJsonPath("$.additionalRiskInformation")
+    }
+  }
+
   @Nested
   inner class Ordering {
     val uuid1 = UUID.fromString("10000000-0106-4bcf-9da4-2a3c8c062114")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
@@ -6,6 +6,7 @@ import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
@@ -16,7 +17,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.Integr
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.RisksAndNeedsService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceUserAccessResult
+import java.util.UUID
 
 @PactBroker
 @Provider("Interventions Service")
@@ -25,6 +28,7 @@ class PactTest : IntegrationTestBase() {
   @MockBean private lateinit var hmppsAuthService: HMPPSAuthService
   @MockBean private lateinit var communityAPIOffenderService: CommunityAPIOffenderService
   @MockBean private lateinit var communityAPIReferralService: CommunityAPIReferralService
+  @MockBean private lateinit var risksAndNeedsService: RisksAndNeedsService
 
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
@@ -34,6 +38,9 @@ class PactTest : IntegrationTestBase() {
 
   @BeforeEach
   fun `before each`(context: PactVerificationContext) {
+    // required for 'sendDraftReferral' to return a valid DTO
+    whenever(risksAndNeedsService.createSupplementaryRisk(any(), any(), any(), anyOrNull(), any())).thenReturn(UUID.randomUUID())
+
     whenever(communityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any()))
       .thenReturn(ServiceUserAccessResult(true, emptyList()))
 


### PR DESCRIPTION
please review each commit in isolation.

## What does this pull request do?

This PR does include some functional changes! 

- collection type referral fields (desired outcomes, complexity levels, service categories) are explicitly set to null if empty. the reason for this is to ensure the responses are consistent between freshly created referrals (these fields are `null`) and retrieved referrals (where they are empty lists - due to the way JPA loads them). since these things can never be emptied via our api, an empty list isn't a valid state for the fields to be in. so if the collection is empty in all three cases, we return a null value in the response. this also ties in with a failing contract on the UI which was expecting complexity levels to be null, but it was returning an empty list.

- sent referral DTOs no longer include additionalRiskInformation. this is to avoid API clients trying to use it. once the referral is sent we do not store or purport to store _any_ risk information in the service. this API changes makes that clear.

## What is the intent behind these changes?

get the pacts green before prod usage commences.
