### PR TITLE
IC-1943: Make appointment delivery mandatory + Pact tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
@@ -15,6 +16,8 @@ data class AddressDTO private constructor(
   val postCode: String,
 ) {
   companion object {
+    @JvmStatic
+    @JsonCreator
     operator fun invoke(firstAddressLine: String, secondAddressLine: String? = null, townOrCity: String? = null, county: String? = null, postCode: String): AddressDTO {
       val normalizedPostCode = postCode.replace("\\s".toRegex(), "").uppercase()
       return AddressDTO(firstAddressLine, secondAddressLine, townOrCity, county, normalizedPostCode)
@@ -45,20 +48,18 @@ data class ActionPlanSessionDTO(
   val appointmentTime: OffsetDateTime?,
   val durationInMinutes: Int?,
   val appointmentDeliveryType: AppointmentDeliveryType?,
-  val appointmentDeliveryAddress: List<String>?,
+  val appointmentDeliveryAddress: AddressDTO?,
   val sessionFeedback: SessionFeedbackDTO,
 ) {
   companion object {
     fun from(session: ActionPlanSession): ActionPlanSessionDTO {
       val appointmentDelivery = session.currentAppointment?.appointmentDelivery
       val address = when (appointmentDelivery?.appointmentDeliveryType) {
-        AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE -> listOfNotNull(appointmentDelivery?.npsOfficeCode)
         AppointmentDeliveryType.IN_PERSON_MEETING_OTHER -> {
           if (appointmentDelivery?.appointmentDeliveryAddress !== null) {
             val address = appointmentDelivery.appointmentDeliveryAddress
             if (address != null) {
-
-              listOfNotNull(address.firstAddressLine, address.secondAddressLine ?: "", address.townCity, address.county, address.postCode)
+              AddressDTO(address.firstAddressLine, address.secondAddressLine ?: "", address.townCity, address.county, address.postCode)
             } else null
           } else null
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -25,8 +25,7 @@ data class AddressDTO private constructor(
 data class UpdateAppointmentDTO(
   val appointmentTime: OffsetDateTime,
   @JsonProperty(required = true) val durationInMinutes: Int,
-  // TODO: remove optional when front-end changes are complete
-  val appointmentDeliveryType: AppointmentDeliveryType? = null,
+  val appointmentDeliveryType: AppointmentDeliveryType,
   val appointmentDeliveryAddress: AddressDTO? = null,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -66,8 +66,7 @@ class ActionPlanSessionsService(
     appointmentTime: OffsetDateTime,
     durationInMinutes: Int,
     updatedBy: AuthUser,
-    // TODO: remove optional when front-end changes are complete
-    appointmentDeliveryType: AppointmentDeliveryType? = null,
+    appointmentDeliveryType: AppointmentDeliveryType,
     appointmentDeliveryAddress: AddressDTO? = null,
   ): ActionPlanSession {
 
@@ -91,21 +90,14 @@ class ActionPlanSessionsService(
         deliusAppointmentId = deliusAppointmentId,
       )
       appointmentRepository.saveAndFlush(appointment)
-
-//       TODO: remove optional when front-end changes are complete
-      if (appointmentDeliveryType != null) {
-        populateAppointmentDelivery(appointment, appointmentDeliveryType, appointmentDeliveryAddress)
-      }
+      populateAppointmentDelivery(appointment, appointmentDeliveryType, appointmentDeliveryAddress)
       session.appointments.add(appointment)
     } else {
       existingAppointment.appointmentTime = appointmentTime
       existingAppointment.durationInMinutes = durationInMinutes
       existingAppointment.deliusAppointmentId = deliusAppointmentId
       appointmentRepository.saveAndFlush(existingAppointment)
-      // TODO: remove optional when front-end changes are complete
-      if (appointmentDeliveryType != null) {
-        populateAppointmentDelivery(existingAppointment, appointmentDeliveryType, appointmentDeliveryAddress)
-      }
+      populateAppointmentDelivery(existingAppointment, appointmentDeliveryType, appointmentDeliveryAddress)
     }
     return actionPlanSessionRepository.save(session)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SupplierAssessmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
@@ -32,7 +33,8 @@ class SupplierAssessmentControllerTest {
     val referral = referralFactory.createSent()
     val durationInMinutes = 60
     val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
-    val update = UpdateAppointmentDTO(appointmentTime, durationInMinutes)
+    val appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL
+    val update = UpdateAppointmentDTO(appointmentTime, durationInMinutes, appointmentDeliveryType)
     val user = authUserFactory.create()
     val token = tokenFactory.create()
     val supplierAssessment = supplierAssessmentFactory.create()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTOTest.kt
@@ -57,10 +57,9 @@ internal class ActionPlanSessionsDTOTest {
   @Test
   fun `Maps from a session with nps office address`() {
     val session = actionPlanSessionFactory.createScheduled()
-    session.appointments.first().appointmentDelivery = appointmentDeliveryFactory.create(session.appointments.first().id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, npsOfficeCode = "ABC")
+    session.appointments.first().appointmentDelivery = appointmentDeliveryFactory.create(session.appointments.first().id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE)
     val sessionDTO = ActionPlanSessionDTO.from(session)
     assertThat(sessionDTO.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE)
-    assertThat(sessionDTO.appointmentDeliveryAddress).isEqualTo(listOf("ABC"))
   }
 
   @Test
@@ -72,19 +71,28 @@ internal class ActionPlanSessionsDTOTest {
     session.appointments.first().appointmentDelivery = appointmentDelivery
     val sessionDTO = ActionPlanSessionDTO.from(session)
     assertThat(sessionDTO.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.IN_PERSON_MEETING_OTHER)
-    assertThat(sessionDTO.appointmentDeliveryAddress).isEqualTo(listOf("Harmony Living Office, Room 4", "44 Bouverie Road", "Blackpool", "Lancashire", "SY4 0RE"))
+    assertThat(sessionDTO.appointmentDeliveryAddress?.firstAddressLine).isEqualTo("Harmony Living Office, Room 4")
+    assertThat(sessionDTO.appointmentDeliveryAddress?.secondAddressLine).isEqualTo("44 Bouverie Road")
+    assertThat(sessionDTO.appointmentDeliveryAddress?.townOrCity).isEqualTo("Blackpool")
+    assertThat(sessionDTO.appointmentDeliveryAddress?.county).isEqualTo("Lancashire")
+    assertThat(sessionDTO.appointmentDeliveryAddress?.postCode).isEqualTo("SY40RE")
   }
 
   @Test
   fun `Maps from a session with non nps office address and second line is empty`() {
     val session = actionPlanSessionFactory.createScheduled()
     val appointmentDelivery = appointmentDeliveryFactory.create(appointmentId = session.appointments.first().id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER)
-    val appointmentDeliveryAddress = appointmentDeliveryAddressFactory.create(appointmentDeliveryId = appointmentDelivery.appointmentId, secondAddressLine = null)
+    val appointmentDeliveryAddress = appointmentDeliveryAddressFactory.create(appointmentDeliveryId = appointmentDelivery.appointmentId, secondAddressLine = null, townCity = null, county = null, postCode = "SY4 0RE")
     appointmentDelivery.appointmentDeliveryAddress = appointmentDeliveryAddress
     session.appointments.first().appointmentDelivery = appointmentDelivery
     val sessionDTO = ActionPlanSessionDTO.from(session)
     assertThat(sessionDTO.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.IN_PERSON_MEETING_OTHER)
-    assertThat(sessionDTO.appointmentDeliveryAddress).isEqualTo(listOf("Harmony Living Office, Room 4", "", "Blackpool", "Lancashire", "SY4 0RE"))
+
+    assertThat(sessionDTO.appointmentDeliveryAddress?.firstAddressLine).isEqualTo("Harmony Living Office, Room 4")
+    assertThat(sessionDTO.appointmentDeliveryAddress?.secondAddressLine).isEqualTo("")
+    assertThat(sessionDTO.appointmentDeliveryAddress?.townOrCity).isNull()
+    assertThat(sessionDTO.appointmentDeliveryAddress?.county).isNull()
+    assertThat(sessionDTO.appointmentDeliveryAddress?.postCode).isEqualTo("SY40RE")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
@@ -9,6 +9,8 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanSessionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryAddressRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
@@ -47,6 +49,8 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var contractTypeRepository: ContractTypeRepository
   @Autowired protected lateinit var appointmentRepository: AppointmentRepository
   @Autowired protected lateinit var supplierAssessmentRepository: SupplierAssessmentRepository
+  @Autowired protected lateinit var appointmentDeliveryRepository: AppointmentDeliveryRepository
+  @Autowired protected lateinit var appointmentDeliveryAddressRepository: AppointmentDeliveryAddressRepository
   protected lateinit var setupAssistant: SetupAssistant
 
   @BeforeEach
@@ -66,7 +70,9 @@ abstract class IntegrationTestBase {
       cancellationReasonRepository,
       contractTypeRepository,
       appointmentRepository,
-      supplierAssessmentRepository
+      supplierAssessmentRepository,
+      appointmentDeliveryRepository,
+      appointmentDeliveryAddressRepository
     )
     setupAssistant.cleanAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
@@ -36,7 +36,7 @@ class ActionPlanContracts(private val setupAssistant: SetupAssistant) {
   )
   fun `create an empty draft plan with 2 2 hours appointments`() {
     val actionPlan = setupAssistant.createActionPlan(id = UUID.fromString("345059d4-1697-467b-8914-fedec9957279"), numberOfSessions = 2)
-    val appointmentDeliveryAddress = AddressDTO(firstAddressLine = "Harmony Living Office, Room 4", secondAddressLine = "44 Bouverie Road", townOrCity = "Blackpool", county = "Lancashire", postCode = "EC1A 1BB")
+    val appointmentDeliveryAddress = AddressDTO(firstAddressLine = "Harmony Living Office, Room 4", secondAddressLine = "44 Bouverie Road", townOrCity = "Blackpool", county = "Lancashire", postCode = "SY40RE")
     setupAssistant.createActionPlanSession(actionPlan, 1, 120, OffsetDateTime.parse("2021-05-13T12:30:00+00:00"), appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = appointmentDeliveryAddress)
     setupAssistant.createActionPlanSession(actionPlan, 2, 120, OffsetDateTime.parse("2021-05-13T12:30:00+00:00"), appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = appointmentDeliveryAddress)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.pact
 
 import au.com.dius.pact.provider.junitsupport.State
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.SetupAssistant
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanActivity
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -23,9 +25,9 @@ class ActionPlanContracts(private val setupAssistant: SetupAssistant) {
   )
   fun `create a submitted action plan with 3 appointments`() {
     val actionPlan = setupAssistant.createActionPlan(id = UUID.fromString("e5ed2f80-dfe2-4bf3-b5c4-d8d4486e963d"), numberOfSessions = 3)
-    setupAssistant.createActionPlanSession(actionPlan, 1, 120, OffsetDateTime.parse("2021-05-13T13:30:00+01:00"))
-    setupAssistant.createActionPlanSession(actionPlan, 2, 120, OffsetDateTime.parse("2021-05-20T13:30:00+01:00"))
-    setupAssistant.createActionPlanSession(actionPlan, 3, 120, OffsetDateTime.parse("2021-05-27T13:30:00+01:00"))
+    setupAssistant.createActionPlanSession(actionPlan, 1, 120, OffsetDateTime.parse("2021-05-13T13:30:00+01:00"), appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL)
+    setupAssistant.createActionPlanSession(actionPlan, 2, 120, OffsetDateTime.parse("2021-05-20T13:30:00+01:00"), appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL)
+    setupAssistant.createActionPlanSession(actionPlan, 3, 120, OffsetDateTime.parse("2021-05-27T13:30:00+01:00"), appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL)
   }
 
   @State(
@@ -34,8 +36,9 @@ class ActionPlanContracts(private val setupAssistant: SetupAssistant) {
   )
   fun `create an empty draft plan with 2 2 hours appointments`() {
     val actionPlan = setupAssistant.createActionPlan(id = UUID.fromString("345059d4-1697-467b-8914-fedec9957279"), numberOfSessions = 2)
-    setupAssistant.createActionPlanSession(actionPlan, 1, 120, OffsetDateTime.parse("2021-05-13T12:30:00+00:00"))
-    setupAssistant.createActionPlanSession(actionPlan, 2, 120, OffsetDateTime.parse("2021-05-13T12:30:00+00:00"))
+    val appointmentDeliveryAddress = AddressDTO(firstAddressLine = "Harmony Living Office, Room 4", secondAddressLine = "44 Bouverie Road", townOrCity = "Blackpool", county = "Lancashire", postCode = "EC1A 1BB")
+    setupAssistant.createActionPlanSession(actionPlan, 1, 120, OffsetDateTime.parse("2021-05-13T12:30:00+00:00"), appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = appointmentDeliveryAddress)
+    setupAssistant.createActionPlanSession(actionPlan, 2, 120, OffsetDateTime.parse("2021-05-13T12:30:00+00:00"), appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = appointmentDeliveryAddress)
   }
 
   @State("an action plan exists with ID 7a165933-d851-48c1-9ab0-ff5b8da12695, and it has been submitted")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceRepositoryTest.kt
@@ -28,7 +28,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @RepositoryTest
-class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
+class ActionPlanSessionsServiceRepositoryTest @Autowired constructor(
   val entityManager: TestEntityManager,
   val referralRepository: ReferralRepository,
   val authUserRepository: AuthUserRepository,
@@ -80,6 +80,7 @@ class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
           appointmentDeliveryAddress = appointmentDeliveryAddress,
         )
       }
+
       @Test
       fun `can update existing appointment with a phone call delivery`() {
         val actionPlanSession = actionPlanSessionFactory.createScheduled()
@@ -122,6 +123,17 @@ class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
 
       @Nested
       inner class WithAppointmentDeliveryAddress {
+
+        // These tests are to ensure that no constraint exceptions are thrown by hibernate if appointment delivery details change
+        @Nested
+        inner class HibernateConstraintTests {
+          @Test
+          fun `can update existing appointment with exactly the same details`() {
+            val actionPlanSession = actionPlanSessionFactory.createScheduled()
+            testSettingNonNPSOffice(actionPlanSession)
+            testSettingNonNPSOffice(actionPlanSession)
+          }
+        }
 
         @Test
         fun `can update existing appointment with a non nps office delivery address`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentDeliveryAddressFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentDeliveryAddressFactory.kt
@@ -11,8 +11,8 @@ class AppointmentDeliveryAddressFactory(em: TestEntityManager? = null) : EntityF
     appointmentDeliveryId: UUID? = null,
     firstAddressLine: String = "Harmony Living Office, Room 4",
     secondAddressLine: String? = "44 Bouverie Road",
-    townCity: String = "Blackpool",
-    county: String = "Lancashire",
+    townCity: String? = "Blackpool",
+    county: String? = "Lancashire",
     postCode: String = "SY4 0RE",
   ): AppointmentDeliveryAddress {
     var id = appointmentDeliveryId


### PR DESCRIPTION
## What does this pull request do?

Removes the ability to specify an optional appointment delivery type when updating an appointment.

## What is the intent behind these changes?

Ensure that user can not edit an appointment without also supplying where it will be delivered


## Note

This is will also require an update on UI side, this will be done in PR https://github.com/ministryofjustice/hmpps-interventions-ui/pull/436
