### PR TITLE
IC-1951 Added End Of Service Report Flag to single sent referral responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -64,7 +64,7 @@ class ReferralController(
     )
     return SentReferralDTO.from(
       referralService.assignSentReferral(sentReferral, assignedBy, assignedTo),
-      referralConcluder.requiresEndOfServiceReport(sentReferral)
+      referralConcluder.requiresEndOfServiceReportCreation(sentReferral)
     )
   }
 
@@ -85,14 +85,14 @@ class ReferralController(
 
     return ResponseEntity
       .created(location)
-      .body(SentReferralDTO.from(sentReferral, referralConcluder.requiresEndOfServiceReport(sentReferral)))
+      .body(SentReferralDTO.from(sentReferral, referralConcluder.requiresEndOfServiceReportCreation(sentReferral)))
   }
 
   @JsonView(Views.SentReferral::class)
   @GetMapping("/sent-referral/{id}")
   fun getSentReferral(@PathVariable id: UUID, authentication: JwtAuthenticationToken): SentReferralDTO {
     val referral = getSentReferralForAuthenticatedUser(authentication, id)
-    return SentReferralDTO.from(referral, referralConcluder.requiresEndOfServiceReport(referral))
+    return SentReferralDTO.from(referral, referralConcluder.requiresEndOfServiceReportCreation(referral))
   }
 
   @JsonView(Views.SentReferral::class)
@@ -114,7 +114,7 @@ class ReferralController(
     val user = userMapper.fromToken(authentication)
     return SentReferralDTO.from(
       referralService.requestReferralEnd(sentReferral, user, cancellationReason, endReferralRequest.comments),
-      referralConcluder.requiresEndOfServiceReport(sentReferral),
+      referralConcluder.requiresEndOfServiceReportCreation(sentReferral),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -64,7 +64,7 @@ class ReferralController(
     )
     return SentReferralDTO.from(
       referralService.assignSentReferral(sentReferral, assignedBy, assignedTo),
-      referralConcluder.requiresEosr(sentReferral)
+      referralConcluder.requiresEndOfServiceReport(sentReferral)
     )
   }
 
@@ -85,14 +85,14 @@ class ReferralController(
 
     return ResponseEntity
       .created(location)
-      .body(SentReferralDTO.from(sentReferral, referralConcluder.requiresEosr(sentReferral)))
+      .body(SentReferralDTO.from(sentReferral, referralConcluder.requiresEndOfServiceReport(sentReferral)))
   }
 
   @JsonView(Views.SentReferral::class)
   @GetMapping("/sent-referral/{id}")
   fun getSentReferral(@PathVariable id: UUID, authentication: JwtAuthenticationToken): SentReferralDTO {
     val referral = getSentReferralForAuthenticatedUser(authentication, id)
-    return SentReferralDTO.from(referral, referralConcluder.requiresEosr(referral))
+    return SentReferralDTO.from(referral, referralConcluder.requiresEndOfServiceReport(referral))
   }
 
   @JsonView(Views.SentReferral::class)
@@ -114,7 +114,7 @@ class ReferralController(
     val user = userMapper.fromToken(authentication)
     return SentReferralDTO.from(
       referralService.requestReferralEnd(sentReferral, user, cancellationReason, endReferralRequest.comments),
-      referralConcluder.requiresEosr(sentReferral),
+      referralConcluder.requiresEndOfServiceReport(sentReferral),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -18,7 +18,7 @@ class SentReferralDTO(
   val endOfServiceReport: EndOfServiceReportDTO?,
   val concludedAt: OffsetDateTime?,
   val supplementaryRiskId: UUID,
-  val endOfServiceReportRequired: Boolean,
+  val endOfServiceReportCreationRequired: Boolean,
 ) {
   companion object {
     fun from(referral: Referral, endOfServiceReportRequired: Boolean): SentReferralDTO {
@@ -36,7 +36,7 @@ class SentReferralDTO(
         endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) },
         concludedAt = referral.concludedAt,
         supplementaryRiskId = referral.supplementaryRiskId!!,
-        endOfServiceReportRequired = endOfServiceReportRequired,
+        endOfServiceReportCreationRequired = endOfServiceReportRequired,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -18,10 +18,10 @@ class SentReferralDTO(
   val endOfServiceReport: EndOfServiceReportDTO?,
   val concludedAt: OffsetDateTime?,
   val supplementaryRiskId: UUID,
-  val eosrRequired: Boolean,
+  val endOfServiceReportRequired: Boolean,
 ) {
   companion object {
-    fun from(referral: Referral, eosrRequired: Boolean): SentReferralDTO {
+    fun from(referral: Referral, endOfServiceReportRequired: Boolean): SentReferralDTO {
       return SentReferralDTO(
         id = referral.id,
         sentAt = referral.sentAt!!,
@@ -36,7 +36,7 @@ class SentReferralDTO(
         endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) },
         concludedAt = referral.concludedAt,
         supplementaryRiskId = referral.supplementaryRiskId!!,
-        eosrRequired = eosrRequired,
+        endOfServiceReportRequired = endOfServiceReportRequired,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTO.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class SentReferralDTO(
+class SentReferralSummaryDTO(
   val id: UUID,
   val sentAt: OffsetDateTime,
   val sentBy: AuthUserDTO,
@@ -17,12 +17,11 @@ class SentReferralDTO(
   val endRequestedComments: String?,
   val endOfServiceReport: EndOfServiceReportDTO?,
   val concludedAt: OffsetDateTime?,
-  val supplementaryRiskId: UUID,
-  val eosrRequired: Boolean,
+  val supplementaryRiskId: UUID
 ) {
   companion object {
-    fun from(referral: Referral, eosrRequired: Boolean): SentReferralDTO {
-      return SentReferralDTO(
+    fun from(referral: Referral): SentReferralSummaryDTO {
+      return SentReferralSummaryDTO(
         id = referral.id,
         sentAt = referral.sentAt!!,
         sentBy = AuthUserDTO.from(referral.sentBy!!),
@@ -36,7 +35,6 @@ class SentReferralDTO(
         endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) },
         concludedAt = referral.concludedAt,
         supplementaryRiskId = referral.supplementaryRiskId!!,
-        eosrRequired = eosrRequired,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -12,8 +12,8 @@ interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
 
   @Query(
     "select count(sesh) from ActionPlanSession sesh join sesh.appointments appt " +
-      "where sesh.actionPlan.id = :actionPlanId and (appt.attended = 'YES' or appt.attended = 'LATE') " +
+      "where sesh.actionPlan.id = :actionPlanId and appt.attended is not null " +
       "and appt.appointmentFeedbackSubmittedAt is not null"
   )
-  fun countNumberOfAttendedSessions(actionPlanId: UUID): Int
+  fun countNumberOfAttemptedSessions(actionPlanId: UUID): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -12,7 +12,8 @@ interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
 
   @Query(
     "select count(sesh) from ActionPlanSession sesh join sesh.appointments appt " +
-      "where sesh.actionPlan.id = :actionPlanId and (appt.attended = 'YES' or appt.attended = 'LATE')"
+      "where sesh.actionPlan.id = :actionPlanId and (appt.attended = 'YES' or appt.attended = 'LATE') " +
+      "and appt.appointmentFeedbackSubmittedAt is not null"
   )
   fun countNumberOfAttendedSessions(actionPlanId: UUID): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -35,7 +35,7 @@ class ReferralConcluder(
     }
   }
 
-  fun requiresEosr(referral: Referral): Boolean {
+  fun requiresEndOfServiceReport(referral: Referral): Boolean {
     return countSessionsWithAttendanceRecorded(referral) > 0
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -36,14 +36,14 @@ class ReferralConcluder(
   }
 
   fun requiresEosr(referral: Referral): Boolean {
-    return getNumberOfAttendedAppointments(referral) > 0
+    return countSessionsWithAttendanceRecorded(referral) > 0
   }
 
   private fun getConcludedEventType(referral: Referral): ReferralEventType? {
 
     val hasActionPlan = nonNull(referral.actionPlan)
 
-    val numberOfAttendedAppointments = getNumberOfAttendedAppointments(referral)
+    val numberOfAttendedAppointments = countSessionsWithAttendanceRecorded(referral)
     val hasAttendedNoAppointments = numberOfAttendedAppointments == 0
 
     val totalNumberOfAppointments = referral.actionPlan?.numberOfSessions ?: 0
@@ -67,7 +67,7 @@ class ReferralConcluder(
     return null
   }
 
-  private fun getNumberOfAttendedAppointments(referral: Referral): Int {
+  private fun countSessionsWithAttendanceRecorded(referral: Referral): Int {
     return referral.actionPlan?.let {
       actionPlanRepository.countNumberOfAttendedSessions(it.id)
     } ?: 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -35,41 +35,54 @@ class ReferralConcluder(
     }
   }
 
-  fun requiresEndOfServiceReport(referral: Referral): Boolean {
-    return countSessionsWithAttendanceRecorded(referral) > 0
+  fun requiresEndOfServiceReportCreation(referral: Referral): Boolean {
+    if (referral.endOfServiceReport != null)
+      return false
+
+    val numberOfSessionsAttempted = countSessionsAttempted(referral)
+    val totalNumberOfSessions = referral.actionPlan?.numberOfSessions ?: 0
+    val allSessionsAttempted = totalNumberOfSessions == numberOfSessionsAttempted
+    if (allSessionsAttempted)
+      return true
+
+    val atLeastOneSessionAttempted = numberOfSessionsAttempted > 0
+    if (atLeastOneSessionAttempted && referral.endRequestedAt != null)
+      return true
+
+    return false
   }
 
   private fun getConcludedEventType(referral: Referral): ReferralEventType? {
 
     val hasActionPlan = nonNull(referral.actionPlan)
 
-    val numberOfAttendedAppointments = countSessionsWithAttendanceRecorded(referral)
-    val hasAttendedNoAppointments = numberOfAttendedAppointments == 0
+    val numberOfAttemptedSessions = countSessionsAttempted(referral)
+    val hasAttemptedNoSessions = numberOfAttemptedSessions == 0
 
-    val totalNumberOfAppointments = referral.actionPlan?.numberOfSessions ?: 0
-    val hasAttendedSomeAppointments = totalNumberOfAppointments > numberOfAttendedAppointments
-    val hasAttendedAllAppointments = totalNumberOfAppointments == numberOfAttendedAppointments
+    val totalNumberOfSessions = referral.actionPlan?.numberOfSessions ?: 0
+    val hasAttemptedSomeSessions = totalNumberOfSessions > numberOfAttemptedSessions
+    val hasAttemptedAllSessions = totalNumberOfSessions == numberOfAttemptedSessions
 
     val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
 
     if (!hasActionPlan)
       return CANCELLED
 
-    if (hasAttendedNoAppointments)
+    if (hasAttemptedNoSessions)
       return CANCELLED
 
-    if (hasAttendedSomeAppointments && hasSubmittedEndOfServiceReport)
+    if (hasAttemptedSomeSessions && hasSubmittedEndOfServiceReport)
       return PREMATURELY_ENDED
 
-    if (hasAttendedAllAppointments && hasSubmittedEndOfServiceReport)
+    if (hasAttemptedAllSessions && hasSubmittedEndOfServiceReport)
       return COMPLETED
 
     return null
   }
 
-  private fun countSessionsWithAttendanceRecorded(referral: Referral): Int {
+  private fun countSessionsAttempted(referral: Referral): Int {
     return referral.actionPlan?.let {
-      actionPlanRepository.countNumberOfAttendedSessions(it.id)
+      actionPlanRepository.countNumberOfAttemptedSessions(it.id)
     } ?: 0
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -39,8 +39,11 @@ class ReferralConcluder(
     if (referral.endOfServiceReport != null)
       return false
 
-    val numberOfSessionsAttempted = countSessionsAttempted(referral)
     val totalNumberOfSessions = referral.actionPlan?.numberOfSessions ?: 0
+    if (totalNumberOfSessions == 0)
+      return false
+
+    val numberOfSessionsAttempted = countSessionsAttempted(referral)
     val allSessionsAttempted = totalNumberOfSessions == numberOfSessionsAttempted
     if (allSessionsAttempted)
       return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -35,13 +35,15 @@ class ReferralConcluder(
     }
   }
 
+  fun requiresEosr(referral: Referral): Boolean {
+    return getNumberOfAttendedAppointments(referral) > 0
+  }
+
   private fun getConcludedEventType(referral: Referral): ReferralEventType? {
 
     val hasActionPlan = nonNull(referral.actionPlan)
 
-    val numberOfAttendedAppointments = referral.actionPlan?.let {
-      actionPlanRepository.countNumberOfAttendedSessions(it.id)
-    } ?: 0
+    val numberOfAttendedAppointments = getNumberOfAttendedAppointments(referral)
     val hasAttendedNoAppointments = numberOfAttendedAppointments == 0
 
     val totalNumberOfAppointments = referral.actionPlan?.numberOfSessions ?: 0
@@ -63,5 +65,11 @@ class ReferralConcluder(
       return COMPLETED
 
     return null
+  }
+
+  private fun getNumberOfAttendedAppointments(referral: Referral): Int {
+    return referral.actionPlan?.let {
+      actionPlanRepository.countNumberOfAttendedSessions(it.id)
+    } ?: 0
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -212,7 +212,7 @@ internal class ReferralControllerTest {
         token,
       )
       assertThat(sentReferralResponse.body.id).isEqualTo(sentReferral.id)
-      assertThat(sentReferralResponse.body.endOfServiceReportRequired).isFalse
+      assertThat(sentReferralResponse.body.endOfServiceReportCreationRequired).isFalse
     }
 
     @Test
@@ -225,7 +225,7 @@ internal class ReferralControllerTest {
         token,
       )
       assertThat(sentReferral.id).isEqualTo(referral.id)
-      assertThat(sentReferral.endOfServiceReportRequired).isFalse
+      assertThat(sentReferral.endOfServiceReportCreationRequired).isFalse
     }
 
     @Test
@@ -241,7 +241,7 @@ internal class ReferralControllerTest {
         tokenFactory.create(userID = "by")
       )
       assertThat(assignedReferral.id).isEqualTo(referral.id)
-      assertThat(assignedReferral.endOfServiceReportRequired).isFalse
+      assertThat(assignedReferral.endOfServiceReportCreationRequired).isFalse
     }
 
     @Test
@@ -260,7 +260,7 @@ internal class ReferralControllerTest {
       whenever(referralConcluder.requiresEndOfServiceReportCreation(referral)).thenReturn(true)
 
       val response = referralController.endSentReferral(referral.id, endReferralDTO, token)
-      assertThat(response.endOfServiceReportRequired).isTrue
+      assertThat(response.endOfServiceReportCreationRequired).isTrue
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -133,7 +133,7 @@ internal class ReferralControllerTest {
     val token = tokenFactory.create(user.id, user.authSource, user.userName)
     val endedReferral = referralFactory.createEnded(endRequestedComments = "comment")
     whenever(referralService.requestReferralEnd(any(), any(), any(), any())).thenReturn(endedReferral)
-    whenever(referralConcluder.requiresEosr(endedReferral)).thenReturn(true)
+    whenever(referralConcluder.requiresEndOfServiceReport(endedReferral)).thenReturn(true)
 
     referralController.endSentReferral(referral.id, endReferralDTO, token)
     verify(referralService).requestReferralEnd(referral, user, cancellationReason, "comment")
@@ -206,26 +206,26 @@ internal class ReferralControllerTest {
       val sentReferral = referralFactory.createSent()
       whenever(referralService.getDraftReferralForUser(draftReferral.id, user)).thenReturn(draftReferral)
       whenever(referralService.sendDraftReferral(draftReferral, user)).thenReturn(sentReferral)
-      whenever(referralConcluder.requiresEosr(sentReferral)).thenReturn(false)
+      whenever(referralConcluder.requiresEndOfServiceReport(sentReferral)).thenReturn(false)
       val sentReferralResponse = referralController.sendDraftReferral(
         draftReferral.id,
         token,
       )
       assertThat(sentReferralResponse.body.id).isEqualTo(sentReferral.id)
-      assertThat(sentReferralResponse.body.eosrRequired).isFalse
+      assertThat(sentReferralResponse.body.endOfServiceReportRequired).isFalse
     }
 
     @Test
     fun `is set when getting a set referral`() {
       val referral = referralFactory.createSent()
       whenever(referralService.getSentReferralForUser(eq(referral.id), any())).thenReturn(referral)
-      whenever(referralConcluder.requiresEosr(referral)).thenReturn(false)
+      whenever(referralConcluder.requiresEndOfServiceReport(referral)).thenReturn(false)
       val sentReferral = referralController.getSentReferral(
         referral.id,
         token,
       )
       assertThat(sentReferral.id).isEqualTo(referral.id)
-      assertThat(sentReferral.eosrRequired).isFalse
+      assertThat(sentReferral.endOfServiceReportRequired).isFalse
     }
 
     @Test
@@ -234,14 +234,14 @@ internal class ReferralControllerTest {
       val assignedToUser = authUserFactory.create(id = "to")
       whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
       whenever(referralService.assignSentReferral(any(), any(), any())).thenReturn(referral)
-      whenever(referralConcluder.requiresEosr(referral)).thenReturn(false)
+      whenever(referralConcluder.requiresEndOfServiceReport(referral)).thenReturn(false)
       val assignedReferral = referralController.assignSentReferral(
         UUID.randomUUID(),
         ReferralAssignmentDTO(AuthUserDTO.from(assignedToUser)),
         tokenFactory.create(userID = "by")
       )
       assertThat(assignedReferral.id).isEqualTo(referral.id)
-      assertThat(assignedReferral.eosrRequired).isFalse
+      assertThat(assignedReferral.endOfServiceReportRequired).isFalse
     }
 
     @Test
@@ -257,10 +257,10 @@ internal class ReferralControllerTest {
       val token = tokenFactory.create(user.id, user.authSource, user.userName)
       val endedReferral = referralFactory.createEnded(endRequestedComments = "comment")
       whenever(referralService.requestReferralEnd(any(), any(), any(), any())).thenReturn(endedReferral)
-      whenever(referralConcluder.requiresEosr(referral)).thenReturn(true)
+      whenever(referralConcluder.requiresEndOfServiceReport(referral)).thenReturn(true)
 
       val response = referralController.endSentReferral(referral.id, endReferralDTO, token)
-      assertThat(response.eosrRequired).isTrue
+      assertThat(response.endOfServiceReportRequired).isTrue
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -133,7 +133,7 @@ internal class ReferralControllerTest {
     val token = tokenFactory.create(user.id, user.authSource, user.userName)
     val endedReferral = referralFactory.createEnded(endRequestedComments = "comment")
     whenever(referralService.requestReferralEnd(any(), any(), any(), any())).thenReturn(endedReferral)
-    whenever(referralConcluder.requiresEndOfServiceReport(endedReferral)).thenReturn(true)
+    whenever(referralConcluder.requiresEndOfServiceReportCreation(endedReferral)).thenReturn(true)
 
     referralController.endSentReferral(referral.id, endReferralDTO, token)
     verify(referralService).requestReferralEnd(referral, user, cancellationReason, "comment")
@@ -206,7 +206,7 @@ internal class ReferralControllerTest {
       val sentReferral = referralFactory.createSent()
       whenever(referralService.getDraftReferralForUser(draftReferral.id, user)).thenReturn(draftReferral)
       whenever(referralService.sendDraftReferral(draftReferral, user)).thenReturn(sentReferral)
-      whenever(referralConcluder.requiresEndOfServiceReport(sentReferral)).thenReturn(false)
+      whenever(referralConcluder.requiresEndOfServiceReportCreation(sentReferral)).thenReturn(false)
       val sentReferralResponse = referralController.sendDraftReferral(
         draftReferral.id,
         token,
@@ -219,7 +219,7 @@ internal class ReferralControllerTest {
     fun `is set when getting a set referral`() {
       val referral = referralFactory.createSent()
       whenever(referralService.getSentReferralForUser(eq(referral.id), any())).thenReturn(referral)
-      whenever(referralConcluder.requiresEndOfServiceReport(referral)).thenReturn(false)
+      whenever(referralConcluder.requiresEndOfServiceReportCreation(referral)).thenReturn(false)
       val sentReferral = referralController.getSentReferral(
         referral.id,
         token,
@@ -234,7 +234,7 @@ internal class ReferralControllerTest {
       val assignedToUser = authUserFactory.create(id = "to")
       whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
       whenever(referralService.assignSentReferral(any(), any(), any())).thenReturn(referral)
-      whenever(referralConcluder.requiresEndOfServiceReport(referral)).thenReturn(false)
+      whenever(referralConcluder.requiresEndOfServiceReportCreation(referral)).thenReturn(false)
       val assignedReferral = referralController.assignSentReferral(
         UUID.randomUUID(),
         ReferralAssignmentDTO(AuthUserDTO.from(assignedToUser)),
@@ -257,7 +257,7 @@ internal class ReferralControllerTest {
       val token = tokenFactory.create(user.id, user.authSource, user.userName)
       val endedReferral = referralFactory.createEnded(endRequestedComments = "comment")
       whenever(referralService.requestReferralEnd(any(), any(), any(), any())).thenReturn(endedReferral)
-      whenever(referralConcluder.requiresEndOfServiceReport(referral)).thenReturn(true)
+      whenever(referralConcluder.requiresEndOfServiceReportCreation(referral)).thenReturn(true)
 
       val response = referralController.endSentReferral(referral.id, endReferralDTO, token)
       assertThat(response.endOfServiceReportRequired).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
@@ -87,7 +87,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceProvider": {"name": "Provider"}
         },
         "actionPlanId": null,
-        "endOfServiceReportRequired": false
+        "endOfServiceReportCreationRequired": false
       }
     """
     )
@@ -135,7 +135,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceProvider": {"name": "Provider"}
         },
         "actionPlanId": "${referral.actionPlan?.id}",
-        "endOfServiceReportRequired": false
+        "endOfServiceReportCreationRequired": false
       }
     """
     )
@@ -186,7 +186,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceUser": {"crn": "X123456"},
           "serviceProvider": {"name": "Harmony Living"}
         },
-        "endOfServiceReportRequired": true,
+        "endOfServiceReportCreationRequired": true,
         "endOfServiceReport": {
         "id" : "3b9ed289-8412-41a9-8291-45e33e60276c",
         "referralId": "3b9ed289-8412-41a9-8291-45e33e60276c",
@@ -228,7 +228,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
         "endRequestedAt": "2021-01-13T21:57:13Z",
         "endRequestedReason": "service user turned into a tomato",
         "endRequestedComments": null,
-        "endOfServiceReportRequired": false,
+        "endOfServiceReportCreationRequired": false,
         "concludedAt": "2021-01-13T21:57:13Z"
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
@@ -87,7 +87,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceProvider": {"name": "Provider"}
         },
         "actionPlanId": null,
-        "eosrRequired": false
+        "endOfServiceReportRequired": false
       }
     """
     )
@@ -135,7 +135,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceProvider": {"name": "Provider"}
         },
         "actionPlanId": "${referral.actionPlan?.id}",
-        "eosrRequired": false
+        "endOfServiceReportRequired": false
       }
     """
     )
@@ -186,7 +186,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceUser": {"crn": "X123456"},
           "serviceProvider": {"name": "Harmony Living"}
         },
-        "eosrRequired": true,
+        "endOfServiceReportRequired": true,
         "endOfServiceReport": {
         "id" : "3b9ed289-8412-41a9-8291-45e33e60276c",
         "referralId": "3b9ed289-8412-41a9-8291-45e33e60276c",
@@ -228,7 +228,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
         "endRequestedAt": "2021-01-13T21:57:13Z",
         "endRequestedReason": "service user turned into a tomato",
         "endRequestedComments": null,
-        "eosrRequired": false,
+        "endOfServiceReportRequired": false,
         "concludedAt": "2021-01-13T21:57:13Z"
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTOTest.kt
@@ -15,7 +15,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @JsonTest
-class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferralDTO>) {
+class SentReferralSummaryDTOTest(@Autowired private val json: JacksonTester<SentReferralSummaryDTO>) {
   private val referralFactory = ReferralFactory()
 
   @Test
@@ -24,26 +24,26 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
     val timestamp = OffsetDateTime.now()
 
     assertThrows<RuntimeException> {
-      SentReferralDTO.from(referral, false)
+      SentReferralSummaryDTO.from(referral)
     }
 
     referral.sentAt = timestamp
     assertThrows<RuntimeException> {
-      SentReferralDTO.from(referral, false)
+      SentReferralSummaryDTO.from(referral)
     }
 
     referral.referenceNumber = "something"
     assertThrows<RuntimeException> {
-      SentReferralDTO.from(referral, false)
+      SentReferralSummaryDTO.from(referral)
     }
 
     referral.sentBy = AuthUser("id", "source", "username")
     assertThrows<RuntimeException> {
-      SentReferralDTO.from(referral, false)
+      SentReferralSummaryDTO.from(referral)
     }
 
     referral.supplementaryRiskId = UUID.randomUUID()
-    assertDoesNotThrow { SentReferralDTO.from(referral, false) }
+    assertDoesNotThrow { SentReferralSummaryDTO.from(referral) }
   }
 
   @Test
@@ -67,7 +67,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
     referral.sentAt = sentAt
     referral.sentBy = sentBy
 
-    val out = json.write(SentReferralDTO.from(referral, false))
+    val out = json.write(SentReferralSummaryDTO.from(referral))
     Assertions.assertThat(out).isEqualToJson(
       """
       {
@@ -86,8 +86,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceUser": {"crn": "X123456"},
           "serviceProvider": {"name": "Provider"}
         },
-        "actionPlanId": null,
-        "eosrRequired": false
+        "actionPlanId": null
       }
     """
     )
@@ -115,7 +114,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
     referral.sentAt = sentAt
     referral.sentBy = sentBy
 
-    val out = json.write(SentReferralDTO.from(referral, false))
+    val out = json.write(SentReferralSummaryDTO.from(referral))
     Assertions.assertThat(out).isEqualToJson(
       """
       {
@@ -134,8 +133,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceUser": {"crn": "X123456"},
           "serviceProvider": {"name": "Provider"}
         },
-        "actionPlanId": "${referral.actionPlan?.id}",
-        "eosrRequired": false
+        "actionPlanId": "${referral.actionPlan?.id}"
       }
     """
     )
@@ -167,7 +165,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
     referral.sentAt = sentAt
     referral.sentBy = sentBy
 
-    val out = json.write(SentReferralDTO.from(referral, true))
+    val out = json.write(SentReferralSummaryDTO.from(referral))
     Assertions.assertThat(out).isEqualToJson(
       """
       {
@@ -186,7 +184,6 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
           "serviceUser": {"crn": "X123456"},
           "serviceProvider": {"name": "Harmony Living"}
         },
-        "eosrRequired": true,
         "endOfServiceReport": {
         "id" : "3b9ed289-8412-41a9-8291-45e33e60276c",
         "referralId": "3b9ed289-8412-41a9-8291-45e33e60276c",
@@ -221,14 +218,13 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
     referral.endRequestedReason = CancellationReason("TOM", "service user turned into a tomato")
     referral.concludedAt = OffsetDateTime.parse("2021-01-13T21:57:13+00:00")
 
-    val out = json.write(SentReferralDTO.from(referral, false))
+    val out = json.write(SentReferralSummaryDTO.from(referral))
     Assertions.assertThat(out).isEqualToJson(
       """
       {
         "endRequestedAt": "2021-01-13T21:57:13Z",
         "endRequestedReason": "service user turned into a tomato",
         "endRequestedComments": null,
-        "eosrRequired": false,
         "concludedAt": "2021-01-13T21:57:13Z"
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
@@ -32,8 +32,8 @@ class ActionPlanRepositoryTest @Autowired constructor(
     val actionPlan2 = actionPlanFactory.create()
     actionPlanSessionFactory.createAttended(actionPlan = actionPlan2)
 
-    assertThat(actionPlanRepository.countNumberOfAttendedSessions(actionPlan1.id)).isEqualTo(4)
-    assertThat(actionPlanRepository.countNumberOfAttendedSessions(actionPlan2.id)).isEqualTo(1)
+    assertThat(actionPlanRepository.countNumberOfAttemptedSessions(actionPlan1.id)).isEqualTo(4)
+    assertThat(actionPlanRepository.countNumberOfAttemptedSessions(actionPlan2.id)).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -138,6 +138,32 @@ internal class ReferralConcluderTest {
     verifyZeroInteractions(referralRepository, referralEventPublisher)
   }
 
+  @Test
+  fun `should flag end of service report as required when at least one session has been attended`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(1)
+
+    val eosrRequired = referralConcluder.requiresEosr(referralWithActionPlanAndSomeAttendedAppointments)
+
+    assertThat(eosrRequired).isTrue
+    verifyZeroInteractions(referralRepository, referralEventPublisher)
+  }
+
+  @Test
+  fun `should not flag end of service report as required when no sessions have been attended`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
+
+    val eosrRequired = referralConcluder.requiresEosr(referralWithActionPlanAndSomeAttendedAppointments)
+
+    assertThat(eosrRequired).isFalse
+    verifyZeroInteractions(referralRepository, referralEventPublisher)
+  }
+
   private fun verifyEventPublished(referralWithNoActionPlan: Referral, value: ReferralEventType) {
     verify(referralEventPublisher).referralConcludedEvent(same(referralWithNoActionPlan), same(value))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -145,9 +145,9 @@ internal class ReferralConcluderTest {
     val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
     whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(1)
 
-    val eosrRequired = referralConcluder.requiresEosr(referralWithActionPlanAndSomeAttendedAppointments)
+    val endOfServiceReportRequired = referralConcluder.requiresEndOfServiceReport(referralWithActionPlanAndSomeAttendedAppointments)
 
-    assertThat(eosrRequired).isTrue
+    assertThat(endOfServiceReportRequired).isTrue
     verifyZeroInteractions(referralRepository, referralEventPublisher)
   }
 
@@ -158,9 +158,9 @@ internal class ReferralConcluderTest {
     val referralWithActionPlanAndSomeAttendedAppointments = referralFactory.createSent(actionPlan = actionPlan)
     whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
 
-    val eosrRequired = referralConcluder.requiresEosr(referralWithActionPlanAndSomeAttendedAppointments)
+    val endOfServiceReportRequired = referralConcluder.requiresEndOfServiceReport(referralWithActionPlanAndSomeAttendedAppointments)
 
-    assertThat(eosrRequired).isFalse
+    assertThat(endOfServiceReportRequired).isFalse
     verifyZeroInteractions(referralRepository, referralEventPublisher)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -179,6 +179,17 @@ internal class ReferralConcluderTest {
   }
 
   @Test
+  fun `should not flag end of service report as required when action plan exists`() {
+
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlan = null)
+
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+
+    assertThat(endOfServiceReportCreationRequired).isFalse
+    verifyZeroInteractions(actionPlanRepository, referralRepository, referralEventPublisher)
+  }
+
+  @Test
   fun `should not flag end of service report as required when no sessions have been attempted`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionP
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SelectedDesiredOutcomesMapping
@@ -102,6 +103,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     sentBy: AuthUser = authUserFactory.create(),
     referenceNumber: String? = "JS18726AC",
     supplementaryRiskId: UUID = UUID.randomUUID(),
+    actionPlan: ActionPlan? = null,
 
     assignedBy: AuthUser? = null,
     assignedTo: AuthUser? = null,
@@ -113,6 +115,8 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     endRequestedComments: String? = null,
 
     concludedAt: OffsetDateTime? = null,
+
+    endOfServiceReport: EndOfServiceReport? = null,
   ): Referral {
     return create(
       id = id,
@@ -121,6 +125,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
       serviceUserCRN = serviceUserCRN,
       intervention = intervention,
       selectedServiceCategories = selectedServiceCategories,
+      actionPlan = actionPlan,
 
       sentAt = sentAt,
       sentBy = sentBy,
@@ -137,6 +142,8 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
       endRequestedComments = endRequestedComments,
 
       concludedAt = concludedAt,
+
+      endOfServiceReport = endOfServiceReport,
     )
   }
 
@@ -172,6 +179,8 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     endRequestedComments: String? = null,
 
     concludedAt: OffsetDateTime? = null,
+
+    endOfServiceReport: EndOfServiceReport? = null,
   ): Referral {
     val referral = save(
       Referral(
@@ -200,6 +209,7 @@ class ReferralFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         endRequestedReason = endRequestedReason,
         endRequestedComments = endRequestedComments,
         concludedAt = concludedAt,
+        endOfServiceReport = endOfServiceReport,
       )
     )
     referral.selectedDesiredOutcomes = desiredOutcomes.map { SelectedDesiredOutcomesMapping(it.serviceCategoryId, it.id) }.toMutableList()


### PR DESCRIPTION
## What does this pull request do?
A derived field which indicates to the user interface if a EoS Report is required. 

## What is the intent behind these changes?
To avoid duplicating the business rule in UI
