### PR TITLE
Allow for detailed error messages in FieldErrors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/ActionPlanValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/ActionPlanValidator.kt
@@ -32,13 +32,13 @@ class ActionPlanValidator {
   private fun validateNumberOfSessionsIsGreaterThanZero(update: ActionPlan, errors: MutableList<FieldError>) {
     update.numberOfSessions?.let {
       if (it <= 0) {
-        errors.add(FieldError(field = "numberOfSessions", error = CANNOT_BE_NEGATIVE_OR_ZERO))
+        errors.add(FieldError(field = "numberOfSessions", error = CANNOT_BE_NEGATIVE_OR_ZERO, errorMessage = "Number of sessions cannot be negative or zero"))
       }
     }
   }
 
   private fun validateNumberOfSessionsIsSpecified(update: ActionPlan, errors: MutableList<FieldError>) {
     update.numberOfSessions?.let {
-    } ?: errors.add(FieldError(field = "numberOfSessions", error = CANNOT_BE_EMPTY))
+    } ?: errors.add(FieldError(field = "numberOfSessions", error = CANNOT_BE_EMPTY, errorMessage = "Number of sessions cannot be empty"))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -29,6 +29,7 @@ enum class Code {
 data class FieldError(
   val field: String,
   val error: Code,
+  val errorMessage: String,
 )
 
 class ValidationError(override val message: String, val errors: List<FieldError>) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -222,7 +222,7 @@ class ReferralService(
 
     update.completionDeadline?.let {
       if (it.isBefore(LocalDate.now())) {
-        errors.add(FieldError(field = "completionDeadline", error = Code.DATE_MUST_BE_IN_THE_FUTURE))
+        errors.add(FieldError(field = "completionDeadline", error = Code.DATE_MUST_BE_IN_THE_FUTURE, errorMessage = "Completion deadline must be in the future"))
       }
 
       // fixme: error if completion deadline is after sentence end date
@@ -230,19 +230,19 @@ class ReferralService(
 
     update.needsInterpreter?.let {
       if (it && update.interpreterLanguage == null) {
-        errors.add(FieldError(field = "needsInterpreter", error = Code.CONDITIONAL_FIELD_MUST_BE_SET))
+        errors.add(FieldError(field = "needsInterpreter", error = Code.CONDITIONAL_FIELD_MUST_BE_SET, "Needs interpreter must be set."))
       }
     }
 
     update.hasAdditionalResponsibilities?.let {
       if (it && update.whenUnavailable == null) {
-        errors.add(FieldError(field = "hasAdditionalResponsibilities", error = Code.CONDITIONAL_FIELD_MUST_BE_SET))
+        errors.add(FieldError(field = "hasAdditionalResponsibilities", error = Code.CONDITIONAL_FIELD_MUST_BE_SET, errorMessage = "Has additional responsibilities must be set."))
       }
     }
 
     update.serviceUser?.let {
       if (it.crn != null && it.crn != referral.serviceUserCRN) {
-        errors.add(FieldError(field = "serviceUser.crn", error = Code.FIELD_CANNOT_BE_CHANGED))
+        errors.add(FieldError(field = "serviceUser.crn", error = Code.FIELD_CANNOT_BE_CHANGED, "CRN cannot be changed"))
       }
     }
 
@@ -252,7 +252,7 @@ class ReferralService(
         serviceCategory.id
       }.containsAll(it)
       ) {
-        errors.add(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT))
+        errors.add(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT, "Invalid service category id for contract"))
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -418,7 +418,7 @@ class ReferralServiceUnitTest {
         referralService.updateDraftReferral(referral, update)
       }
       assertThat(exception.message).isEqualTo("draft referral update invalid")
-      assertThat(exception.errors[0]).isEqualTo(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT))
+      assertThat(exception.errors[0]).isEqualTo(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT, "Invalid service category id for contract"))
     }
   }
 


### PR DESCRIPTION
## What does this pull request do?

This adds an additional field onto a FieldError to specify a more detailed message for the error.

## What is the intent behind these changes?

Provide further information to the caller of API for why their request failed.

There could be multiple reasons for why an error code has been produced for a particular field.

## Additional notes / discussion
This is mainly from a comment by @sldblog in PR https://github.com/ministryofjustice/hmpps-interventions-service/pull/334

![image](https://user-images.githubusercontent.com/83066216/122389654-0fe34380-cf69-11eb-858d-a6eae60fe73b.png)

David, you made a suggestion to serialise this into `"error": "$code: $message"`. I think separating the error code from the error message makes it easier for the caller to work with. What do you think?