### PR TITLE
Feedback test improvements

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ActionPlanSessionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ActionPlanSessionFactory.kt
@@ -77,13 +77,13 @@ class ActionPlanSessionFactory(em: TestEntityManager? = null) : EntityFactory(em
       createdAt = createdAt,
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
-      appointmentFeedbackSubmittedBy = createdBy,
       deliusAppointmentId = deliusAppointmentId,
       attended = attended,
       attendanceSubmittedAt = attendanceSubmittedAt,
       additionalAttendanceInformation = additionalAttendanceInformation,
       notifyPPOfAttendanceBehaviour = notifyPPOfAttendanceBehaviour,
       appointmentFeedbackSubmittedAt = appointmentFeedbackSubmittedAt,
+      appointmentFeedbackSubmittedBy = appointmentFeedbackSubmittedBy,
     )
 
     return save(


### PR DESCRIPTION
## What does this pull request do?

Minor tweaks:

1. Fixes a factory method using not intended input
2. Adds an assertion that validates that `appointmentFeedbackSubmittedBy` is set to the submitter

## What is the intent behind these changes?

Increasing test robustness