### PR TITLE
Extend business KPIs

### DIFF
--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_details_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_details_report.sql
@@ -1,0 +1,22 @@
+-- referrals by contract type
+SELECT ct.name     AS contract_type,
+       COUNT(r.id) AS number_of_sent_referrals
+FROM referral r
+         JOIN intervention i ON r.intervention_id = i.id
+         JOIN dynamic_framework_contract c ON i.dynamic_framework_contract_id = c.id
+         JOIN contract_type ct ON c.contract_type_id = ct.id
+WHERE r.sent_at IS NOT NULL
+GROUP BY ct.name
+ORDER BY ct.name;
+
+-- referrals by NPS region
+SELECT nr.name     AS probation_region_including_PCCs,
+       COUNT(r.id) AS number_of_sent_referrals
+FROM referral r
+         JOIN intervention i ON r.intervention_id = i.id
+         JOIN dynamic_framework_contract c ON i.dynamic_framework_contract_id = c.id
+         LEFT JOIN pcc_region pr ON c.pcc_region_id = pr.id
+         LEFT JOIN nps_region nr ON (c.nps_region_id = nr.id OR pr.nps_region_id = nr.id)
+WHERE r.sent_at IS NOT NULL
+GROUP BY nr.name
+ORDER BY nr.name;

--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
@@ -12,7 +12,8 @@ WITH counts AS (
                                       r.end_requested_at IS NOT NULL AND
                                       eosr.submitted_at IS NOT NULL )       AS count_of_early_end_referrals,
            count(r.id) FILTER ( WHERE r.end_requested_reason_code = 'MIS' ) AS count_of_mistaken_referrals,
-           count(r.sent_by_id)                                              AS count_of_pp_users_sending_referrals
+           count(DISTINCT r.created_by_id)                                  AS count_of_pp_users_starting_referrals,
+           count(DISTINCT r.sent_by_id)                                     AS count_of_pp_users_sending_referrals
     FROM referral r
              LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id),
 
@@ -33,6 +34,7 @@ SELECT counts.count_of_started_referrals,
        counts.count_of_cancelled_referrals,
        counts.count_of_mistaken_referrals,
        counts.count_of_early_end_referrals,
+       counts.count_of_pp_users_starting_referrals,
        counts.count_of_pp_users_sending_referrals,
        case
            when counts.count_of_started_referrals = 0 then 0.0

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -17,6 +17,7 @@ spec:
           containers:
           - name: data-extractor-reporting
             image: ministryofjustice/data-engineering-data-extractor:develop
+            imagePullPolicy: Always
             args: ["mkdir -p 'export/csv/reports' && psql -v ON_ERROR_STOP=1 --file=/reports/crs_performance_report.sql > 'export/csv/reports/crs_performance_report.csv' && transfer_local_to_s3.sh"]
             volumeMounts:
             - name: data-extractor-reports

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -31,12 +31,22 @@ spec:
           containers:
           - name: data-extractor-reporting
             image: ministryofjustice/data-engineering-data-extractor:develop
-            args: ["psql -v ON_ERROR_STOP=1 --tuples-only --expanded --file=/reports/team_kpi_report.sql > 'export/team_kpi_report' && /scripts/send_to_slack.sh 'export/team_kpi_report'"]
+            args:
+              - |
+                psql -v ON_ERROR_STOP=1 --tuples-only --expanded --file=/reports/team_kpi_report.sql > 'export/team_kpi_report' \
+                  && /scripts/send_to_slack.sh 'export/team_kpi_details_report'
+              - |
+                psql -v ON_ERROR_STOP=1 --pset="footer=off" --file=/reports/team_kpi_details_report.sql > 'export/team_kpi_details_report' \
+                  && /scripts/send_to_slack.sh 'export/team_kpi_details_report'
             volumeMounts:
             - name: data-extractor-reports
               mountPath: /reports/team_kpi_report.sql
               readOnly: true
               subPath: team_kpi_report.sql
+            - name: data-extractor-reports
+              mountPath: /reports/team_kpi_details_report.sql
+              readOnly: true
+              subPath: team_kpi_details_report.sql
             - name: kpi-scripts
               mountPath: /scripts/send_to_slack.sh
               readOnly: true

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -31,6 +31,7 @@ spec:
           containers:
           - name: data-extractor-reporting
             image: ministryofjustice/data-engineering-data-extractor:develop
+            imagePullPolicy: Always
             args:
               - |
                 psql -v ON_ERROR_STOP=1 --tuples-only --expanded --file=/reports/team_kpi_report.sql > 'export/team_kpi_report' \

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -53,8 +53,6 @@ spec:
               readOnly: true
               subPath: send_to_slack.sh
             env:
-              - name: USE_STATIC_LOCATION
-                value: "true"
               - name: ENVIRONMENT
                 value: {{ .Values.env.SENTRY_ENVIRONMENT | quote }}
               - name: SLACK_WEBHOOK


### PR DESCRIPTION
## What does this pull request do?

⚠️ **Always pull all data-extractor job images**
To avoid weird states, i.e. an outdated image requiring `PGPORT` to be defined

IC-1947: **Adds sent referrals per contract type**
```
              contract_type               | number_of_sent_referrals 
------------------------------------------+--------------------------
 Accommodation                            |                       16
 Education, Training and Employment (ETE) |                        1
 Personal Wellbeing                       |                        1
 Women's Services                         |                        1
```

IC-1955: **Adds sent referrals per probation region**
```
 probation_region_including_pccs | number_of_sent_referrals 
---------------------------------+--------------------------
 East Midlands                   |                       14
 East of England                 |                        1
 North West                      |                        1
 South West                      |                        3
```

IC-1949: **Adds started by and fixes unique users on sent by**
```
count_of_pp_users_starting_referrals | 2
count_of_pp_users_sending_referrals  | 1
```

## What is the intent behind these changes?

Improve business KPIs

## Screenshots (pre-prod)

<img width="706" alt="image" src="https://user-images.githubusercontent.com/1526295/122571622-d41dac00-d044-11eb-8cd9-2d9fe9f5d1be.png">
