### PR TITLE
🪲 Fix first KPI message being empty

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -35,7 +35,7 @@ spec:
             args:
               - |
                 psql -v ON_ERROR_STOP=1 --tuples-only --expanded --file=/reports/team_kpi_report.sql > 'export/team_kpi_report' \
-                  && /scripts/send_to_slack.sh 'export/team_kpi_details_report'
+                  && /scripts/send_to_slack.sh 'export/team_kpi_report'
               - |
                 psql -v ON_ERROR_STOP=1 --pset="footer=off" --file=/reports/team_kpi_details_report.sql > 'export/team_kpi_details_report' \
                   && /scripts/send_to_slack.sh 'export/team_kpi_details_report'


### PR DESCRIPTION
## What does this pull request do?

Fixes the first KPI message being empty due to a mismatch in file created and used for the output

## What is the intent behind these changes?

I messed up the script; however, I don't think it's worth adding DRY and/or `psql | send_to_slack` pipes -- this is meant to be temporary