### PR TITLE
add the concept of approvals to action plans

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
@@ -13,7 +13,9 @@ data class ActionPlanDTO(
   val createdBy: AuthUserDTO,
   val createdAt: OffsetDateTime,
   val submittedBy: AuthUserDTO?,
-  val submittedAt: OffsetDateTime?
+  val submittedAt: OffsetDateTime?,
+  val approvedBy: AuthUserDTO?,
+  val approvedAt: OffsetDateTime?
 ) {
   companion object {
     fun from(actionPlan: ActionPlan): ActionPlanDTO {
@@ -26,6 +28,8 @@ data class ActionPlanDTO(
         createdAt = actionPlan.createdAt,
         submittedBy = actionPlan.submittedBy?.let { AuthUserDTO.from(it) },
         submittedAt = actionPlan.submittedAt,
+        approvedBy = actionPlan.approvedBy?.let { AuthUserDTO.from(it) },
+        approvedAt = actionPlan.approvedAt,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanEventPublisher.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionP
 
 enum class ActionPlanEventType {
   SUBMITTED,
+  APPROVED,
 }
 
 class ActionPlanEvent(source: Any, val type: ActionPlanEventType, val actionPlan: ActionPlan, val detailUrl: String) : ApplicationEvent(source) {
@@ -25,6 +26,10 @@ class ActionPlanEventPublisher(
 
   fun actionPlanSubmitEvent(actionPlan: ActionPlan) {
     applicationEventPublisher.publishEvent(ActionPlanEvent(this, ActionPlanEventType.SUBMITTED, actionPlan, createDetailUrl(actionPlan)))
+  }
+
+  fun actionPlanApprovedEvent(actionPlan: ActionPlan) {
+    applicationEventPublisher.publishEvent(ActionPlanEvent(this, ActionPlanEventType.APPROVED, actionPlan, createDetailUrl(actionPlan)))
   }
 
   private fun createDetailUrl(actionPlan: ActionPlan): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlan.kt
@@ -31,6 +31,8 @@ data class ActionPlan(
   @NotNull val createdAt: OffsetDateTime,
   @ManyToOne @Fetch(FetchMode.JOIN) var submittedBy: AuthUser? = null,
   var submittedAt: OffsetDateTime? = null,
+  @ManyToOne @Fetch(FetchMode.JOIN) var approvedBy: AuthUser? = null,
+  var approvedAt: OffsetDateTime? = null,
 
   // Required
   @NotNull @OneToOne @Fetch(FetchMode.JOIN) val referral: Referral,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.ActionPlanValidator
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventPublisher
@@ -95,9 +96,8 @@ class ActionPlanService(
   }
 
   fun getActionPlan(id: UUID): ActionPlan {
-    return actionPlanRepository.findById(id).orElseThrow {
-      throw EntityNotFoundException("action plan not found [id=$id]")
-    }
+    return actionPlanRepository.findByIdOrNull(id)
+      ?: throw EntityNotFoundException("action plan not found [id=$id]")
   }
 
   fun getActionPlanByReferral(referralId: UUID): ActionPlan {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -77,8 +77,6 @@ class ActionPlanService(
     val submittedActionPlan = updateDraftActionPlanAsSubmitted(draftActionPlan, submittedByUser)
     actionPlanValidator.validateSubmittedActionPlan(submittedActionPlan)
 
-    actionPlanSessionsService.createUnscheduledSessionsForActionPlan(submittedActionPlan)
-
     val savedSubmittedActionPlan = actionPlanRepository.save(submittedActionPlan)
     actionPlanEventPublisher.actionPlanSubmitEvent(savedSubmittedActionPlan)
 
@@ -89,6 +87,8 @@ class ActionPlanService(
     val actionPlan = getActionPlan(id)
     actionPlan.approvedAt = OffsetDateTime.now()
     actionPlan.approvedBy = authUserRepository.save(user)
+
+    actionPlanSessionsService.createUnscheduledSessionsForActionPlan(actionPlan)
     return actionPlanRepository.save(actionPlan)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -89,7 +89,9 @@ class ActionPlanService(
     actionPlan.approvedBy = authUserRepository.save(user)
 
     actionPlanSessionsService.createUnscheduledSessionsForActionPlan(actionPlan)
-    return actionPlanRepository.save(actionPlan)
+    val approvedActionPlan = actionPlanRepository.save(actionPlan)
+    actionPlanEventPublisher.actionPlanSubmitEvent(approvedActionPlan)
+    return approvedActionPlan
   }
 
   fun getActionPlan(id: UUID): ActionPlan {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -85,6 +85,13 @@ class ActionPlanService(
     return savedSubmittedActionPlan
   }
 
+  fun approveActionPlan(id: UUID, user: AuthUser): ActionPlan {
+    val actionPlan = getActionPlan(id)
+    actionPlan.approvedAt = OffsetDateTime.now()
+    actionPlan.approvedBy = authUserRepository.save(user)
+    return actionPlanRepository.save(actionPlan)
+  }
+
   fun getActionPlan(id: UUID): ActionPlan {
     return actionPlanRepository.findById(id).orElseThrow {
       throw EntityNotFoundException("action plan not found [id=$id]")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -29,10 +29,10 @@ class ActionPlanSessionsService(
   val communityAPIBookingService: CommunityAPIBookingService,
   val appointmentRepository: AppointmentRepository,
 ) {
-  fun createUnscheduledSessionsForActionPlan(submittedActionPlan: ActionPlan) {
-    val numberOfSessions = submittedActionPlan.numberOfSessions!!
+  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan) {
+    val numberOfSessions = approvedActionPlan.numberOfSessions!!
     for (i in 1..numberOfSessions) {
-      createSession(submittedActionPlan, i)
+      createSession(approvedActionPlan, i)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -33,6 +33,16 @@ class SNSActionPlanService(
         )
         snsPublisher.publish(event.actionPlan.referral.id, event.actionPlan.submittedBy!!, snsEvent)
       }
+      ActionPlanEventType.APPROVED -> {
+        val snsEvent = EventDTO(
+          "intervention.action-plan.approved",
+          "An action plan has been approved",
+          event.detailUrl,
+          event.actionPlan.approvedAt!!,
+          mapOf("actionPlanId" to event.actionPlan.id, "approvedBy" to (event.actionPlan.approvedBy?.userName!!))
+        )
+        snsPublisher.publish(event.actionPlan.referral.id, event.actionPlan.approvedBy!!, snsEvent)
+      }
     }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ notify:
     referral-sent: "336f2158-d130-4c63-a59b-da12df15a5a3"
     referral-assigned: "f0fe2fce-df0f-46c0-839a-822037d39c28"
     action-plan-submitted: "83743b43-9abb-4ffb-913d-dc583ab22dbf"
+    action-plan-approved: "f060e1ae-c2a6-4752-ad20-436120c5880b "
     appointment-not-attended: "21b14c86-30d2-4bf2-b355-8f3deb62ef69"
     concerning-behaviour: "a8ef6769-4c8e-4459-938c-19dd4b661b04"
     end-of-service-report-submitted: "f79cb53f-dc5c-42aa-947e-f599f9ad7942"

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -89,6 +89,8 @@ COMMENT ON COLUMN action_plan.created_by_id IS 'who the service user''s action p
 COMMENT ON COLUMN action_plan.created_at IS 'when the service user''s action plan was created';
 COMMENT ON COLUMN action_plan.submitted_at IS 'when the service user''s action plan was submitted for approval';
 COMMENT ON COLUMN action_plan.submitted_by_id IS 'who submitted the service user''s action plan';
+COMMENT ON COLUMN action_plan.approved_at IS 'when the service user''s action plan was approved';
+COMMENT ON COLUMN action_plan.approved_by_id IS 'who approved the service user''s action plan';
 
 COMMENT ON TABLE action_plan_activity IS 'service user''s action plan activity details';
 COMMENT ON COLUMN action_plan_activity.id IS 'service user''s action plan activity unique identifier';

--- a/src/main/resources/db/migration/V1_58__action_plan_approval_fields.sql
+++ b/src/main/resources/db/migration/V1_58__action_plan_approval_fields.sql
@@ -1,0 +1,4 @@
+alter table action_plan
+    add column approved_at timestamp with time zone,
+    add column approved_by_id text,
+    add constraint fk_action_plan_approved_by foreign key (approved_by_id) references auth_user;

--- a/src/main/resources/db/migration/V1_58__action_plan_approval_fields.sql
+++ b/src/main/resources/db/migration/V1_58__action_plan_approval_fields.sql
@@ -2,3 +2,6 @@ alter table action_plan
     add column approved_at timestamp with time zone,
     add column approved_by_id text,
     add constraint fk_action_plan_approved_by foreign key (approved_by_id) references auth_user;
+
+alter table action_plan_session
+    add unique (action_plan_id, session_number);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanControllerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers.ActionPlanMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ActionPlanDTO
@@ -35,8 +36,15 @@ internal class ActionPlanControllerTest {
   private val userMapper = mock<UserMapper>()
   private val actionPlanService = mock<ActionPlanService>()
   private val locationMapper = mock<LocationMapper>()
+  private val userTypeChecker = mock<UserTypeChecker>()
 
-  private val actionPlanController = ActionPlanController(actionPlanMapper, userMapper, actionPlanService, locationMapper)
+  private val actionPlanController = ActionPlanController(
+    actionPlanMapper,
+    userMapper,
+    actionPlanService,
+    locationMapper,
+    userTypeChecker,
+  )
 
   @Test
   fun `throws error if an action plan already exists for the referral`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.mockito.AdditionalAnswers
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.ActionPlanValidator
@@ -203,23 +204,20 @@ internal class ActionPlanServiceTest {
 
     assertThat(submittedActionPlan).isNotNull
     verify(actionPlanValidator).validateSubmittedActionPlan(any())
-    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(any())
   }
 
   @Test
-  fun `creates unscheduled sessions`() {
+  fun `action plan approval sets approved and creates unscheduled sessions`() {
     val actionPlanId = UUID.randomUUID()
     val actionPlan = SampleData.sampleActionPlan(id = actionPlanId, numberOfSessions = 2)
     val authUser = AuthUser("CRN123", "auth", "user")
-    whenever(actionPlanRepository.findByIdAndSubmittedAtIsNull(actionPlanId)).thenReturn(actionPlan)
-    val savedActionPlan = SampleData.sampleActionPlan()
-    whenever(actionPlanRepository.save(any())).thenReturn(savedActionPlan)
-    whenever(authUserRepository.save(any())).thenReturn(SampleData.sampleAuthUser())
+    whenever(actionPlanRepository.findById(actionPlanId)).thenReturn(of(actionPlan))
+    whenever(authUserRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<AuthUser>())
+    whenever(actionPlanRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<ActionPlan>())
 
-    val submittedActionPlan = actionPlanService.submitDraftActionPlan(actionPlanId, authUser)
-
-    assertThat(submittedActionPlan).isEqualTo(savedActionPlan)
-    verify(actionPlanValidator).validateSubmittedActionPlan(any())
+    val approvedActionPlan = actionPlanService.approveActionPlan(actionPlanId, authUser)
+    assertThat(approvedActionPlan.approvedAt).isNotNull
+    assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
     verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(actionPlan))
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -59,25 +59,14 @@ internal class ActionPlanServiceTest {
     whenever(referralRepository.getOne(referralId)).thenReturn(referral)
     whenever(
       actionPlanRepository.save(
-        ArgumentMatchers.argThat { (
-          numberOfSessionsArg,
-          activitiesArg,
-          createdByArg,
-          _,
-          submittedByArg,
-          submittedAtArg,
-          referralArg,
-          _
-        ) ->
-          (
-            numberOfSessionsArg == numberOfSessions &&
-              activitiesArg.size == activities.size &&
-              activitiesArg.first() == activities.first() &&
-              createdByArg == authUser &&
-              submittedAtArg == null &&
-              submittedByArg == null &&
-              referralArg.equals(referral)
-            )
+        ArgumentMatchers.argThat {
+          it.numberOfSessions == numberOfSessions &&
+            it.activities.size == activities.size &&
+            it.activities.first() == activities.first() &&
+            it.createdBy == authUser &&
+            it.submittedAt == null &&
+            it.submittedBy == null &&
+            it.referral == referral
         }
       )
     ).thenReturn(SampleData.sampleActionPlan())
@@ -194,27 +183,17 @@ internal class ActionPlanServiceTest {
     whenever(actionPlanRepository.findByIdAndSubmittedAtIsNull(actionPlanId)).thenReturn(actionPlan)
     whenever(
       actionPlanRepository.save(
-        ArgumentMatchers.argThat { (
-          numberOfSessionsArg,
-          activitiesArg,
-          createdByArg,
-          createdAtArg,
-          submittedByArg,
-          submittedAtArg,
-          referralArg,
-          idArg,
-        ) ->
-          (
-            numberOfSessionsArg == actionPlan.numberOfSessions &&
-              activitiesArg.size == actionPlan.activities.size &&
-              activitiesArg.first() == actionPlan.activities.first() &&
-              createdByArg == actionPlan.createdBy &&
-              createdAtArg == actionPlan.createdAt &&
-              submittedAtArg!!.isAfter(timeBeforeSubmit) &&
-              submittedByArg!! == authUser &&
-              referralArg == actionPlan.referral &&
-              idArg == actionPlanId
-            )
+        ArgumentMatchers.argThat {
+          it.numberOfSessions == actionPlan.numberOfSessions &&
+            it.activities.size == actionPlan.activities.size &&
+            it.activities.first() == actionPlan.activities.first() &&
+            it.createdAt == actionPlan.createdAt &&
+            it.createdBy == actionPlan.createdBy &&
+            it.submittedAt!!.isAfter(timeBeforeSubmit) &&
+            it.submittedBy == authUser &&
+            it.approvedAt == null &&
+            it.approvedBy == null &&
+            it.referral == actionPlan.referral
         }
       )
     ).thenReturn(SampleData.sampleActionPlan())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
@@ -13,15 +13,18 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSender
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType.APPROVED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType.SUBMITTED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class NotifyActionPlanServiceTest {
   private val emailSender = mock<EmailSender>()
   private val hmppsAuthService = mock<HMPPSAuthService>()
+  private val actionPlanFactory = ActionPlanFactory()
 
   private val actionPlanSubmittedEvent = ActionPlanEvent(
     "source",
@@ -37,6 +40,16 @@ class NotifyActionPlanServiceTest {
         sentBy = AuthUser("abc999", "auth", "abc999")
       ),
       submittedBy = AuthUser("abc123", "auth", "abc123")
+    ),
+    "http://localhost:8080/action-plan/42c7d267-0776-4272-a8e8-a673bfe30d0d",
+  )
+
+  private val actionPlanApprovedEvent = ActionPlanEvent(
+    "source",
+    APPROVED,
+    actionPlanFactory.createApproved(
+      id = UUID.fromString("42c7d267-0776-4272-a8e8-a673bfe30d0d"),
+      submittedBy = AuthUser("abc123", "auth", "abc123"),
     ),
     "http://localhost:8080/action-plan/42c7d267-0776-4272-a8e8-a673bfe30d0d",
   )
@@ -62,13 +75,37 @@ class NotifyActionPlanServiceTest {
   }
 
   @Test
-  fun `referral assigned event does not swallow hmpps auth errors`() {
+  fun `action plan approved event does not send email when user details are not available`() {
+    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    assertThrows<RuntimeException> {
+      notifyService().onApplicationEvent(actionPlanApprovedEvent)
+    }
+    verifyZeroInteractions(emailSender)
+  }
+
+  @Test
+  fun `action plan approved event generates valid url and sends an email`() {
+    val event = actionPlanApprovedEvent
+    val actionPlan = event.actionPlan
+    whenever(hmppsAuthService.getUserDetail(actionPlan.submittedBy!!))
+      .thenReturn(UserDetail("tom", "tom@tom.tom"))
+
+    notifyService().onApplicationEvent(actionPlanApprovedEvent)
+    val personalisationCaptor = argumentCaptor<Map<String, String>>()
+    verify(emailSender).sendEmail(eq("template"), eq("tom@tom.tom"), personalisationCaptor.capture())
+    assertThat(personalisationCaptor.firstValue["submitterFirstName"]).isEqualTo("tom")
+    assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo(actionPlan.referral.referenceNumber)
+    assertThat(personalisationCaptor.firstValue["actionPlanUrl"]).isEqualTo("http://example.com/action-plan/42c7d267-0776-4272-a8e8-a673bfe30d0d")
+  }
+
+  @Test
+  fun `action plan submitted event does not swallow hmpps auth errors`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenThrow(UnverifiedEmailException::class.java)
     assertThrows<UnverifiedEmailException> { notifyService().onApplicationEvent(actionPlanSubmittedEvent) }
   }
 
   @Test
-  fun `referral assigned event generates valid url and sends an email`() {
+  fun `action plan submitted event generates valid url and sends an email`() {
     whenever(hmppsAuthService.getUserDetail(AuthUser("abc999", "auth", "abc999")))
       .thenReturn(UserDetail("tom", "tom@tom.tom"))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
@@ -44,6 +44,7 @@ class NotifyActionPlanServiceTest {
   private fun notifyService(): NotifyActionPlanService {
     return NotifyActionPlanService(
       "template",
+      "template",
       "http://example.com",
       "/action-plan/{id}",
       emailSender,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ActionPlanFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ActionPlanFactory.kt
@@ -11,22 +11,72 @@ class ActionPlanFactory(em: TestEntityManager? = null) : EntityFactory(em) {
   private val authUserFactory = AuthUserFactory(em)
   private val referralFactory = ReferralFactory(em)
 
-  fun create(
-    id: UUID? = null,
-    referral: Referral? = null,
+  fun createSubmitted(
+    id: UUID = UUID.randomUUID(),
+    referral: Referral = referralFactory.createSent(),
     numberOfSessions: Int? = null,
-    createdAt: OffsetDateTime? = null,
-    createdBy: AuthUser? = null,
+    createdAt: OffsetDateTime = OffsetDateTime.now(),
+    createdBy: AuthUser = authUserFactory.create(),
+    submittedAt: OffsetDateTime? = createdAt,
+    submittedBy: AuthUser? = createdBy,
+  ): ActionPlan {
+    return create(
+      id = id,
+      referral = referral,
+      numberOfSessions = numberOfSessions,
+      createdAt = createdAt,
+      createdBy = createdBy,
+      submittedAt = submittedAt,
+      submittedBy = submittedBy,
+    )
+  }
+
+  fun createApproved(
+    id: UUID = UUID.randomUUID(),
+    referral: Referral = referralFactory.createSent(),
+    numberOfSessions: Int? = null,
+    createdAt: OffsetDateTime = OffsetDateTime.now(),
+    createdBy: AuthUser = authUserFactory.create(),
+    submittedAt: OffsetDateTime? = createdAt,
+    submittedBy: AuthUser? = createdBy,
+    approvedAt: OffsetDateTime? = submittedAt,
+    approvedBy: AuthUser? = authUserFactory.create(authSource = "delius"),
+  ): ActionPlan {
+    return create(
+      id = id,
+      referral = referral,
+      numberOfSessions = numberOfSessions,
+      createdAt = createdAt,
+      createdBy = createdBy,
+      submittedAt = submittedAt,
+      submittedBy = submittedBy,
+      approvedAt = approvedAt,
+      approvedBy = approvedBy,
+    )
+  }
+
+  fun create(
+    id: UUID = UUID.randomUUID(),
+    referral: Referral = referralFactory.createSent(),
+    numberOfSessions: Int? = null,
+    createdAt: OffsetDateTime = OffsetDateTime.now(),
+    createdBy: AuthUser = authUserFactory.create(),
     submittedAt: OffsetDateTime? = null,
+    submittedBy: AuthUser? = null,
+    approvedAt: OffsetDateTime? = null,
+    approvedBy: AuthUser? = null,
   ): ActionPlan {
     return save(
       ActionPlan(
-        id = id ?: UUID.randomUUID(),
-        referral = referral ?: referralFactory.createSent(),
+        id = id,
+        referral = referral,
         numberOfSessions = numberOfSessions,
-        createdAt = createdAt ?: OffsetDateTime.now(),
-        createdBy = createdBy ?: authUserFactory.create(),
-        submittedAt = submittedAt ?: OffsetDateTime.now(),
+        createdAt = createdAt,
+        createdBy = createdBy,
+        submittedAt = submittedAt,
+        submittedBy = submittedBy,
+        approvedAt = approvedAt,
+        approvedBy = approvedBy,
         activities = mutableListOf()
       )
     )


### PR DESCRIPTION
## What does this pull request do?

add action plan 'approvedBy' and 'approvedAt' fields
adds controller / service methods for approving action plans 
stops session creation on action plan submission and moves it to action plan approval
adds sns and notify events for action plan approval

## What is the intent behind these changes?

initially, the intent is just to stop action plans being implicitly approved on submission. this is the start of more work to come.
