### PR TITLE
IC-1895: Move incoming referral email addresses to interventions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Intervention.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Intervention.kt
@@ -15,6 +15,7 @@ data class Intervention(
 
   @NotNull val title: String,
   @NotNull val description: String,
+  @NotNull val incomingReferralDistributionEmail: String,
 
   @NotNull @OneToOne @JoinColumn(name = "dynamic_framework_contract_id")
   val dynamicFrameworkContract: DynamicFrameworkContract,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProvider.kt
@@ -11,7 +11,6 @@ data class ServiceProvider(
   // Service Provider id maps to the hmpps-auth field Group#groupCode
   @NotNull @Id val id: AuthGroupID,
   @NotNull val name: String,
-  @NotNull val incomingReferralDistributionEmail: String,
 ) {
   override fun hashCode(): Int {
     return id.hashCode()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
@@ -142,13 +142,13 @@ class NotifyReferralService(
   @AsyncEventExceptionHandling
   override fun onApplicationEvent(event: ReferralEvent) {
     when (event.type) {
-
       ReferralEventType.SENT -> {
         val location = generateResourceUrl(interventionsUIBaseURL, interventionsUISentReferralLocation, event.referral.id)
-        val serviceProvider = event.referral.intervention.dynamicFrameworkContract.primeProvider
+        val intervention = event.referral.intervention
+        val serviceProvider = intervention.dynamicFrameworkContract.primeProvider
         emailSender.sendEmail(
           referralSentTemplateID,
-          serviceProvider.incomingReferralDistributionEmail,
+          intervention.incomingReferralDistributionEmail,
           mapOf(
             "organisationName" to serviceProvider.name,
             "referenceNumber" to event.referral.referenceNumber!!,

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -31,7 +31,6 @@ COMMENT ON COLUMN pcc_region.nps_region_id IS 'the ID of the National Probation 
 COMMENT ON TABLE service_provider IS 'service provider details';
 COMMENT ON COLUMN service_provider.id IS 'service provider unique identifier, used in hmpps-auth as group code';
 COMMENT ON COLUMN service_provider.name IS 'service provider name';
-COMMENT ON COLUMN service_provider.incoming_referral_distribution_email IS 'service provider email address';
 
 COMMENT ON TABLE intervention IS 'intervention details';
 COMMENT ON COLUMN intervention.id IS 'intervention unique identifier';
@@ -39,6 +38,7 @@ COMMENT ON COLUMN intervention.dynamic_framework_contract_id IS 'dynamic framewo
 COMMENT ON COLUMN intervention.created_at IS 'when the record was added';
 COMMENT ON COLUMN intervention.title IS 'intervention name';
 COMMENT ON COLUMN intervention.description IS 'intervention description';
+COMMENT ON COLUMN intervention.incoming_referral_distribution_email IS 'email address receiving notifications about new referrals';
 
 COMMENT ON TABLE referral IS 'referral details';
 COMMENT ON COLUMN referral.id IS 'referral unique identifier';

--- a/src/main/resources/db/migration/V1_58__move_emails_to_interventions.sql
+++ b/src/main/resources/db/migration/V1_58__move_emails_to_interventions.sql
@@ -1,0 +1,10 @@
+alter table intervention
+    add column incoming_referral_distribution_email text not null default '__no_data__';
+
+update intervention i
+set incoming_referral_distribution_email = p.incoming_referral_distribution_email
+from service_provider p join dynamic_framework_contract c on p.id = c.prime_provider_id
+where i.dynamic_framework_contract_id = c.id;
+
+alter table service_provider
+    drop column incoming_referral_distribution_email;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -29,11 +29,9 @@ class SampleData {
         ServiceProviderFactory(em).create(
           id = it.id,
           name = it.name,
-          incomingReferralDistributionEmail = it.incomingReferralDistributionEmail,
         )
       }
 
-//      em.persist(intervention.dynamicFrameworkContract.contractEligibility)
       em.persist(intervention.dynamicFrameworkContract.contractType)
       em.persist(intervention.dynamicFrameworkContract)
       return em.persistAndFlush(intervention)
@@ -108,6 +106,7 @@ class SampleData {
         • Bulleted list
         • With indentation and unicode
       """,
+      incomingReferralDistributionEmail: String = "acc-inbox@provider.example.com",
       dynamicFrameworkContract: DynamicFrameworkContract,
       id: UUID? = null,
       createdAt: OffsetDateTime? = null,
@@ -117,6 +116,7 @@ class SampleData {
         createdAt = createdAt ?: OffsetDateTime.now(),
         title = title,
         description = description,
+        incomingReferralDistributionEmail = incomingReferralDistributionEmail,
         dynamicFrameworkContract = dynamicFrameworkContract,
       )
     }
@@ -238,9 +238,8 @@ class SampleData {
     fun sampleServiceProvider(
       id: AuthGroupID = "HARMONY_LIVING",
       name: String = "Harmony Living",
-      emailAddress: String = "contact@harmonyLiving.com",
     ): ServiceProvider {
-      return ServiceProvider(id, name, emailAddress)
+      return ServiceProvider(id, name)
     }
 
     fun sampleServiceCategory(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -296,17 +296,5 @@ class SampleData {
     ): AuthUser {
       return AuthUser(id, authSource, userName)
     }
-
-    fun sampleCancellationReason(
-      id: String = "MIS",
-      description: String = "Referral was made by mistake"
-    ): CancellationReason {
-      return CancellationReason(id, description)
-    }
-
-    fun persistPCCRegion(em: TestEntityManager, pccRegion: PCCRegion): PCCRegion {
-      em.persist(pccRegion.npsRegion)
-      return em.persistAndFlush(pccRegion)
-    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -54,7 +54,7 @@ internal class CommunityAPIBookingServiceTest {
 
   @Test
   fun `requests booking for a new appointment`() {
-    val now = OffsetDateTime.now()
+    val now = now()
 
     val uri = "/appt/X1/123/CRS"
     val notes = "Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -28,7 +28,7 @@ internal class CommunityAPIBookingServiceTest {
     relevantSentenceId = 123L,
     referenceNumber = "XX123456",
     intervention = interventionFactory.create(
-      contract = dynamicFrameworkContractFactory.create(primeProvider = ServiceProvider("SPN", "SPN", ""))
+      contract = dynamicFrameworkContractFactory.create(primeProvider = ServiceProvider("SPN", "SPN"))
     )
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/InterventionServiceTest.kt
@@ -158,9 +158,9 @@ class InterventionServiceTest @Autowired constructor(
 
     // build map of service providers
     val serviceProviders = mapOf(
-      "harmonyLiving" to serviceProviderFactory.create("HARMONY_LIVING", "Harmony Living", "contact@harmonyliving.com"),
-      "homeTrust" to serviceProviderFactory.create("HOME_TRUST", "Home Trust", "manager@hometrust.com"),
-      "liveWell" to serviceProviderFactory.create("LIVE_WELL", "Live Well", "contact@livewell.com")
+      "harmonyLiving" to serviceProviderFactory.create("HARMONY_LIVING", "Harmony Living"),
+      "homeTrust" to serviceProviderFactory.create("HOME_TRUST", "Home Trust"),
+      "liveWell" to serviceProviderFactory.create("LIVE_WELL", "Live Well")
     )
 
     val npsRegion = npsRegionFactory.create()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -60,7 +60,11 @@ class NotifyReferralServiceTest {
   fun `referral sent event generates valid url and sends an email`() {
     notifyService().onApplicationEvent(referralSentEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
-    verify(emailSender).sendEmail(eq("referralSentTemplateID"), eq("harmony@example.com"), personalisationCaptor.capture())
+    verify(emailSender).sendEmail(
+      eq("referralSentTemplateID"),
+      eq("shs-incoming@provider.example.com"),
+      personalisationCaptor.capture()
+    )
     assertThat(personalisationCaptor.firstValue["organisationName"]).isEqualTo("Harmony Living")
     assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("JS8762AC")
     assertThat(personalisationCaptor.firstValue["referralUrl"]).isEqualTo("http://example.com/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/InterventionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/InterventionFactory.kt
@@ -18,6 +18,7 @@ class InterventionFactory(em: TestEntityManager? = null) : EntityFactory(em) {
       • Bulleted list
       • With indentation and unicode
     """,
+    incomingReferralDistributionEmail: String = "shs-incoming@provider.example.com",
     contract: DynamicFrameworkContract? = null,
   ): Intervention {
     return save(
@@ -26,6 +27,7 @@ class InterventionFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         createdAt = createdAt ?: OffsetDateTime.now(),
         title = title,
         description = description,
+        incomingReferralDistributionEmail = incomingReferralDistributionEmail,
         dynamicFrameworkContract = contract ?: dynamicFrameworkContractFactory.create(),
       )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ServiceProviderFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ServiceProviderFactory.kt
@@ -8,13 +8,11 @@ class ServiceProviderFactory(em: TestEntityManager? = null) : EntityFactory(em) 
   fun create(
     id: AuthGroupID = "HARMONY_LIVING",
     name: String = "Harmony Living",
-    incomingReferralDistributionEmail: String = "harmony@example.com",
   ): ServiceProvider {
     return save(
       ServiceProvider(
         id = id,
         name = name,
-        incomingReferralDistributionEmail = incomingReferralDistributionEmail
       )
     )
   }


### PR DESCRIPTION
## What does this pull request do?

🐾 Moves incoming referrals email address to be defined on individual interventions.
💾 No current emails exist, but we data migrate to retain the testing environments' integrity
💅 The last two commits deal with random warnings I came across.

## What is the intent behind these changes?

IC-1895: When service providers fill out their intervention detail forms it has an entry for a receiver e-mail address. This change reflects this model of input.