### PR TITLE
IC-1942: multiple provider groups

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessChecker.kt
@@ -28,8 +28,8 @@ class ReferralAccessChecker(
     val eligibleServiceProviders = eligibleProviderMapper.fromReferral(referral)
     val errors = mutableListOf<String>()
 
-    if (!eligibleServiceProviders.contains(userScope.serviceProvider)) {
-      errors.add("user's organization is not eligible to access this referral")
+    if (eligibleServiceProviders.intersect(userScope.serviceProviders).isEmpty()) {
+      errors.add("user does not have the required provider group to access this referral")
     }
 
     if (!userScope.contracts.contains(referral.intervention.dynamicFrameworkContract)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -10,14 +10,14 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
 
 data class ServiceProviderAccessScope(
-  val serviceProviders: List<ServiceProvider>,
-  val contracts: List<DynamicFrameworkContract>,
+  val serviceProviders: Set<ServiceProvider>,
+  val contracts: Set<DynamicFrameworkContract>,
 )
 
 private data class WorkingScope(
   val authGroups: List<String>,
-  val providers: MutableList<ServiceProvider> = mutableListOf(),
-  val contracts: MutableList<DynamicFrameworkContract> = mutableListOf(),
+  val providers: MutableSet<ServiceProvider> = mutableSetOf(),
+  val contracts: MutableSet<DynamicFrameworkContract> = mutableSetOf(),
   val errors: MutableList<String> = mutableListOf(),
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -103,18 +103,18 @@ class ServiceProviderAccessScopeMapper(
 
   private fun getProviders(providerGroups: List<String>, configErrors: MutableList<String>): List<ServiceProvider> {
     val providers = serviceProviderRepository.findAllById(providerGroups)
-    val removedProviders = providerGroups.subtract(providers.map { it.id })
-    removedProviders.forEach { undefinedProvider ->
-      configErrors.add("removed provider '$undefinedProvider' from scope: group does not exist in the reference data")
+    val unidentifiedProviders = providerGroups.subtract(providers.map { it.id })
+    unidentifiedProviders.forEach { undefinedProvider ->
+      configErrors.add("unidentified provider '$undefinedProvider': group does not exist in the reference data")
     }
     return providers
   }
 
   private fun getContracts(contractGroups: List<String>, configErrors: MutableList<String>): List<DynamicFrameworkContract> {
     val contracts = dynamicFrameworkContractRepository.findAllByContractReferenceIn(contractGroups)
-    val removedContracts = contractGroups.subtract(contracts.map { it.contractReference })
-    removedContracts.forEach { undefinedContract ->
-      configErrors.add("removed contract '$undefinedContract' from scope: group does not exist in the reference data")
+    val unidentifiedContracts = contractGroups.subtract(contracts.map { it.contractReference })
+    unidentifiedContracts.forEach { undefinedContract ->
+      configErrors.add("unidentified contract '$undefinedContract': group does not exist in the reference data")
     }
     return contracts
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -8,8 +8,8 @@ import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
   // queries for service providers
-  fun findAllByInterventionDynamicFrameworkContractPrimeProviderAndSentAtIsNotNull(provider: ServiceProvider): List<Referral>
-  fun findAllByInterventionDynamicFrameworkContractSubcontractorProvidersAndSentAtIsNotNull(provider: ServiceProvider): List<Referral>
+  fun findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(providers: List<ServiceProvider>): List<Referral>
+  fun findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(providers: List<ServiceProvider>): List<Referral>
 
   // queries for sent referrals
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -8,8 +8,8 @@ import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
   // queries for service providers
-  fun findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(providers: List<ServiceProvider>): List<Referral>
-  fun findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(providers: List<ServiceProvider>): List<Referral>
+  fun findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(providers: Iterable<ServiceProvider>): List<Referral>
+  fun findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(providers: Iterable<ServiceProvider>): List<Referral>
 
   // queries for sent referrals
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -105,11 +105,11 @@ class ReferralService(
   }
 
   private fun getSentReferralsForServiceProviderUser(user: AuthUser): List<Referral> {
-    val serviceProvider = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProvider
+    val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
 
-    val referrals = referralRepository.findAllByInterventionDynamicFrameworkContractPrimeProviderAndSentAtIsNotNull(serviceProvider) +
+    val referrals = referralRepository.findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(serviceProviders) +
       // todo: query for referrals where the service provider has been granted nominated access only
-      referralRepository.findAllByInterventionDynamicFrameworkContractSubcontractorProvidersAndSentAtIsNotNull(serviceProvider)
+      referralRepository.findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(serviceProviders)
 
     return referralAccessFilter.serviceProviderReferrals(referrals, user)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -166,8 +166,10 @@ class ListReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "service provider id 'HOME_TRUST' does not exist in the interventions database",
-      "contract '0999' does not exist in the interventions database"
+      "removed provider 'HOME_TRUST' from scope: group does not exist in the reference data",
+      "removed contract '0999' from scope: group does not exist in the reference data",
+      "no valid service provider groups associated with user",
+      "no valid contract groups associated with user"
       ]}
       """.trimIndent()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -166,8 +166,8 @@ class ListReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "removed provider 'HOME_TRUST' from scope: group does not exist in the reference data",
-      "removed contract '0999' from scope: group does not exist in the reference data",
+      "unidentified provider 'HOME_TRUST': group does not exist in the reference data",
+      "unidentified contract '0999': group does not exist in the reference data",
       "no valid service provider groups associated with user",
       "no valid contract groups associated with user"
       ]}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -220,8 +220,10 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "service provider id 'BETTER_LTD' does not exist in the interventions database",
-      "contract '0002' does not exist in the interventions database"
+      "removed provider 'BETTER_LTD' from scope: group does not exist in the reference data",
+      "removed contract '0002' from scope: group does not exist in the reference data",
+      "no valid service provider groups associated with user",
+      "no valid contract groups associated with user"
       ]}
       """.trimIndent()
     )
@@ -293,7 +295,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "contract '0002' does not exist in the interventions database"
+      "removed contract '0002' from scope: group does not exist in the reference data",
+      "no valid contract groups associated with user"
       ]}
       """.trimIndent()
     )
@@ -318,8 +321,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "no service provider groups associated with user",
-      "no contract groups associated with user"
+      "no valid service provider groups associated with user",
+      "no valid contract groups associated with user"
       ]}
       """.trimIndent()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -262,7 +262,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "user's organization is not eligible to access this referral",
+      "user does not have the required provider group to access this referral",
       "user does not have the required contract group to access this referral"
       ]}
       """.trimIndent()
@@ -330,34 +330,46 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
   @MethodSource("sentReferralRequests")
-  fun `sp user has more than one service provider group in hmpps auth`(request: Request) {
+  fun `sp users with multiple providers can access all referrals with those providers and contracts`(request: Request) {
     val user = setupAssistant.createSPUser()
     setUserGroups(
       user,
       listOf(
         "INT_SP_HARMONY_LIVING",
         "INT_SP_BETTER_LTD",
-        "INT_CR_0001"
+        "INT_CR_0001",
+        "INT_CR_0002",
+        "INT_CR_0003",
       )
     )
 
-    val contract = setupAssistant.createDynamicFrameworkContract(
+    val contract1 = setupAssistant.createDynamicFrameworkContract(
       contractReference = "0001",
       primeProviderId = "HARMONY_LIVING",
       subContractorServiceProviderIds = setOf("BETTER_LTD")
     )
-    val referral = createSentReferral(contract)
+    val contract2 = setupAssistant.createDynamicFrameworkContract(
+      contractReference = "0002",
+      primeProviderId = "BETTER_LTD",
+    )
+    val contract3 = setupAssistant.createDynamicFrameworkContract(
+      contractReference = "0003",
+      primeProviderId = "DONT_HAVE_THIS_GROUP",
+      subContractorServiceProviderIds = setOf("BETTER_LTD")
+    )
+    val referral1 = createSentReferral(contract1)
+    val referral2 = createSentReferral(contract2)
+    val referral3 = createSentReferral(contract3)
     val token = createEncodedTokenForUser(user)
 
-    val response = requestFactory.create(request, token, referral.id.toString()).exchange()
-    response.expectStatus().isForbidden
-    response.expectBody().json(
-      """
-      {"accessErrors": [
-      "more than one service provider group associated with user"
-      ]}
-      """.trimIndent()
-    )
+    val checkReferral1 = requestFactory.create(request, token, referral1.id.toString()).exchange()
+    checkReferral1.expectStatus().is2xxSuccessful
+
+    val checkReferral2 = requestFactory.create(request, token, referral2.id.toString()).exchange()
+    checkReferral2.expectStatus().is2xxSuccessful
+
+    val checkReferral3 = requestFactory.create(request, token, referral3.id.toString()).exchange()
+    checkReferral3.expectStatus().is2xxSuccessful
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -220,8 +220,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "removed provider 'BETTER_LTD' from scope: group does not exist in the reference data",
-      "removed contract '0002' from scope: group does not exist in the reference data",
+      "unidentified provider 'BETTER_LTD': group does not exist in the reference data",
+      "unidentified contract '0002': group does not exist in the reference data",
       "no valid service provider groups associated with user",
       "no valid contract groups associated with user"
       ]}
@@ -334,7 +334,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "removed contract '0002' from scope: group does not exist in the reference data",
+      "unidentified contract '0002': group does not exist in the reference data",
       "no valid contract groups associated with user"
       ]}
       """.trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -7,6 +7,8 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -29,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Desired
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanSessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
@@ -438,74 +441,53 @@ class ReferralServiceTest @Autowired constructor(
     assertThat(referrals[0].serviceUserCRN).isEqualTo("CRN129876234")
   }
 
-  @Test
-  fun `get sent referrals for prime provider returns filtered referrals`() {
-    // setup 2 users and 2 providers with a contract and referral for each provider
-    val users = listOf(userFactory.create("sp_user_1", "auth"), userFactory.create("sp_user_2", "auth"))
-    val spOrgs = listOf(serviceProviderFactory.create("sp_org_1"), serviceProviderFactory.create("sp_org_2"))
-    spOrgs.forEach {
-      val intervention = interventionFactory.create(
-        contract = contractFactory.create(
-          primeProvider = it
-        )
-      )
-      referralFactory.createSent(intervention = intervention)
+  @Nested
+  @DisplayName("get sent referrals with a provider user")
+  inner class GetSentReferralsSPUser {
+    private lateinit var otherPrime: ServiceProvider
+    private lateinit var otherSub: ServiceProvider
+
+    private fun userWithProviders(providers: List<ServiceProvider>): AuthUser {
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(providers.toSet(), setOf()))
+      return user
     }
 
-    // the first user works for the first provider
-    whenever(serviceProviderAccessScopeMapper.fromUser(users[0])).thenReturn(
-      ServiceProviderAccessScope(listOf(spOrgs[0]), listOf())
-    )
-    // the second user works for a different provider entirely
-    whenever(serviceProviderAccessScopeMapper.fromUser(users[1])).thenReturn(
-      ServiceProviderAccessScope(listOf(serviceProviderFactory.create("missing")), listOf())
-    )
-    // no access restrictions for the purpose of this test
-    whenever(referralAccessFilter.serviceProviderReferrals(any(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
-
-    // the first user sees referrals for their provider
-    val referrals = referralService.getSentReferralsForUser(users[0])
-    assertThat(referrals.size).isEqualTo(1)
-    assertThat(referrals[0].intervention.dynamicFrameworkContract.primeProvider).isEqualTo(spOrgs[0])
-
-    // the second user doesn't see any referrals (because there aren't any for their provider)
-    assertThat(referralService.getSentReferralsForUser(users[1])).isEmpty()
-  }
-
-  @Test
-  fun `get sent referrals for subcontractor provider returns filtered referrals`() {
-    // setup 2 users and 2 subcontractor providers with a contract and referral for each provider
-    val users = listOf(userFactory.create("sp_user_1", "auth"), userFactory.create("sp_user_2", "auth"))
-    val spPrimeOrg = serviceProviderFactory.create("prime_org")
-    val spSubOrgs = listOf(serviceProviderFactory.create("sub_org_1"), serviceProviderFactory.create("sub_org_2"))
-    spSubOrgs.forEach {
+    private fun newReferralWithProviders(prime: ServiceProvider, vararg subs: ServiceProvider): Referral {
       val intervention = interventionFactory.create(
-        contract = contractFactory.create(
-          primeProvider = spPrimeOrg,
-          subcontractorProviders = setOf(it)
-        )
+        contract = contractFactory.create(primeProvider = prime, subcontractorProviders = subs.toSet())
       )
-      referralFactory.createSent(intervention = intervention)
+      return referralFactory.createSent(intervention = intervention)
     }
 
-    // the first user works for the first provider
-    whenever(serviceProviderAccessScopeMapper.fromUser(users[0])).thenReturn(
-      ServiceProviderAccessScope(listOf(spSubOrgs[0]), listOf())
-    )
-    // the second user works for a different provider entirely
-    whenever(serviceProviderAccessScopeMapper.fromUser(users[1])).thenReturn(
-      ServiceProviderAccessScope(listOf(serviceProviderFactory.create("missing")), listOf())
-    )
-    // no access restrictions for the purpose of this test
-    whenever(referralAccessFilter.serviceProviderReferrals(any(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
+    @BeforeEach
+    fun setup() {
+      // do not test access restrictions in these tests; only test selection of referrals
+      whenever(referralAccessFilter.serviceProviderReferrals(any(), any()))
+        .then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
 
-    // the first user sees referrals for their provider
-    val referrals = referralService.getSentReferralsForUser(users[0])
-    assertThat(referrals.size).isEqualTo(1)
-    assertThat(referrals[0].intervention.dynamicFrameworkContract.subcontractorProviders).contains(spSubOrgs[0])
+      otherPrime = serviceProviderFactory.create("other_prime")
+      otherSub = serviceProviderFactory.create("other_sub")
+    }
 
-    // the second user doesn't see any referrals (because there aren't any for their provider)
-    assertThat(referralService.getSentReferralsForUser(users[1])).isEmpty()
+    @Test
+    fun `user with multiple providers can see referrals where the providers are subcontractors`() {
+      val userProviders = listOf("test_org_1", "test_org_2").map(serviceProviderFactory::create)
+
+      val primeRef1 = newReferralWithProviders(userProviders[0])
+      val primeRef2 = newReferralWithProviders(userProviders[1])
+      val subRef1 = newReferralWithProviders(otherPrime, userProviders[0])
+      val subRef2 = newReferralWithProviders(otherPrime, userProviders[1])
+      val noAccess = newReferralWithProviders(otherPrime, otherSub)
+
+      val multiSubUser = userWithProviders(userProviders)
+
+      val result = referralService.getSentReferralsForUser(multiSubUser)
+      assertThat(result).doesNotContain(noAccess)
+      assertThat(result).containsAll(listOf(primeRef1, primeRef2, subRef1, subRef2))
+      assertThat(result.size).isEqualTo(4)
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -453,10 +453,12 @@ class ReferralServiceTest @Autowired constructor(
     }
 
     // the first user works for the first provider
-    whenever(serviceProviderAccessScopeMapper.fromUser(users[0])).thenReturn(ServiceProviderAccessScope(spOrgs[0], listOf()))
+    whenever(serviceProviderAccessScopeMapper.fromUser(users[0])).thenReturn(
+      ServiceProviderAccessScope(listOf(spOrgs[0]), listOf())
+    )
     // the second user works for a different provider entirely
     whenever(serviceProviderAccessScopeMapper.fromUser(users[1])).thenReturn(
-      ServiceProviderAccessScope(serviceProviderFactory.create("missing"), listOf())
+      ServiceProviderAccessScope(listOf(serviceProviderFactory.create("missing")), listOf())
     )
     // no access restrictions for the purpose of this test
     whenever(referralAccessFilter.serviceProviderReferrals(any(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
@@ -487,10 +489,12 @@ class ReferralServiceTest @Autowired constructor(
     }
 
     // the first user works for the first provider
-    whenever(serviceProviderAccessScopeMapper.fromUser(users[0])).thenReturn(ServiceProviderAccessScope(spSubOrgs[0], listOf()))
+    whenever(serviceProviderAccessScopeMapper.fromUser(users[0])).thenReturn(
+      ServiceProviderAccessScope(listOf(spSubOrgs[0]), listOf())
+    )
     // the second user works for a different provider entirely
     whenever(serviceProviderAccessScopeMapper.fromUser(users[1])).thenReturn(
-      ServiceProviderAccessScope(serviceProviderFactory.create("missing"), listOf())
+      ServiceProviderAccessScope(listOf(serviceProviderFactory.create("missing")), listOf())
     )
     // no access restrictions for the purpose of this test
     whenever(referralAccessFilter.serviceProviderReferrals(any(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
@@ -528,7 +532,7 @@ class ReferralServiceTest @Autowired constructor(
 
     referralRepository.flush()
     val updatedReferral = referralRepository.findById(referral.id).get()
-    assertThat(updatedReferral!!.selectedServiceCategories).hasSize(1)
+    assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
     assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId2)
     assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(0)
   }
@@ -553,7 +557,7 @@ class ReferralServiceTest @Autowired constructor(
 
     referralRepository.flush()
     val updatedReferral = referralRepository.findById(referral.id).get()
-    assertThat(updatedReferral!!.selectedServiceCategories).hasSize(1)
+    assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
     assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId)
     assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(1)
   }


### PR DESCRIPTION
## What does this pull request do?

Enables authenticated service provider users to access the service with multiple provider groups

## What is the intent behind these changes?

Providers users are being setup with multiple `INT_SP_` provider groups:

We have a user that belongs to **all** of these groups:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1526295/122432746-81cd8400-cf8d-11eb-8621-9f1c34e58dfe.png">

This is a result of insufficient shared understanding, sorry about that.
A review of the authorization model will be booked next month

So -- multiple provider groups have to provide access to:

- referrals that have any of those providers as prime
- referrals that have any of those providers as subcontractor

Misconfiguration issues to be raised:

- because we now allow a combination of things, be explicit when a contract group is found which has no relation to any of the provider groups:

For example, error if someone has the groups represented by the purple set:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/1526295/122433014-b93c3080-cf8d-11eb-8483-47881bedc80b.png">


Trade-offs:

- with multi-provider memberships, it will be impossible to figure which provider someone is acting on behalf of