### PR TITLE
IC-1722 Supplier Assessment booking requests in nDelius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -68,3 +68,8 @@ enum class Attended {
     return this.toString().lowercase()
   }
 }
+
+enum class AppointmentType {
+  SERVICE_DELIVERY,
+  SUPPLIER_ASSESSMENT;
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDelivery
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryAddress
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SERVICE_DELIVERY
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
@@ -77,7 +78,8 @@ class ActionPlanSessionsService(
       session.actionPlan.referral,
       existingAppointment,
       appointmentTime,
-      durationInMinutes
+      durationInMinutes,
+      SERVICE_DELIVERY
     )
 
     if (existingAppointment == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -31,22 +31,19 @@ class AppointmentService(
     val initialAppointmentRequired = appointment == null
     if (initialAppointmentRequired) {
       val deliusAppointmentId = communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType)
-      val createdAppointment = createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser)
-      return appointmentRepository.save(createdAppointment)
+      return createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser)
     }
 
     val updateCurrentAppointmentRequired = appointment!!.attended == null
     if (updateCurrentAppointmentRequired) {
       val deliusAppointmentId = communityAPIBookingService.book(referral, appointment, appointmentTime, durationInMinutes, appointmentType)
-      val updatedAppointment = updateAppointment(appointment, durationInMinutes, appointmentTime, deliusAppointmentId)
-      return appointmentRepository.save(updatedAppointment)
+      return updateAppointment(appointment, durationInMinutes, appointmentTime, deliusAppointmentId)
     }
 
     val additionalAppointmentRequired = appointment.attended == Attended.NO
     if (additionalAppointmentRequired) {
       val deliusAppointmentId = communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType)
-      val additionalAppointment = createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser)
-      return appointmentRepository.save(additionalAppointment)
+      return createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser)
     }
 
     throw IllegalStateException("Is it not possible to update an appointment that has already been attended")
@@ -58,13 +55,15 @@ class AppointmentService(
     deliusAppointmentId: Long?,
     createdByUser: AuthUser,
   ): Appointment {
-    return Appointment(
-      id = UUID.randomUUID(),
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = deliusAppointmentId,
-      createdBy = authUserRepository.save(createdByUser),
-      createdAt = OffsetDateTime.now()
+    return appointmentRepository.save(
+      Appointment(
+        id = UUID.randomUUID(),
+        appointmentTime = appointmentTime,
+        durationInMinutes = durationInMinutes,
+        deliusAppointmentId = deliusAppointmentId,
+        createdBy = authUserRepository.save(createdByUser),
+        createdAt = OffsetDateTime.now()
+      )
     )
   }
 
@@ -77,6 +76,6 @@ class AppointmentService(
     appointment.durationInMinutes = durationInMinutes
     appointment.appointmentTime = appointmentTime
     appointment.deliusAppointmentId = deliusAppointmentId
-    return appointment
+    return appointmentRepository.save(appointment)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import java.time.OffsetDateTime
@@ -14,54 +16,67 @@ import javax.transaction.Transactional
 @Transactional
 class AppointmentService(
   val appointmentRepository: AppointmentRepository,
+  val communityAPIBookingService: CommunityAPIBookingService,
   val authUserRepository: AuthUserRepository,
 ) {
   fun createOrUpdateAppointment(
+    referral: Referral,
     appointment: Appointment?,
     durationInMinutes: Int,
     appointmentTime: OffsetDateTime,
+    appointmentType: AppointmentType,
     createdByUser: AuthUser
   ): Appointment {
-    val noAppointment = appointment == null
-    if (noAppointment) {
-      return createAppointment(durationInMinutes, appointmentTime, createdByUser)
+
+    val initialAppointmentRequired = appointment == null
+    if (initialAppointmentRequired) {
+      val deliusAppointmentId = communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType)
+      val createdAppointment = createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser)
+      return appointmentRepository.save(createdAppointment)
     }
 
-    val appointmentWithoutAttendanceRecorded = appointment!!.attended == null
-    if (appointmentWithoutAttendanceRecorded) {
-      return updateAppointment(appointment, durationInMinutes, appointmentTime)
+    val updateCurrentAppointmentRequired = appointment!!.attended == null
+    if (updateCurrentAppointmentRequired) {
+      val deliusAppointmentId = communityAPIBookingService.book(referral, appointment, appointmentTime, durationInMinutes, appointmentType)
+      val updatedAppointment = updateAppointment(appointment, durationInMinutes, appointmentTime, deliusAppointmentId)
+      return appointmentRepository.save(updatedAppointment)
     }
 
-    val appointmentWithNonAttendance = appointment.attended == Attended.NO
-    if (appointmentWithNonAttendance) {
-      return createAppointment(durationInMinutes, appointmentTime, createdByUser)
+    val additionalAppointmentRequired = appointment.attended == Attended.NO
+    if (additionalAppointmentRequired) {
+      val deliusAppointmentId = communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType)
+      val additionalAppointment = createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser)
+      return appointmentRepository.save(additionalAppointment)
     }
+
     throw IllegalStateException("Is it not possible to update an appointment that has already been attended")
   }
 
   private fun createAppointment(
     durationInMinutes: Int,
     appointmentTime: OffsetDateTime,
+    deliusAppointmentId: Long?,
     createdByUser: AuthUser,
   ): Appointment {
-    val appointment = Appointment(
+    return Appointment(
       id = UUID.randomUUID(),
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
+      deliusAppointmentId = deliusAppointmentId,
       createdBy = authUserRepository.save(createdByUser),
       createdAt = OffsetDateTime.now()
     )
-    appointmentRepository.save(appointment)
-    return appointment
   }
 
   private fun updateAppointment(
     appointment: Appointment,
     durationInMinutes: Int,
-    appointmentTime: OffsetDateTime
+    appointmentTime: OffsetDateTime,
+    deliusAppointmentId: Long?,
   ): Appointment {
     appointment.durationInMinutes = durationInMinutes
     appointment.appointmentTime = appointmentTime
-    return appointmentRepository.save(appointment)
+    appointment.deliusAppointmentId = deliusAppointmentId
+    return appointment
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import java.lang.IllegalStateException
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
@@ -17,24 +19,26 @@ import javax.validation.constraints.NotNull
 class CommunityAPIBookingService(
   @Value("\${community-api.appointments.bookings.enabled}") private val bookingsEnabled: Boolean,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
-  @Value("\${interventions-ui.probation-links.view-appointment}") private val interventionsUIViewAppointment: String,
+  @Value("#{\${interventions-ui.probation-appointment-links}}") private val interventionsUIViewAppointmentLinks: Map<AppointmentType, String>,
   @Value("\${community-api.locations.book-appointment}") private val communityApiBookAppointmentLocation: String,
   @Value("\${community-api.locations.reschedule-appointment}") private val communityApiRescheduleAppointmentLocation: String,
   @Value("\${community-api.appointments.office-location}") private val officeLocation: String,
+  @Value("#{\${community-api.appointments.notes-field-qualifier}}") private val notesFieldQualifier: Map<AppointmentType, String>,
+  @Value("#{\${community-api.appointments.counts-towards-rar-days}}") private val countsTowardsRarDays: Map<AppointmentType, Boolean>,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   val communityAPIClient: CommunityAPIClient,
 ) : CommunityAPIService {
   companion object : KLogging()
 
-  fun book(referral: Referral, existingAppointment: Appointment?, appointmentTime: OffsetDateTime, durationInMinutes: Int): Long? {
+  fun book(referral: Referral, existingAppointment: Appointment?, appointmentTime: OffsetDateTime, durationInMinutes: Int, appointmentType: AppointmentType): Long? {
     if (!bookingsEnabled) {
-      return null
+      return existingAppointment?.deliusAppointmentId
     }
 
-    return processingBooking(referral, existingAppointment, appointmentTime, durationInMinutes)
+    return processingBooking(referral, existingAppointment, appointmentTime, durationInMinutes, appointmentType)
   }
 
-  private fun processingBooking(referral: Referral, existingAppointment: Appointment?, appointmentTime: OffsetDateTime, durationInMinutes: Int): Long? {
+  private fun processingBooking(referral: Referral, existingAppointment: Appointment?, appointmentTime: OffsetDateTime, durationInMinutes: Int, appointmentType: AppointmentType): Long? {
     return existingAppointment?.let {
       if (!isRescheduleBooking(existingAppointment, appointmentTime, durationInMinutes)) {
         // nothing to do !
@@ -44,7 +48,7 @@ class CommunityAPIBookingService(
       val appointmentRequestDTO = buildAppointmentRescheduleRequestDTO(appointmentTime, durationInMinutes)
       makeBooking(referral.serviceUserCRN, it.deliusAppointmentId!!, appointmentRequestDTO, communityApiRescheduleAppointmentLocation)
     } ?: run {
-      val appointmentRequestDTO = buildAppointmentCreateRequestDTO(referral, appointmentTime, durationInMinutes)
+      val appointmentRequestDTO = buildAppointmentCreateRequestDTO(referral, appointmentTime, durationInMinutes, appointmentType)
       makeBooking(referral.serviceUserCRN, referral.relevantSentenceId!!, appointmentRequestDTO, communityApiBookAppointmentLocation)
     }
   }
@@ -60,8 +64,8 @@ class CommunityAPIBookingService(
     return response.appointmentId
   }
 
-  private fun buildAppointmentCreateRequestDTO(referral: Referral, appointmentTime: OffsetDateTime, durationInMinutes: Int): AppointmentCreateRequestDTO {
-    val resourceUrl = buildReferralResourceUrl(referral)
+  private fun buildAppointmentCreateRequestDTO(referral: Referral, appointmentTime: OffsetDateTime, durationInMinutes: Int, appointmentType: AppointmentType): AppointmentCreateRequestDTO {
+    val resourceUrl = buildReferralResourceUrl(referral, appointmentType)
 
     return AppointmentCreateRequestDTO(
       contractType = referral.intervention.dynamicFrameworkContract.contractType.code,
@@ -70,8 +74,8 @@ class CommunityAPIBookingService(
       appointmentStart = appointmentTime,
       appointmentEnd = appointmentTime.plusMinutes(durationInMinutes.toLong()),
       officeLocationCode = officeLocation,
-      notes = getNotes(referral, resourceUrl, "Appointment"),
-      countsTowardsRarDays = true, // Fixme: For assessment booking this should be false and will pass in when assessment booking is done
+      notes = getNotes(referral, resourceUrl, "${get(appointmentType, notesFieldQualifier)} Appointment"),
+      countsTowardsRarDays = get(appointmentType, countsTowardsRarDays),
     )
   }
 
@@ -83,9 +87,9 @@ class CommunityAPIBookingService(
     )
   }
 
-  private fun buildReferralResourceUrl(referral: Referral): String {
+  private fun buildReferralResourceUrl(referral: Referral, appointmentType: AppointmentType): String {
     return UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
-      .path(interventionsUIViewAppointment)
+      .path(get(appointmentType, interventionsUIViewAppointmentLinks))
       .buildAndExpand(referral.id)
       .toString()
   }
@@ -95,6 +99,10 @@ class CommunityAPIBookingService(
 
   fun isDifferentTimings(existingAppointment: Appointment, appointmentTime: OffsetDateTime, durationInMinutes: Int): Boolean =
     !existingAppointment.appointmentTime.isEqual(appointmentTime) || existingAppointment.durationInMinutes != durationInMinutes
+
+  private inline fun <reified T> get(appointmentType: AppointmentType, map: Map<AppointmentType, T>): T {
+    return map[appointmentType] ?: throw IllegalStateException("Property value not found for $appointmentType")
+  }
 }
 
 abstract class AppointmentRequestDTO

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
@@ -38,7 +39,14 @@ class SupplierAssessmentService(
     appointmentTime: OffsetDateTime,
     createdByUser: AuthUser
   ): Appointment {
-    val appointment = appointmentService.createOrUpdateAppointment(supplierAssessment.currentAppointment, durationInMinutes, appointmentTime, createdByUser)
+    val appointment = appointmentService.createOrUpdateAppointment(
+      supplierAssessment.referral,
+      supplierAssessment.currentAppointment,
+      durationInMinutes,
+      appointmentTime,
+      SUPPLIER_ASSESSMENT,
+      createdByUser,
+    )
     supplierAssessment.appointments.add(appointment)
     supplierAssessmentRepository.save(supplierAssessment)
     return appointment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,10 +94,13 @@ interventions-ui:
     sent-referral: "/probation-practitioner/referrals/{id}/details"
     cancelled-referral: "/probation-practitioner/referrals/{id}/details"
     action-plan: "/probation-practitioner/referrals/{id}/progress"
-    view-appointment: "/probation-practitioner/referrals/{id}/progress"
     pp-referral-progress: "/probation-practitioner/referrals/{id}/progress"
     submit-end-of-service-report: "/probation-practitioner/end-of-service-report/{id}"
     session-feedback: "/probation-practitioner/action-plan/{id}/appointment/{sessionNumber}/post-session-feedback"
+  probation-appointment-links: "{
+    SERVICE_DELIVERY:'/probation-practitioner/referrals/{id}/progress',
+    SUPPLIER_ASSESSMENT:'/probation-practitioner/referrals/{id}/supplier-assessment'
+    }"
 
 community-api:
   locations:
@@ -114,6 +117,14 @@ community-api:
     bookings:
       enabled: true
     office-location: CRSEXTL
+    notes-field-qualifier: "{
+      SERVICE_DELIVERY:'Service Delivery',
+      SUPPLIER_ASSESSMENT:'Supplier Assessment'
+      }"
+    counts-towards-rar-days: "{
+      SERVICE_DELIVERY:true,
+      SUPPLIER_ASSESSMENT:false
+      }"
   referrals:
       enabled: true
   integration-context: commissioned-rehabilitation-services

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceTest.kt
@@ -18,6 +18,7 @@ import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SERVICE_DELIVERY
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanSessionRepository
@@ -148,7 +149,8 @@ internal class ActionPlanSessionsServiceTest {
         referral,
         session.currentAppointment,
         appointmentTime,
-        durationInMinutes
+        durationInMinutes,
+        SERVICE_DELIVERY
       )
     ).thenReturn(999L)
     whenever(actionPlanSessionRepository.findByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(
@@ -168,7 +170,13 @@ internal class ActionPlanSessionsServiceTest {
     )
 
     assertThat(updatedSession).isEqualTo(session)
-    verify(communityAPIBookingService).book(referral, session.currentAppointment, appointmentTime, durationInMinutes)
+    verify(communityAPIBookingService).book(
+      referral,
+      session.currentAppointment,
+      appointmentTime,
+      durationInMinutes,
+      SERVICE_DELIVERY
+    )
     verify(appointmentRepository, times(2)).saveAndFlush(
       ArgumentMatchers.argThat {
         it.deliusAppointmentId == 999L
@@ -186,7 +194,15 @@ internal class ActionPlanSessionsServiceTest {
     val appointmentTime = OffsetDateTime.now()
     val durationInMinutes = 15
 
-    whenever(communityAPIBookingService.book(referral, session.currentAppointment, appointmentTime, durationInMinutes)).thenReturn(null)
+    whenever(
+      communityAPIBookingService.book(
+        referral,
+        session.currentAppointment,
+        appointmentTime,
+        durationInMinutes,
+        SERVICE_DELIVERY
+      )
+    ).thenReturn(null)
     whenever(actionPlanSessionRepository.findByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
     whenever(authUserRepository.save(createdByUser)).thenReturn(createdByUser)
     whenever(actionPlanSessionRepository.save(any())).thenReturn(session)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
@@ -1,15 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
@@ -66,7 +68,16 @@ class SupplierAssessmentServiceTest {
     val durationInMinutes = 60
     val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
 
-    whenever(appointmentService.createOrUpdateAppointment(anyOrNull(), any(), any(), any())).thenReturn(appointment)
+    whenever(
+      appointmentService.createOrUpdateAppointment(
+        eq(supplierAssessment.referral),
+        isNull(),
+        eq(durationInMinutes),
+        eq(appointmentTime),
+        eq(SUPPLIER_ASSESSMENT),
+        eq(createdByUser)
+      )
+    ).thenReturn(appointment)
     whenever(supplierAssessmentRepository.save(any())).thenReturn(supplierAssessment)
 
     supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(supplierAssessment, durationInMinutes, appointmentTime, createdByUser)


### PR DESCRIPTION
## What does this pull request do?
Contains the logic to request a booking for the supplier assessment appointment made in R&M 

## What is the intent behind these changes?
With this PR supplier assessments are also notified to Delius so all appointments pertaining to a CRN are maintained in Delius for clash checking.
