### PR TITLE
IC-1906 Serialised EoSR Submitted And Referral End Notifications/Updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -119,7 +119,7 @@ class CommunityAPIReferralEventService(
 
   private fun postNotificationRequest(endOfServiceReport: EndOfServiceReport?) {
 
-    endOfServiceReport?.submittedAt?: run {
+    endOfServiceReport?.submittedAt ?: run {
       throw IllegalStateException("End of service report not submitted so should not get to this point")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -82,6 +82,10 @@ class CommunityAPIReferralEventService(
       ReferralEventType.COMPLETED,
       -> {
 
+        // This should be an independent event based notification
+        // However a race condition arises with the referral end
+        // notification. To Avoid a NSI not found in community-api
+        // this must be sent and processed before referral end
         postNotificationRequest(event.referral.endOfServiceReport)
 
         val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIEndOfServiceReportEventServiceTest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
@@ -19,7 +19,7 @@ class CommunityAPIEndOfServiceReportEventServiceTest {
   private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
   private val submittedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
 
-  val communityAPIService = CommunityAPIEndOfServiceReportEventService(
+  private val communityAPIService = CommunityAPIEndOfServiceReportEventService(
     "http://testUrl",
     "/probation-practitioner/end-of-service-report/{id}",
     "/secure/offenders/crn/{crn}/sentence/{sentenceId}/notifications/context/{contextName}",
@@ -28,22 +28,12 @@ class CommunityAPIEndOfServiceReportEventServiceTest {
   )
 
   @Test
-  fun `notify submitted end of service report`() {
+  fun `nothing is notified as its done as part of the referral end event`() {
 
     val event = getEvent(SUBMITTED)
     communityAPIService.onApplicationEvent(event)
 
-    verify(communityAPIClient).makeAsyncPostRequest(
-      "/secure/offenders/crn/X123456/sentence/1234/notifications/context/commissioned-rehabilitation-services",
-      NotificationCreateRequestDTO(
-        "ACC",
-        sentAtDefault,
-        event.endOfServiceReport.referral.id,
-        submittedAtDefault,
-        "End of Service Report Submitted for Accommodation Referral XX1234 with Prime Provider Harmony Living\n" +
-          "http://testUrl/probation-practitioner/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
-      )
-    )
+    verifyZeroInteractions(communityAPIClient)
   }
 
   private fun getEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
+import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
@@ -19,6 +21,7 @@ class CommunityAPIReferralEventServiceTest {
 
   private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
   private val concludedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
+  private val submittedAtDefault = OffsetDateTime.of(2020, 3, 3, 3, 3, 3, 3, ZoneOffset.UTC)
 
   private val communityAPIService = CommunityAPIReferralEventService(
     "http://testUrl",
@@ -27,6 +30,7 @@ class CommunityAPIReferralEventServiceTest {
     "/referral/end-of-service-report/{id}",
     "secure/offenders/crn/{crn}/referral/start/context/{contextName}",
     "secure/offenders/crn/{crn}/referral/end/context/{contextName}",
+    "secure/offenders/crn/{crn}/sentence/{sentenceId}/notifications/context/{contextName}",
     "commissioned-rehabilitation-services",
     communityAPIClient
   )
@@ -67,7 +71,21 @@ class CommunityAPIReferralEventServiceTest {
     val event = getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault, endOfServiceReport)
     communityAPIService.onApplicationEvent(event)
 
-    verify(communityAPIClient).makeAsyncPostRequest(
+    val inOrder = inOrder(communityAPIClient)
+
+    inOrder.verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/sentence/123456789/notifications/context/commissioned-rehabilitation-services",
+      NotificationCreateRequestDTO(
+        "ACC",
+        sentAtDefault,
+        event.referral.id,
+        submittedAtDefault,
+        "End of Service Report Submitted for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
+          "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+
+    inOrder.verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
       ReferralEndRequest(
         "ACC",
@@ -83,12 +101,33 @@ class CommunityAPIReferralEventServiceTest {
   }
 
   @Test
+  fun `notify prematurely ended throws exception when no end of service report exists`() {
+
+    val event = getEvent(ReferralEventType.PREMATURELY_ENDED, concludedAtDefault)
+    assertThrows<IllegalStateException> { communityAPIService.onApplicationEvent(event) }
+  }
+
+  @Test
   fun `notify completed referral`() {
 
     val event = getEvent(ReferralEventType.COMPLETED, concludedAtDefault, endOfServiceReport)
     communityAPIService.onApplicationEvent(event)
 
-    verify(communityAPIClient).makeAsyncPostRequest(
+    val inOrder = inOrder(communityAPIClient)
+
+    inOrder.verify(communityAPIClient).makeAsyncPostRequest(
+      "secure/offenders/crn/X123456/sentence/123456789/notifications/context/commissioned-rehabilitation-services",
+      NotificationCreateRequestDTO(
+        "ACC",
+        sentAtDefault,
+        event.referral.id,
+        submittedAtDefault,
+        "End of Service Report Submitted for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
+          "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
+      )
+    )
+
+    inOrder.verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
       ReferralEndRequest(
         "ACC",
@@ -101,6 +140,13 @@ class CommunityAPIReferralEventServiceTest {
           "http://testUrl/referral/end-of-service-report/120b1a45-8ac7-4920-b05b-acecccf4734b",
       )
     )
+  }
+
+  @Test
+  fun `notify cancelled referral throws exception when no end of service report exists`() {
+
+    val event = getEvent(ReferralEventType.COMPLETED, concludedAtDefault)
+    assertThrows<IllegalStateException> { communityAPIService.onApplicationEvent(event) }
   }
 
   private fun getEvent(
@@ -127,6 +173,14 @@ class CommunityAPIReferralEventServiceTest {
   private val endOfServiceReport =
     SampleData.sampleEndOfServiceReport(
       id = UUID.fromString("120b1a45-8ac7-4920-b05b-acecccf4734b"),
-      referral = SampleData.sampleReferral(crn = "X123456", serviceProviderName = "Harmony Living"),
+      referral = SampleData.sampleReferral(
+        id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
+        referenceNumber = "HAS71263",
+        crn = "X123456",
+        relevantSentenceId = 123456789,
+        serviceProviderName = "Harmony Living",
+        sentAt = sentAtDefault,
+        concludedAt = concludedAtDefault),
+      submittedAt = submittedAtDefault
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
@@ -180,7 +180,8 @@ class CommunityAPIReferralEventServiceTest {
         relevantSentenceId = 123456789,
         serviceProviderName = "Harmony Living",
         sentAt = sentAtDefault,
-        concludedAt = concludedAtDefault),
+        concludedAt = concludedAtDefault
+      ),
       submittedAt = submittedAtDefault
     )
 }


### PR DESCRIPTION
## What does this pull request do?
EoS Report and Referral End should be independent event based notifications/updates. However a race condition arises between them, such that if the referral has been terminated in delius before the EoSR notification is consumed, a NSI not found exception is raised in community-api. As a temporary measure, these notifications have been serialised.

## What is the intent behind these changes?
This is a temporary fix to ensure all notifications are successfully processed by delius and delius remains up to date.
