### PR TITLE
IC-1891 Prevent exception by checking attendance behaviour provided b…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -144,8 +144,12 @@ class ActionPlanSessionsService(
     actionPlanSessionRepository.save(session)
 
     appointmentEventPublisher.attendanceRecordedEvent(session, appointment.attended!! == Attended.NO)
-    appointmentEventPublisher.behaviourRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour!!)
-    appointmentEventPublisher.sessionFeedbackRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour!!)
+
+    if (appointment.attendanceBehaviourSubmittedAt != null) { // excluding the case of non attendance
+      appointmentEventPublisher.behaviourRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour!!)
+    }
+
+    appointmentEventPublisher.sessionFeedbackRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour ?: false)
     return session
   }
 


### PR DESCRIPTION
…efore sending event

## What does this pull request do?
When non-attendance, there is no session feedback, and the code throws an exception as it assumes it does exist. This is a fix to deal with this scenario.

## What is the intent behind these changes?
Bug fix