### PR TITLE
IC-1592 PP sent referral dashboard updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -15,6 +15,7 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?
   fun findByCreatedByAndSentAtIsNotNull(user: AuthUser): List<Referral>
   fun existsByReferenceNumber(reference: String): Boolean
+  fun findByServiceUserCRNAndSentAtIsNotNull(crn: String): List<Referral>
 
   // queries for draft referrals
   fun findByIdAndSentAtIsNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
@@ -14,12 +13,8 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
 
   // queries for sent referrals
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?
-  fun findBySentAtIsNotNull(): List<Referral>
-  fun findByInterventionDynamicFrameworkContractPrimeProviderIdAndSentAtIsNotNull(id: AuthGroupID): List<Referral>
+  fun findByCreatedByAndSentAtIsNotNull(user: AuthUser): List<Referral>
   fun existsByReferenceNumber(reference: String): Boolean
-  fun findBySentBy(user: AuthUser): List<Referral>
-  fun findBySentById(userId: String): List<Referral>
-  fun findByAssignedToId(userId: String): List<Referral>
 
   // queries for draft referrals
   fun findByIdAndSentAtIsNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -3,10 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+
+data class Offender(
+  val crnNumber: String,
+)
 
 data class ServiceUserAccessResult(
   val canAccess: Boolean,
@@ -18,9 +23,15 @@ private data class UserAccessResponse(
   val restrictionMessage: String?,
 )
 
+private data class StaffDetailsResponse(
+  val staffIdentifier: String,
+)
+
 @Service
 class CommunityAPIOffenderService(
   @Value("\${community-api.locations.offender-access}") private val offenderAccessLocation: String,
+  @Value("\${community-api.locations.managed-offenders}") private val managedOffendersLocation: String,
+  @Value("\${community-api.locations.staff-details}") private val staffDetailsLocation: String,
   private val communityApiRestClient: RestClient,
 ) {
   fun checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user: AuthUser, crn: String): ServiceUserAccessResult {
@@ -38,5 +49,41 @@ class CommunityAPIOffenderService(
       !response.statusCode.equals(HttpStatus.FORBIDDEN),
       listOfNotNull(response.body.restrictionMessage, response.body.exclusionMessage)
     )
+  }
+
+  fun getManagedOffendersForDeliusUser(user: AuthUser): List<Offender> {
+    val staffIdentifier = getStaffIdentifier(user)
+      // if a delius user does not have a staff identifier it's not an error;
+      // but it does mean they do not have any managed offenders allocated.
+      ?: return emptyList()
+
+    val managedOffendersPath = UriComponentsBuilder.fromPath(managedOffendersLocation)
+      .buildAndExpand(staffIdentifier)
+      .toString()
+
+    return communityApiRestClient.get(managedOffendersPath)
+      .retrieve()
+      .bodyToFlux(Offender::class.java)
+      .collectList()
+      .block()
+  }
+
+  private fun getStaffIdentifier(user: AuthUser): String? {
+    val staffDetailsPath = UriComponentsBuilder.fromPath(staffDetailsLocation)
+      .buildAndExpand(user.userName)
+      .toString()
+
+    return communityApiRestClient.get(staffDetailsPath)
+      .retrieve()
+      .bodyToMono(StaffDetailsResponse::class.java)
+      .onErrorResume(WebClientResponseException::class.java) { e ->
+        when (e.statusCode) {
+          // not all delius users are staff
+          HttpStatus.NOT_FOUND -> Mono.empty()
+          else -> Mono.error(e)
+        }
+      }
+      .block()
+      ?.staffIdentifier
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
@@ -52,6 +53,7 @@ class ReferralService(
   val communityAPIReferralService: CommunityAPIReferralService,
   val serviceUserAccessChecker: ServiceUserAccessChecker,
   val assessRisksAndNeedsService: RisksAndNeedsService,
+  val communityAPIOffenderService: CommunityAPIOffenderService,
 ) {
   companion object {
     private val logger = KotlinLogging.logger {}
@@ -113,8 +115,20 @@ class ReferralService(
   }
 
   private fun getSentReferralsForProbationPractitionerUser(user: AuthUser): List<Referral> {
-    val referrals = referralRepository.findByCreatedByAndSentAtIsNotNull(user)
-    return referralAccessFilter.probationPractitionerReferrals(referrals, user)
+    val referralsStartedByPP = referralRepository.findByCreatedByAndSentAtIsNotNull(user)
+    val referralsManagedByPP = try {
+      communityAPIOffenderService.getManagedOffendersForDeliusUser(user)
+    } catch (e: WebClientResponseException) {
+      // don't stop users seeing their own referrals just because delius is not playing nice
+      logger.error(
+        "failed to get managed offenders for user {}",
+        e,
+        kv("username", user.userName),
+      )
+      emptyList()
+    }.flatMap { referralRepository.findByServiceUserCRNAndSentAtIsNotNull(it.crnNumber) }
+
+    return referralAccessFilter.probationPractitionerReferrals(referralsStartedByPP + referralsManagedByPP, user)
   }
 
   fun requestReferralEnd(referral: Referral, user: AuthUser, reason: CancellationReason, comments: String?): Referral {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -113,12 +113,8 @@ class ReferralService(
   }
 
   private fun getSentReferralsForProbationPractitionerUser(user: AuthUser): List<Referral> {
-    val referrals = getSentReferralsSentBy(user)
+    val referrals = referralRepository.findByCreatedByAndSentAtIsNotNull(user)
     return referralAccessFilter.probationPractitionerReferrals(referrals, user)
-  }
-
-  private fun getSentReferralsSentBy(user: AuthUser): List<Referral> {
-    return referralRepository.findBySentBy(user)
   }
 
   fun requestReferralEnd(referral: Referral, user: AuthUser, reason: CancellationReason, comments: String?): Referral {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,6 +102,8 @@ community-api:
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
     notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
     offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"
+    managed-offenders: "/secure/staff/staffIdentifier/{staffIdentifier}/managedOffenders"
+    staff-details: "/secure/staff/username/{username}"
   appointments:
     bookings:
       enabled: true

--- a/src/main/resources/db/migration/V1_57__add_index_on_referral_crn.sql
+++ b/src/main/resources/db/migration/V1_57__add_index_on_referral_crn.sql
@@ -1,0 +1,1 @@
+create index IX_referral_service_usercrn on referral (service_usercrn);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.authorization
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -8,12 +9,15 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.Integr
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
 
 class ListReferralEndpoints : IntegrationTestBase() {
   @MockBean
   lateinit var mockHmppsAuthService: HMPPSAuthService
+
+  @MockBean lateinit var mockCommunityAPIOffenderService: CommunityAPIOffenderService
 
   private lateinit var requestFactory: RequestFactory
 
@@ -176,6 +180,7 @@ class ListReferralEndpoints : IntegrationTestBase() {
     setupAssistant.createSentReferral(ppUser = user1)
     setupAssistant.createSentReferral(ppUser = user2)
 
+    whenever(mockCommunityAPIOffenderService.getManagedOffendersForDeliusUser(any())).thenReturn(emptyList())
     val token = createEncodedTokenForUser(user1)
     val response = requestFactory.create(Request.GetSentReferrals, token).exchange()
     response.expectStatus().is2xxSuccessful

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -11,47 +11,83 @@ import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 
-internal class CommunityAPIOffenderServiceTest {
-  private val authUserFactory = AuthUserFactory()
+private data class MockedResponse(
+  val path: String,
+  val status: HttpStatus,
+  val responseBody: String,
+)
 
-  private fun createMockedRestClient(status: HttpStatus, responseBody: String): RestClient {
+internal class CommunityAPIOffenderServiceTest {
+  private val user = AuthUserFactory().create()
+  private val offenderAccessLocation = "offender-access"
+  private val managedOffendersLocation = "managed-offenders"
+  private val staffDetailsLocation = "staff-details"
+
+  private fun createMockedRestClient(vararg responses: MockedResponse): RestClient {
     return RestClient(
       WebClient.builder()
-        .exchangeFunction {
-          Mono.just(
-            ClientResponse.create(status)
-              .header("content-type", "application/json")
-              .body(responseBody)
-              .build()
-          )
-        }.build()
+        .exchangeFunction exchange@{ req ->
+          responses.forEach {
+            if (req.url().path == it.path) {
+              return@exchange Mono.just(
+                ClientResponse.create(it.status)
+                  .header("content-type", "application/json")
+                  .body(it.responseBody)
+                  .build()
+              )
+            }
+          }
+          Mono.empty()
+        }
+        .build()
     )
+  }
+
+  private fun offenderServiceFactory(restClient: RestClient): CommunityAPIOffenderService {
+    return CommunityAPIOffenderService(offenderAccessLocation, managedOffendersLocation, staffDetailsLocation, restClient)
   }
 
   @Test
   fun `checkIfAuthenticatedDeliusUserHasAccessToServiceUser success`() {
-    val client = createMockedRestClient(HttpStatus.OK, "{\"exclusionMessage\": null, \"restrictionMessage\": null}")
-    val offenderService = CommunityAPIOffenderService("/", client)
-    val result = offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authUserFactory.create(), "X123456")
+    val response = MockedResponse(offenderAccessLocation, HttpStatus.OK, "{\"exclusionMessage\": null, \"restrictionMessage\": null}")
+    val offenderService = offenderServiceFactory(createMockedRestClient(response))
+    val result = offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user, "X123456")
     assertThat(result.canAccess).isTrue
     assertThat(result.messages).isEmpty()
   }
 
   @Test
   fun `checkIfAuthenticatedDeliusUserHasAccessToServiceUser forbidden`() {
-    val client = createMockedRestClient(HttpStatus.FORBIDDEN, "{\"exclusionMessage\": \"family exclusion\", \"restrictionMessage\": null}")
-    val offenderService = CommunityAPIOffenderService("/", client)
-    val result = offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authUserFactory.create(), "X123456")
+    val response = MockedResponse(offenderAccessLocation, HttpStatus.FORBIDDEN, "{\"exclusionMessage\": \"family exclusion\", \"restrictionMessage\": null}")
+    val offenderService = offenderServiceFactory(createMockedRestClient(response))
+    val result = offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user, "X123456")
     assertThat(result.canAccess).isFalse
     assertThat(result.messages).isEqualTo(listOf("family exclusion"))
   }
 
   @Test
   fun `checkIfAuthenticatedDeliusUserHasAccessToServiceUser unhandled error`() {
-    val client = createMockedRestClient(HttpStatus.INTERNAL_SERVER_ERROR, "{\"exclusionMessage\": null, \"restrictionMessage\": null}")
-    val offenderService = CommunityAPIOffenderService("/", client)
+    val response = MockedResponse(offenderAccessLocation, HttpStatus.INTERNAL_SERVER_ERROR, "")
+    val offenderService = offenderServiceFactory(createMockedRestClient(response))
     assertThrows<WebClientResponseException> {
-      offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(authUserFactory.create(), "X123456")
+      offenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user, "X123456")
     }
+  }
+
+  @Test
+  fun `getManagedOffendersForDeliusUser returns empty list if user has no staff identifier`() {
+    val response = MockedResponse(staffDetailsLocation, HttpStatus.NOT_FOUND, "")
+    val offenderService = offenderServiceFactory(createMockedRestClient(response))
+    val result = offenderService.getManagedOffendersForDeliusUser(user)
+    assertThat(result.isEmpty())
+  }
+
+  @Test
+  fun `getManagedOffendersForDeliusUser returns list of offenders`() {
+    val staffResponse = MockedResponse(staffDetailsLocation, HttpStatus.OK, "{\"staffIdentifier\": \"tom\"}")
+    val offendersResponse = MockedResponse(managedOffendersLocation, HttpStatus.OK, "[{\"crnNumber\": \"CRN123\"}, {\"crnNumber\": \"CRN456\"}]")
+    val offenderService = offenderServiceFactory(createMockedRestClient(staffResponse, offendersResponse))
+    val result = offenderService.getManagedOffendersForDeliusUser(user)
+    assertThat(result).isEqualTo(listOf(Offender("CRN123"), Offender("CRN456")))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -392,17 +392,20 @@ class ReferralServiceTest @Autowired constructor(
   }
 
   @Test
-  fun `get sent referrals sent by PP returns filtered referrals`() {
+  fun `get sent referrals for PP returns filtered referrals`() {
     val users = listOf(userFactory.create("pp_user_1", "delius"), userFactory.create("pp_user_2", "delius"))
     users.forEach {
-      referralFactory.createSent(sentBy = it)
+      referralFactory.createSent(createdBy = it)
     }
+
+    // this one should not be part of the result set - only referrals created by the pp!
+    referralFactory.createSent(sentBy = users[0])
 
     whenever(referralAccessFilter.probationPractitionerReferrals(any(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
 
     val referrals = referralService.getSentReferralsForUser(users[0])
     assertThat(referrals.size).isEqualTo(1)
-    assertThat(referrals[0].sentBy).isEqualTo(users[0])
+    assertThat(referrals[0].createdBy).isEqualTo(users[0])
 
     assertThat(referralService.getSentReferralsForUser(AuthUser("missing", "delius", "missing"))).isEmpty()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -62,6 +62,7 @@ class ReferralServiceUnitTest {
   private val userTypeChecker: UserTypeChecker = mock()
   private val serviceUserAccessChecker: ServiceUserAccessChecker = mock()
   private val assessRisksAndNeedsService: RisksAndNeedsService = mock()
+  private val communityAPIOffenderService: CommunityAPIOffenderService = mock()
 
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
@@ -76,7 +77,7 @@ class ReferralServiceUnitTest {
     referralEventPublisher, referralReferenceGenerator, cancellationReasonRepository,
     actionPlanSessionRepository, serviceCategoryRepository, referralAccessChecker, userTypeChecker,
     serviceProviderAccessScopeMapper, referralAccessFilter, communityAPIReferralService, serviceUserAccessChecker,
-    assessRisksAndNeedsService,
+    assessRisksAndNeedsService, communityAPIOffenderService,
   )
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

- changes the dashboard to show referrals _started_ by the PP , not sent by
- include referrals for offenders managed by the PP

## What is the intent behind these changes?

show pps all the referrals they need to see.
