### PR TITLE
Include event logs analytics extract

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -15,8 +15,6 @@ spec:
             imagePullPolicy: Always
             args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             env:
-              - name: PGPORT
-                value: "5432"
               - name: PGHOST
                 valueFrom:
                   secretKeyRef:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -54,3 +54,5 @@ spec:
                     key: secret_access_key
               - name: AWS_DEFAULT_REGION
                 value: eu-west-2
+          - name: SAVE_EVENTS_LOG
+            value: "true"


### PR DESCRIPTION
## What does this pull request do?

Sets `SAVE_EVENTS_LOG` in the job to extract data to the analytical platform

Removes redundant `PGPORT` variables as process now takes the default value if none is provided.

## What is the intent behind these changes?

To transfer the logs that capture contextual information about the extraction to aid with monitoring its usage.