### PR TITLE
IC-1891 Fix for exception when non-attendance and there is no session feedback

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentsService.kt
@@ -119,8 +119,12 @@ class AppointmentsService(
     actionPlanAppointmentRepository.save(appointment)
 
     appointmentEventPublisher.attendanceRecordedEvent(appointment, appointment.attended == Attended.NO)
-    appointmentEventPublisher.behaviourRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour!!)
-    appointmentEventPublisher.sessionFeedbackRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour!!)
+
+    if (appointment.notifyPPOfAttendanceBehaviour != null) {
+      appointmentEventPublisher.behaviourRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour!!)
+    }
+
+    appointmentEventPublisher.sessionFeedbackRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour ?: false)
     return appointment
   }
 


### PR DESCRIPTION
## What does this pull request do?
When non-attendance and there is no session feedback an exception is thrown. This is a fix to deal with this scenario.

## What is the intent behind these changes?
Bug fix.