### PR TITLE
IC-1953: ensure we don't duplicate live referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -107,11 +107,11 @@ class ReferralService(
   private fun getSentReferralsForServiceProviderUser(user: AuthUser): List<Referral> {
     val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
 
-    val referrals = referralRepository.findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(serviceProviders) +
+    val referrals = referralRepository.findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(serviceProviders)
       // todo: query for referrals where the service provider has been granted nominated access only
-      referralRepository.findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(serviceProviders)
+      .union(referralRepository.findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(serviceProviders))
 
-    return referralAccessFilter.serviceProviderReferrals(referrals, user)
+    return referralAccessFilter.serviceProviderReferrals(referrals.toList(), user)
   }
 
   private fun getSentReferralsForProbationPractitionerUser(user: AuthUser): List<Referral> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -477,16 +477,17 @@ class ReferralServiceTest @Autowired constructor(
 
       val primeRef1 = newReferralWithProviders(userProviders[0])
       val primeRef2 = newReferralWithProviders(userProviders[1])
-      val subRef1 = newReferralWithProviders(otherPrime, userProviders[0])
-      val subRef2 = newReferralWithProviders(otherPrime, userProviders[1])
+      val primeAndSubRef = newReferralWithProviders(userProviders[0], userProviders[1])
+      val refWithAllProvidersBeingSubs = newReferralWithProviders(otherPrime, userProviders[0], userProviders[1])
+      val subRef = newReferralWithProviders(otherPrime, userProviders[1])
       val noAccess = newReferralWithProviders(otherPrime, otherSub)
 
       val multiSubUser = userWithProviders(userProviders)
 
       val result = referralService.getSentReferralsForUser(multiSubUser)
       assertThat(result).doesNotContain(noAccess)
-      assertThat(result).containsAll(listOf(primeRef1, primeRef2, subRef1, subRef2))
-      assertThat(result.size).isEqualTo(4)
+      assertThat(result).containsAll(listOf(primeRef1, primeRef2, primeAndSubRef, refWithAllProvidersBeingSubs, subRef))
+      assertThat(result.size).isEqualTo(5)
     }
   }
 


### PR DESCRIPTION
## What does this pull request do?

Ensure we only select live referrals once for service provider users with multiple provider groups

By changing concatenation to union. It preserves iteration order:

> The returned set preserves the element iteration order of the original collection

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/union.html#union

## What is the intent behind these changes?

Given a user that has multiple provider groups
And those groups are on the same contract (as a prime and as a sub)
Then the user sees referrals made for that contract *more than once*

This happens because they get the referrals

- once for the groups which are prime on those contracts
- again for the groups which are subs on those contracts