### PR TITLE
Send custom events about our authorisation problems

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessChecker.kt
@@ -19,7 +19,7 @@ class ReferralAccessChecker(
     when {
       userTypeChecker.isProbationPractitionerUser(user) -> forProbationPractitionerUser(referral, user)
       userTypeChecker.isServiceProviderUser(user) -> forServiceProviderUser(referral, user)
-      else -> throw AccessError(userTypeError, listOf("logins from ${user.authSource} are not supported"))
+      else -> throw AccessError(user, userTypeError, listOf("logins from ${user.authSource} are not supported"))
     }
   }
 
@@ -37,7 +37,7 @@ class ReferralAccessChecker(
     }
 
     if (errors.isNotEmpty()) {
-      throw AccessError(insufficientPrivilegeError, errors)
+      throw AccessError(user, insufficientPrivilegeError, errors)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -28,11 +28,11 @@ class ServiceProviderAccessScopeMapper(
 
   fun fromUser(user: AuthUser): ServiceProviderAccessScope {
     if (!userTypeChecker.isServiceProviderUser(user)) {
-      throw AccessError(errorMessage, listOf("user is not a service provider"))
+      throw AccessError(user, errorMessage, listOf("user is not a service provider"))
     }
 
     val groups = hmppsAuthService.getUserGroups(user)
-      ?: throw AccessError(errorMessage, listOf("cannot find user in hmpps auth"))
+      ?: throw AccessError(user, errorMessage, listOf("cannot find user in hmpps auth"))
 
     val configErrors = mutableListOf<String>()
 
@@ -51,7 +51,7 @@ class ServiceProviderAccessScopeMapper(
     // FIXME we also need to remove contracts which do not belong to the user's provider
 
     if (configErrors.isNotEmpty()) {
-      throw AccessError(errorMessage, configErrors)
+      throw AccessError(user, errorMessage, configErrors)
     }
 
     // this not null assertion on serviceProvider is ugly, but it's the only way i could think

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/UserMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/UserMapper.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
 
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 
 @Component
@@ -26,7 +26,7 @@ class UserMapper {
     }
 
     if (errors.isNotEmpty()) {
-      throw AccessError("could not map auth token to user", errors)
+      throw AccessDeniedException("could not map auth token to user: $errors")
     }
 
     return AuthUser(id = userID, authSource = authSource, userName = userName)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -70,7 +70,7 @@ class ReferralService(
 
   fun getDraftReferralForUser(id: UUID, user: AuthUser): Referral? {
     if (!userTypeChecker.isProbationPractitionerUser(user)) {
-      throw AccessError("unsupported user type", listOf("only probation practitioners can access draft referrals"))
+      throw AccessError(user, "unsupported user type", listOf("only probation practitioners can access draft referrals"))
     }
 
     val referral = referralRepository.findByIdAndSentAtIsNull(id)
@@ -99,7 +99,7 @@ class ReferralService(
       return getSentReferralsForProbationPractitionerUser(user)
     }
 
-    throw AccessError("unsupported user type", listOf("logins from ${user.authSource} are not supported"))
+    throw AccessError(user, "unsupported user type", listOf("logins from ${user.authSource} are not supported"))
   }
 
   private fun getSentReferralsForServiceProviderUser(user: AuthUser): List<Referral> {
@@ -184,7 +184,7 @@ class ReferralService(
     endOfServiceReport: EndOfServiceReport? = null,
   ): Referral {
     if (!userTypeChecker.isProbationPractitionerUser(user)) {
-      throw AccessError("user cannot create referral", listOf("only probation practitioners can create draft referrals"))
+      throw AccessError(user, "user cannot create referral", listOf("only probation practitioners can create draft referrals"))
     }
 
     // PPs can't create referrals for service users they are not allowed to see
@@ -378,7 +378,7 @@ class ReferralService(
 
   fun getDraftReferralsForUser(user: AuthUser): List<Referral> {
     if (!userTypeChecker.isProbationPractitionerUser(user)) {
-      throw AccessError("user does not have access to referrals", listOf("only probation practitioners can access draft referrals"))
+      throw AccessError(user, "user does not have access to referrals", listOf("only probation practitioners can access draft referrals"))
     }
 
     val referrals = referralRepository.findByCreatedByIdAndSentAtIsNull(user.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -417,10 +417,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectStatus().isForbidden
     response.expectBody().json(
       """
-      {"accessErrors": [
-      "no 'auth_source' claim in token",
-      "no 'user_name' claim in token"
-      ]}
+      {"status":403,"error":"access denied",
+       "message":"could not map auth token to user: [no 'user_name' claim in token, no 'auth_source' claim in token]"}
       """.trimIndent()
     )
   }


### PR DESCRIPTION
## What does this pull request do?

Send custom events about our authorisation problems

`UserMapper` now raises `AccessDeniedException` instead of `AccessError` as the latter is now is always in the user's context

## What is the intent behind these changes?

So we can monitor the percentage of our user base having issues (and what they are)