### PR TITLE
Send domain events even if SNS is disabled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
@@ -24,18 +24,22 @@ class SNSPublisher(
   fun publish(referralId: UUID, actor: AuthUser, event: EventDTO) {
     if (enabled) {
       buildRequestAndPublish(event)
-      telemetryClient.trackEvent(
-        "InterventionsDomainEvent",
-        mapOf(
-          "event" to event.eventType,
-          "referralId" to referralId.toString(),
-          "actorUserId" to actor.id,
-        ),
-        null
-      )
     } else {
       logger.debug("Event notification was not published due to sns being disabled.")
     }
+    sendCustomEvent(referralId, actor, event.eventType)
+  }
+
+  private fun sendCustomEvent(referralId: UUID, actor: AuthUser, eventType: String) {
+    telemetryClient.trackEvent(
+      "InterventionsDomainEvent",
+      mapOf(
+        "event" to eventType,
+        "referralId" to referralId.toString(),
+        "actorUserId" to actor.id,
+      ),
+      null
+    )
   }
 
   private fun buildRequestAndPublish(event: EventDTO) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
@@ -73,6 +73,19 @@ class SNSPublisherTest {
   fun `event does not publish when service is disabled`() {
     snsPublisher(false).publish(aReferralId, aUser, event)
     verifyZeroInteractions(snsClient)
-    verifyZeroInteractions(telemetryClient)
+  }
+
+  @Test
+  fun `event still sends telemetry when service is disabled`() {
+    snsPublisher(false).publish(aReferralId, aUser, event)
+    verify(telemetryClient).trackEvent(
+      "InterventionsDomainEvent",
+      mapOf(
+        "event" to "intervention.test.event",
+        "referralId" to "82138d14-3835-442b-b39b-9f8a07650bbe",
+        "actorUserId" to "d7c4c3a7a7",
+      ),
+      null
+    )
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Send domain events as telemetry even if SNS integration is disabled

As per feedback in https://github.com/ministryofjustice/hmpps-interventions-service/pull/312#discussion_r648087392

## What is the intent behind these changes?

To make sure telemetry is independent from toggling features