### PR TITLE
IC-1593 renable LAO checks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceUserAccessChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceUserAccessChecker.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
 
@@ -11,14 +12,10 @@ class ServiceUserAccessChecker(
   private val errorMessage = "user is not allowed to access records related to this service user"
 
   fun forProbationPractitionerUser(crn: String, user: AuthUser) {
-    // FIXME: the community API user access integration is currently not functioning properly;
-    // the response always appears to grant access, regardless of the exclusions / restrictions.
-    // this code is commented out so it's clear there is no access check happening.
-
-    // val accessResult =
-    //   communityApiOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user, crn)
-    // if (!accessResult.canAccess) {
-    //   throw AccessError(errorMessage, accessResult.messages)
-    // }
+    val accessResult =
+      communityApiOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user, crn)
+    if (!accessResult.canAccess) {
+      throw AccessError(user, errorMessage, accessResult.messages)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RestClient.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
+
+import org.springframework.http.MediaType
+import org.springframework.util.MultiValueMap
+import org.springframework.web.reactive.function.client.WebClient
+import java.nio.charset.StandardCharsets
+
+class RestClient(
+  private val webClient: WebClient,
+) {
+  fun get(uri: String, queryParams: MultiValueMap<String, String>? = null): WebClient.RequestHeadersSpec<*> {
+    val spec = webClient
+      .get()
+      .uri {
+        it
+          .path(uri)
+          .queryParams(queryParams)
+          .build()
+      }
+
+    return withDefaultHeaders(spec)
+  }
+
+  fun <T> post(uri: String, body: T): WebClient.RequestHeadersSpec<*> {
+    val spec = webClient
+      .post()
+      .uri(uri)
+      .bodyValue(body)
+
+    return withDefaultHeaders(spec)
+  }
+
+  private fun withDefaultHeaders(spec: WebClient.RequestHeadersSpec<*>): WebClient.RequestHeadersSpec<*> {
+    return spec
+      .accept(MediaType.APPLICATION_JSON)
+      .acceptCharset(StandardCharsets.UTF_8)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
 import java.time.Duration
 
 @Configuration
@@ -32,6 +33,7 @@ class WebClientConfiguration(
   }
 
   @Bean
+  @Deprecated("usage of newer 'RestClient' interface is preferred")
   fun communityApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
     return createAuthorizedWebClient(authorizedClientManager, communityApiBaseUrl)
   }
@@ -39,6 +41,11 @@ class WebClientConfiguration(
   @Bean
   fun hmppsAuthApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
     return createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl)
+  }
+
+  @Bean
+  fun communityApiRestClient(communityApiWebClient: WebClient): RestClient {
+    return RestClient(communityApiWebClient)
   }
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -28,8 +28,8 @@ class WebClientConfiguration(
   private val webClientBuilder: WebClient.Builder
 ) {
   @Bean
-  fun assessRisksAndNeedsClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
-    return createAuthorizedWebClient(authorizedClientManager, assessRisksAndNeedsBaseUrl)
+  fun assessRisksAndNeedsClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
+    return RestClient(createAuthorizedWebClient(authorizedClientManager, assessRisksAndNeedsBaseUrl))
   }
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+
+data class ServiceUserAccessResult(
+  val canAccess: Boolean,
+  val messages: List<String>,
+)
+
+private data class UserAccessResponse(
+  val exclusionMessage: String?,
+  val restrictionMessage: String?,
+)
+
+@Service
+class CommunityAPIOffenderService(
+  @Value("\${community-api.locations.offender-access}") private val offenderAccessLocation: String,
+  private val communityApiRestClient: RestClient,
+) {
+  fun checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user: AuthUser, crn: String): ServiceUserAccessResult {
+    val userAccessPath = UriComponentsBuilder.fromPath(offenderAccessLocation)
+      .buildAndExpand(crn, user.userName)
+      .toString()
+
+    val response = communityApiRestClient.get(userAccessPath)
+      .retrieve()
+      .onStatus({ it.equals(HttpStatus.FORBIDDEN) }, { Mono.empty() })
+      .toEntity(UserAccessResponse::class.java)
+      .block()
+
+    return ServiceUserAccessResult(
+      !response.statusCode.equals(HttpStatus.FORBIDDEN),
+      listOfNotNull(response.body.restrictionMessage, response.body.exclusionMessage)
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -29,25 +29,6 @@ interface CommunityAPIService {
 }
 
 @Service
-class CommunityAPIOffenderService(
-  @Value("\${community-api.locations.offender-access}") private val offenderAccessLocation: String,
-  private val communityAPIClient: CommunityAPIClient,
-) {
-  fun checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user: AuthUser, crn: String): ServiceUserAccessResult {
-    val userAccessPath = UriComponentsBuilder.fromPath(offenderAccessLocation)
-      .buildAndExpand(crn)
-      .toString()
-
-    val response = communityAPIClient.makeSyncGetRequest(userAccessPath, UserAccessResponse::class.java)
-
-    return ServiceUserAccessResult(
-      !(response.userExcluded || response.userRestricted),
-      listOfNotNull(response.exclusionMessage, response.restrictionMessage),
-    )
-  }
-}
-
-@Service
 class CommunityAPIReferralEventService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.sent-referral}") private val interventionsUISentReferralLocation: String,
@@ -270,16 +251,4 @@ data class AppointmentOutcomeRequest(
   val notes: String,
   val attended: String,
   val notifyPPOfAttendanceBehaviour: Boolean,
-)
-
-data class UserAccessResponse(
-  val userExcluded: Boolean,
-  val userRestricted: Boolean,
-  val exclusionMessage: String?,
-  val restrictionMessage: String?,
-)
-
-data class ServiceUserAccessResult(
-  val canAccess: Boolean,
-  val messages: List<String>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.lang.IllegalStateException

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
@@ -4,14 +4,12 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
-import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -34,7 +32,7 @@ data class SupplementaryRiskResponse(
 @Transactional
 class RisksAndNeedsService(
   @Value("\${assess-risks-and-needs.locations.create-supplementary-risk}") private val createSupplementaryRiskLocation: String,
-  private val assessRisksAndNeedsClient: WebClient,
+  private val assessRisksAndNeedsClient: RestClient,
 ) {
   companion object : KLogging()
 
@@ -49,10 +47,7 @@ class RisksAndNeedsService(
       riskInformation,
     )
 
-    return assessRisksAndNeedsClient.post().uri(createSupplementaryRiskLocation)
-      .bodyValue(request)
-      .accept(MediaType.APPLICATION_JSON)
-      .acceptCharset(StandardCharsets.UTF_8)
+    return assessRisksAndNeedsClient.post(createSupplementaryRiskLocation, request)
       .retrieve()
       .bodyToMono(SupplementaryRiskResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,7 +101,7 @@ community-api:
     reschedule-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/reschedule/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
     notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
-    offender-access: "/secure/offenders/crn/{crn}/userAccess"
+    offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"
   appointments:
     bookings:
       enabled: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -5,9 +5,11 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.boot.test.mock.mockito.MockBean
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
@@ -82,61 +84,61 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     return tokenFactory.createEncodedToken(userID = user.id, userName = user.userName, authSource = user.authSource)
   }
 
-  // @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
-  // @MethodSource("draftReferralRequests")
-  // fun `pp user cannot access limited access offender referrals`(request: Request) {
-  //   val user = setupAssistant.createPPUser()
-  //   val token = createEncodedTokenForUser(user)
-  //
-  //   setLimitedAccessCRNs("X999999")
-  //   val referral1 = setupAssistant.createDraftReferral(serviceUserCRN = "X000000")
-  //   val referral2 = setupAssistant.createDraftReferral(serviceUserCRN = "X999999")
-  //   setupAssistant.fillReferralFields(referral1)
-  //   setupAssistant.fillReferralFields(referral2)
-  //
-  //   requestFactory.create(request, token, referral1.id.toString())
-  //     .exchange()
-  //     .expectStatus()
-  //     .is2xxSuccessful
-  //
-  //   requestFactory.create(request, token, referral2.id.toString())
-  //     .exchange()
-  //     .expectStatus().isForbidden
-  //     .expectBody().json(
-  //       """
-  //       {"accessErrors": [
-  //       "exclusion message",
-  //       "restriction message"
-  //       ]}
-  //       """.trimIndent()
-  //     )
-  // }
-  //
-  // @Test
-  // fun `pp user cannot create referrals for limited access offenders`() {
-  //   val user = setupAssistant.createPPUser()
-  //   val token = createEncodedTokenForUser(user)
-  //   val intervention = setupAssistant.createIntervention()
-  //
-  //   setLimitedAccessCRNs("X5555555")
-  //
-  //   requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X1233456", intervention.id))
-  //     .exchange()
-  //     .expectStatus()
-  //     .is2xxSuccessful
-  //
-  //   requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X5555555", intervention.id))
-  //     .exchange()
-  //     .expectStatus().isForbidden
-  //     .expectBody().json(
-  //       """
-  //       {"accessErrors": [
-  //       "exclusion message",
-  //       "restriction message"
-  //       ]}
-  //       """.trimIndent()
-  //     )
-  // }
+  @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
+  @MethodSource("draftReferralRequests")
+  fun `pp user cannot access limited access offender referrals`(request: Request) {
+    val user = setupAssistant.createPPUser()
+    val token = createEncodedTokenForUser(user)
+
+    setLimitedAccessCRNs("X999999")
+    val referral1 = setupAssistant.createDraftReferral(serviceUserCRN = "X000000")
+    val referral2 = setupAssistant.createDraftReferral(serviceUserCRN = "X999999")
+    setupAssistant.fillReferralFields(referral1)
+    setupAssistant.fillReferralFields(referral2)
+
+    requestFactory.create(request, token, referral1.id.toString())
+      .exchange()
+      .expectStatus()
+      .is2xxSuccessful
+
+    requestFactory.create(request, token, referral2.id.toString())
+      .exchange()
+      .expectStatus().isForbidden
+      .expectBody().json(
+        """
+        {"accessErrors": [
+        "exclusion message",
+        "restriction message"
+        ]}
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `pp user cannot create referrals for limited access offenders`() {
+    val user = setupAssistant.createPPUser()
+    val token = createEncodedTokenForUser(user)
+    val intervention = setupAssistant.createIntervention()
+
+    setLimitedAccessCRNs("X5555555")
+
+    requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X1233456", intervention.id))
+      .exchange()
+      .expectStatus()
+      .is2xxSuccessful
+
+    requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X5555555", intervention.id))
+      .exchange()
+      .expectStatus().isForbidden
+      .expectBody().json(
+        """
+        {"accessErrors": [
+        "exclusion message",
+        "restriction message"
+        ]}
+        """.trimIndent()
+      )
+  }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
   @MethodSource("sentReferralRequests")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+
+internal class CommunityAPIOffenderServiceTest {
+  private val authUserFactory = AuthUserFactory()
+
+  private fun createMockedRestClient(status: HttpStatus, responseBody: String): RestClient {
+    return RestClient(
+      WebClient.builder()
+        .exchangeFunction {
+          Mono.just(
+            ClientResponse.create(status)
+              .header("content-type", "application/json")
+              .body(responseBody)
+              .build()
+          )
+        }.build()
+    )
+  }
+
+  @Test
+  fun `checkIfAuthenticatedDeliusUserHasAccessToServiceUser success`() {
+    val client = createMockedRestClient(HttpStatus.OK, "{\"exclusionMessage\": null, \"restrictionMessage\": null}")
+    val offenderService = CommunityAPIOffenderService("/", client)
+    val result = offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authUserFactory.create(), "X123456")
+    assertThat(result.canAccess).isTrue
+    assertThat(result.messages).isEmpty()
+  }
+
+  @Test
+  fun `checkIfAuthenticatedDeliusUserHasAccessToServiceUser forbidden`() {
+    val client = createMockedRestClient(HttpStatus.FORBIDDEN, "{\"exclusionMessage\": \"family exclusion\", \"restrictionMessage\": null}")
+    val offenderService = CommunityAPIOffenderService("/", client)
+    val result = offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authUserFactory.create(), "X123456")
+    assertThat(result.canAccess).isFalse
+    assertThat(result.messages).isEqualTo(listOf("family exclusion"))
+  }
+
+  @Test
+  fun `checkIfAuthenticatedDeliusUserHasAccessToServiceUser unhandled error`() {
+    val client = createMockedRestClient(HttpStatus.INTERNAL_SERVER_ERROR, "{\"exclusionMessage\": null, \"restrictionMessage\": null}")
+    val offenderService = CommunityAPIOffenderService("/", client)
+    assertThrows<WebClientResponseException> {
+      offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authUserFactory.create(), "X123456")
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

- adds a new helper class for calling rest methods with webclients in a more consistent way
- changes the LAO check to use a new community API endpoint where we can specify the username in the url
- slightly changes the way we handle the response from the community api endpoint - instead of manually checking the exclusions and restrictions, we just check the status code, this is to avoid duplicating this logic which exists in community api:

```
    private ResponseEntity<AccessLimitation> accessLimitationResponseEntityOf(final OffenderDetail offender, final String username) {
        final var accessLimitation = userService.accessLimitationOf(username, offender);
        return new ResponseEntity<>(accessLimitation, (accessLimitation.isUserExcluded() || accessLimitation.isUserRestricted()) ? FORBIDDEN : OK);
    }
```
- changes the risks and needs service to use the new rest client helper class

## What is the intent behind these changes?

implement LAO checks for PP referral access.
