### PR TITLE
IC-1912: 🪲 Count correct completion rate

### DIFF
--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
@@ -1,5 +1,6 @@
 WITH counts AS (
-    SELECT count(r.id) FILTER ( WHERE r.sent_at IS NULL )                   AS count_of_draft_referrals,
+    SELECT count(r.id)                                                      AS count_of_started_referrals,
+           count(r.id) FILTER ( WHERE r.sent_at IS NULL )                   AS count_of_draft_referrals,
            count(r.id) FILTER ( WHERE r.sent_at IS NOT NULL )               AS count_of_sent_referrals,
            count(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL )          AS count_of_concluded_referrals,
            count(r.id) FILTER ( WHERE r.sent_at IS NOT NULL AND
@@ -24,7 +25,8 @@ WITH counts AS (
          FROM referral
          WHERE sent_at IS NOT NULL)
 
-SELECT counts.count_of_draft_referrals,
+SELECT counts.count_of_started_referrals,
+       counts.count_of_draft_referrals,
        counts.count_of_sent_referrals,
        counts.count_of_concluded_referrals,
        counts.count_of_live_referrals,
@@ -33,8 +35,8 @@ SELECT counts.count_of_draft_referrals,
        counts.count_of_early_end_referrals,
        counts.count_of_pp_users_sending_referrals,
        case
-           when counts.count_of_draft_referrals = 0 then 0.0
-           else 100.0 * counts.count_of_sent_referrals / counts.count_of_draft_referrals
+           when counts.count_of_started_referrals = 0 then 0.0
+           else 100.0 * counts.count_of_sent_referrals / counts.count_of_started_referrals
            end AS completion_rate_percent,
        times.avg_completion_time,
        times.p50_completion_time,


### PR DESCRIPTION
## What does this pull request do?

Fix completion rate calculation introduced in #323 

## What is the intent behind these changes?

If we have 14 referrals, 10 drafts and 4 sents

Currently, the completion rate says 40% (4 completed out of 10)
It should say 28.57% (4 completed out of 14)

I'm not going to unit test this -- but once we have breathing space,
this is one of the best candidates to be moved to a reporting component,
possibly a section of our API, HTTP or otherwise