### PR TITLE
Change JSON for update appointment to use appointment fields rather than array

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -27,6 +27,7 @@ enum class Code {
   INVALID_FORMAT,
   INVALID_LENGTH,
   INVALID_VALUE,
+  NOT_YET_IMPLEMENTED,
 }
 
 data class FieldError(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -9,13 +9,13 @@ import java.util.UUID
 
 data class AddressDTO private constructor(
   val firstAddressLine: String,
-  val secondAddressLine: String? = "",
-  val townOrCity: String,
-  val county: String,
+  val secondAddressLine: String? = null,
+  val townOrCity: String? = null,
+  val county: String? = null,
   val postCode: String,
 ) {
   companion object {
-    operator fun invoke(firstAddressLine: String, secondAddressLine: String? = "", townOrCity: String, county: String, postCode: String,): AddressDTO {
+    operator fun invoke(firstAddressLine: String, secondAddressLine: String? = null, townOrCity: String? = null, county: String? = null, postCode: String): AddressDTO {
       val normalizedPostCode = postCode.replace("\\s".toRegex(), "").uppercase()
       return AddressDTO(firstAddressLine, secondAddressLine, townOrCity, county, normalizedPostCode)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -7,12 +7,27 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attende
 import java.time.OffsetDateTime
 import java.util.UUID
 
+data class AddressDTO private constructor(
+  val firstAddressLine: String,
+  val secondAddressLine: String? = "",
+  val townOrCity: String,
+  val county: String,
+  val postCode: String,
+) {
+  companion object {
+    operator fun invoke(firstAddressLine: String, secondAddressLine: String? = "", townOrCity: String, county: String, postCode: String,): AddressDTO {
+      val normalizedPostCode = postCode.replace("\\s".toRegex(), "").uppercase()
+      return AddressDTO(firstAddressLine, secondAddressLine, townOrCity, county, normalizedPostCode)
+    }
+  }
+}
+
 data class UpdateAppointmentDTO(
   val appointmentTime: OffsetDateTime,
   @JsonProperty(required = true) val durationInMinutes: Int,
   // TODO: remove optional when front-end changes are complete
   val appointmentDeliveryType: AppointmentDeliveryType? = null,
-  val appointmentDeliveryAddress: List<String>? = null,
+  val appointmentDeliveryAddress: AddressDTO? = null,
 )
 
 data class UpdateAppointmentAttendanceDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AppointmentDeliveryAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AppointmentDeliveryAddress.kt
@@ -12,7 +12,7 @@ data class AppointmentDeliveryAddress(
   var appointmentDeliveryId: UUID,
   var firstAddressLine: String,
   var secondAddressLine: String? = null,
-  var townCity: String,
-  var county: String,
+  var townCity: String? = null,
+  var county: String? = null,
   var postCode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidator.kt
@@ -4,41 +4,49 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 
 @Component
 class ActionPlanSessionValidator {
-
+  companion object {
+    val postCodeRegex = Regex("""^[A-Z]{1,2}\d[A-Z\d]?\d[A-Z]{2}${'$'}""")
+  }
   fun validateUpdateAppointment(updateAppointmentDTO: UpdateAppointmentDTO) {
     val errors = mutableListOf<FieldError>()
-    val appointmentDeliveryAddressLines = updateAppointmentDTO.appointmentDeliveryAddress
+    val appointmentDeliveryAddress = updateAppointmentDTO.appointmentDeliveryAddress
     when (updateAppointmentDTO.appointmentDeliveryType) {
-      AppointmentDeliveryType.VIDEO_CALL -> {
-        if (appointmentDeliveryAddressLines == null || appointmentDeliveryAddressLines.isEmpty()) {
-          errors.add(FieldError(field = "appointmentDeliveryAddress", error = Code.CANNOT_BE_EMPTY))
-        }
-      }
       AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE -> {
-        if (appointmentDeliveryAddressLines == null || appointmentDeliveryAddressLines.isEmpty()) {
-          errors.add(FieldError(field = "appointmentDeliveryAddress", error = Code.CANNOT_BE_EMPTY))
-        } else if (appointmentDeliveryAddressLines.first().length > 7) {
-          errors.add(FieldError(field = "appointmentDeliveryAddress", error = Code.INVALID_VALUE))
-        }
+        errors.add(FieldError(field = "appointmentDeliveryType", error = Code.NOT_YET_IMPLEMENTED))
       }
       AppointmentDeliveryType.IN_PERSON_MEETING_OTHER -> {
-        if (appointmentDeliveryAddressLines == null || appointmentDeliveryAddressLines.isEmpty()) {
+        if (appointmentDeliveryAddress == null) {
           errors.add(FieldError(field = "appointmentDeliveryAddress", error = Code.CANNOT_BE_EMPTY))
-        } else if (appointmentDeliveryAddressLines.size !== 5) {
-          errors.add(FieldError(field = "appointmentDeliveryAddress", error = Code.INVALID_LENGTH))
-        } else if (appointmentDeliveryAddressLines.elementAt(4).length > 8) {
-          errors.add(FieldError(field = "appointmentDeliveryAddress", error = Code.INVALID_FORMAT))
+        } else {
+          validateAddress(appointmentDeliveryAddress, errors)
         }
       }
     }
-
     if (errors.isNotEmpty()) {
       throw ValidationError("invalid update session appointment request", errors)
+    }
+  }
+
+  private fun validateAddress(addressDTO: AddressDTO, errors: MutableList<FieldError>) {
+    if (addressDTO.firstAddressLine.isNullOrEmpty()) {
+      errors.add(FieldError(field = "appointmentDeliveryAddress.firstAddressLine", error = Code.CANNOT_BE_EMPTY))
+    }
+    if (addressDTO.townOrCity.isNullOrEmpty()) {
+      errors.add(FieldError(field = "appointmentDeliveryAddress.townOrCity", error = Code.CANNOT_BE_EMPTY))
+    }
+    if (addressDTO.county.isNullOrEmpty()) {
+      errors.add(FieldError(field = "appointmentDeliveryAddress.county", error = Code.CANNOT_BE_EMPTY))
+    }
+    if (addressDTO.postCode.isNullOrEmpty()) {
+      errors.add(FieldError(field = "appointmentDeliveryAddress.postCode", error = Code.CANNOT_BE_EMPTY))
+    } else if (!postCodeRegex.matches(addressDTO.postCode)) {
+      errors.add(FieldError(field = "appointmentDeliveryAddress.postCode", error = Code.INVALID_FORMAT))
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidator.kt
@@ -37,12 +37,6 @@ class ActionPlanSessionValidator {
     if (addressDTO.firstAddressLine.isNullOrEmpty()) {
       errors.add(FieldError(field = "appointmentDeliveryAddress.firstAddressLine", error = Code.CANNOT_BE_EMPTY))
     }
-    if (addressDTO.townOrCity.isNullOrEmpty()) {
-      errors.add(FieldError(field = "appointmentDeliveryAddress.townOrCity", error = Code.CANNOT_BE_EMPTY))
-    }
-    if (addressDTO.county.isNullOrEmpty()) {
-      errors.add(FieldError(field = "appointmentDeliveryAddress.county", error = Code.CANNOT_BE_EMPTY))
-    }
     if (addressDTO.postCode.isNullOrEmpty()) {
       errors.add(FieldError(field = "appointmentDeliveryAddress.postCode", error = Code.CANNOT_BE_EMPTY))
     } else if (!postCodeRegex.matches(addressDTO.postCode)) {

--- a/src/main/resources/db/migration/V1_65__appointment_delivery_address_nullable_fields.sql
+++ b/src/main/resources/db/migration/V1_65__appointment_delivery_address_nullable_fields.sql
@@ -1,0 +1,2 @@
+alter table appointment_delivery_address alter column town_city drop not null;
+alter table appointment_delivery_address alter column county drop not null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTOTest.kt
@@ -86,4 +86,10 @@ internal class ActionPlanSessionsDTOTest {
     assertThat(sessionDTO.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.IN_PERSON_MEETING_OTHER)
     assertThat(sessionDTO.appointmentDeliveryAddress).isEqualTo(listOf("Harmony Living Office, Room 4", "", "Blackpool", "Lancashire", "SY4 0RE"))
   }
+
+  @Test
+  fun `post codes are normalized`() {
+    val addressDTO = AddressDTO("firstline", "secondLine", "town", "county", "  a9   9aa  ")
+    assertThat(addressDTO.postCode).isEqualTo("A99AA")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceRespositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceRespositoryTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
@@ -68,7 +69,7 @@ class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
     @Nested
     inner class AppointmentDelivery {
 
-      private fun callUpdateSessionAppointment(actionPlanId: UUID, appointmentDeliveryType: AppointmentDeliveryType, appointmentDeliveryAddressLines: List<String>?): ActionPlanSession {
+      private fun callUpdateSessionAppointment(actionPlanId: UUID, appointmentDeliveryType: AppointmentDeliveryType, appointmentDeliveryAddress: AddressDTO?): ActionPlanSession {
         return actionPlanSessionsService.updateSessionAppointment(
           actionPlanId = actionPlanId,
           sessionNumber = 1,
@@ -76,7 +77,7 @@ class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
           durationInMinutes = 1,
           updatedBy = userFactory.create(),
           appointmentDeliveryType = appointmentDeliveryType,
-          appointmentDeliveryAddressLines = appointmentDeliveryAddressLines,
+          appointmentDeliveryAddress = appointmentDeliveryAddress,
         )
       }
       @Test
@@ -118,26 +119,6 @@ class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
         assertThat(updatedSession.appointments.first().appointmentDelivery).isNotNull()
         assertThat(updatedSession.appointments.first().appointmentDelivery?.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.VIDEO_CALL)
       }
-      @Test
-      fun `can update existing appointment with an nps office code`() {
-        val actionPlanSession = actionPlanSessionFactory.createScheduled()
-        testSettingNPSOffice(actionPlanSession)
-      }
-
-      @Test
-      fun `can create new appointment with with an nps office code`() {
-        val actionPlanSession = actionPlanSessionFactory.createUnscheduled()
-        testSettingNPSOffice(actionPlanSession)
-      }
-
-      private fun testSettingNPSOffice(actionPlanSession: ActionPlanSession) {
-        callUpdateSessionAppointment(actionPlanSession.actionPlan.id, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, listOf("ABC"))
-        var updatedSession = actionPlanSessionRepository.findById(actionPlanSession.id).get()
-        assertThat(updatedSession.appointments).hasSize(1)
-        assertThat(updatedSession.appointments.first().appointmentDelivery).isNotNull()
-        assertThat(updatedSession.appointments.first().appointmentDelivery?.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE)
-        assertThat(updatedSession.appointments.first().appointmentDelivery?.npsOfficeCode).isEqualTo("ABC")
-      }
 
       @Nested
       inner class WithAppointmentDeliveryAddress {
@@ -155,7 +136,7 @@ class ActionPlanSessionsServiceRespositoryTest @Autowired constructor(
         }
 
         private fun testSettingNonNPSOffice(actionPlanSession: ActionPlanSession) {
-          callUpdateSessionAppointment(actionPlanSession.actionPlan.id, AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, listOf("A", "B", "C", "D", "E"))
+          callUpdateSessionAppointment(actionPlanSession.actionPlan.id, AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, AddressDTO("A", "B", "C", "D", "E"))
           var updatedSession = actionPlanSessionRepository.findById(actionPlanSession.id).get()
           assertThat(updatedSession.appointments).hasSize(1)
           assertThat(updatedSession.appointments.first().appointmentDelivery).isNotNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidatorTest.kt
@@ -41,6 +41,14 @@ internal class ActionPlanSessionValidatorTest {
         }
       }
 
+      @Test
+      fun `can request valid non nps office appointment with null values for optional fields`() {
+        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = AddressDTO("firstline", null, null, null, "A1 1AA"))
+        assertDoesNotThrow {
+          actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        }
+      }
+
       @Nested
       inner class PostCodeValidation {
 
@@ -90,8 +98,6 @@ internal class ActionPlanSessionValidatorTest {
         }
         assertThat(exception.errors).containsExactly(
           FieldError("appointmentDeliveryAddress.firstAddressLine", Code.CANNOT_BE_EMPTY),
-          FieldError("appointmentDeliveryAddress.townOrCity", Code.CANNOT_BE_EMPTY),
-          FieldError("appointmentDeliveryAddress.county", Code.CANNOT_BE_EMPTY),
           FieldError("appointmentDeliveryAddress.postCode", Code.CANNOT_BE_EMPTY),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/ActionPlanSessionValidatorTest.kt
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import java.time.OffsetDateTime
@@ -17,84 +19,82 @@ internal class ActionPlanSessionValidatorTest {
 
   @Nested
   inner class ValidateUpdateAppointment {
-    @Test
-    fun `can request valid nps office appointment`() {
-      val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, appointmentDeliveryAddress = listOf("ABC"))
-      assertDoesNotThrow {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
-      }
-    }
 
     @Test
-    fun `empty nps code for nps office appointment throws validation error`() {
-      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, appointmentDeliveryAddress = null)
+    fun `nps office not yet implemented`() {
+      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE)
       var exception = assertThrows<ValidationError> {
         actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
       }
-      assertThat(exception.errors.first().error).isEqualTo(Code.CANNOT_BE_EMPTY)
-      updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, appointmentDeliveryAddress = listOf())
-      exception = assertThrows {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
-      }
-      assertThat(exception.errors.first().error).isEqualTo(Code.CANNOT_BE_EMPTY)
+      assertThat(exception.errors).containsExactly(
+        FieldError("appointmentDeliveryType", Code.NOT_YET_IMPLEMENTED),
+      )
     }
 
-    @Test
-    fun `invalid nps code for nps office appointment throws validation error`() {
-      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, appointmentDeliveryAddress = listOf("CODE THAT IS TOO LONG"))
-      var exception = assertThrows<ValidationError> {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+    @Nested
+    inner class OtherLocationAppointment {
+      @Test
+      fun `can request valid non nps office appointment`() {
+        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = AddressDTO("firstline", "secondLine", "town", "county", "A1 1AA"))
+        assertDoesNotThrow {
+          actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        }
       }
-      assertThat(exception.errors.first().error).isEqualTo(Code.INVALID_VALUE)
-    }
 
-    @Test
-    fun `can request valid non nps office appointment`() {
-      val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = listOf("firstline", "secondLine", "town", "county", "A1 1AA"))
-      assertDoesNotThrow {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
-      }
-    }
+      @Nested
+      inner class PostCodeValidation {
 
-    @Test
-    fun `empty address for non nps office appointment throws validation error`() {
-      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = null)
-      var exception = assertThrows<ValidationError> {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
-      }
-      assertThat(exception.errors.first().error).isEqualTo(Code.CANNOT_BE_EMPTY)
-      updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = listOf())
-      exception = assertThrows {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
-      }
-      assertThat(exception.errors.first().error).isEqualTo(Code.CANNOT_BE_EMPTY)
-    }
+        private fun createUpdateAppointmentDTO(postCode: String): UpdateAppointmentDTO {
+          return UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = AddressDTO("firstline", "secondLine", "town", "county", postCode))
+        }
+        @Test
+        fun `can request valid non nps office appointment for various postcodes`() {
+          assertDoesNotThrow {
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("aa9a 9aa"))
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("a9a 9aa"))
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("a9 9aa"))
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("a99 9aa"))
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("aa9 9aa"))
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("aa99 9aa"))
+          }
+        }
 
-    @Test
-    fun `too few address fields for non nps office appointment throws validation error`() {
-      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = listOf("firstline", "town", "county", "A1 1AA"))
-      var exception = assertThrows<ValidationError> {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        @Test
+        fun `invalid postcode for non nps office appointment throws validation error`() {
+          var exception = assertThrows<ValidationError> {
+            actionPlanSessionValidator.validateUpdateAppointment(createUpdateAppointmentDTO("aaa9 9aa"))
+          }
+          assertThat(exception.errors).containsExactly(
+            FieldError("appointmentDeliveryAddress.postCode", Code.INVALID_FORMAT),
+          )
+        }
       }
-      assertThat(exception.errors.first().error).isEqualTo(Code.INVALID_LENGTH)
-    }
 
-    @Test
-    fun `too many address fields for non nps office appointment throws validation error`() {
-      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = listOf("firstline", "secondLine", "thirdLine", "town", "county", "A1 1AA"))
-      var exception = assertThrows<ValidationError> {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
-      }
-      assertThat(exception.errors.first().error).isEqualTo(Code.INVALID_LENGTH)
-    }
+      @Test
+      fun `empty address for non nps office appointment throws validation error`() {
+        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = null)
+        var exception = assertThrows<ValidationError> {
+          actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        }
 
-    @Test
-    fun `invalid postcode for non nps office appointment throws validation error`() {
-      var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = listOf("firstline", "secondLine", "town", "county", "AAA1 1AAA"))
-      var exception = assertThrows<ValidationError> {
-        actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        assertThat(exception.errors).containsExactly(
+          FieldError("appointmentDeliveryAddress", Code.CANNOT_BE_EMPTY),
+        )
       }
-      assertThat(exception.errors.first().error).isEqualTo(Code.INVALID_FORMAT)
+
+      @Test
+      fun `empty address fields for non nps office appointment throws validation error`() {
+        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, appointmentDeliveryAddress = AddressDTO("", "", "", "", ""))
+        var exception = assertThrows<ValidationError> {
+          actionPlanSessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        }
+        assertThat(exception.errors).containsExactly(
+          FieldError("appointmentDeliveryAddress.firstAddressLine", Code.CANNOT_BE_EMPTY),
+          FieldError("appointmentDeliveryAddress.townOrCity", Code.CANNOT_BE_EMPTY),
+          FieldError("appointmentDeliveryAddress.county", Code.CANNOT_BE_EMPTY),
+          FieldError("appointmentDeliveryAddress.postCode", Code.CANNOT_BE_EMPTY),
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Change JSON for update appointment to use appointment fields rather than array

## What is the intent behind these changes?

Makes use of field easier to use on front-end

## notes

Previously the updateAppointments accepted an array for address. This was to be a field used to NPS office code, video URL and address.
This has now been changed to an actual DTO for address fields.
The video address is no longer required as comfirmed by Leigh.
The NPS office code is still to be implemented (the ticket is not ready). In this case we'd expected a separate npsOfficeCode field.
