### PR TITLE
IC-1971: show referrals both managed and started by the PP only once

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -129,7 +129,8 @@ class ReferralService(
       emptyList()
     }.flatMap { referralRepository.findByServiceUserCRNAndSentAtIsNotNull(it.crnNumber) }
 
-    return referralAccessFilter.probationPractitionerReferrals(referralsStartedByPP + referralsManagedByPP, user)
+    val ppReferrals = referralsStartedByPP.union(referralsManagedByPP).sortedBy { it.createdAt }
+    return referralAccessFilter.probationPractitionerReferrals(ppReferrals, user)
   }
 
   fun requestReferralEnd(referral: Referral, user: AuthUser, reason: CancellationReason, comments: String?): Referral {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -452,6 +452,18 @@ class ReferralServiceTest @Autowired constructor(
       val result = referralService.getSentReferralsForUser(user)
       assertThat(result).containsExactly(managedReferral)
     }
+
+    @Test
+    fun `returns referrals both managed and started by the user only once`() {
+      val user = userFactory.create("pp_user_1", "delius")
+      val managedAndStartedReferral = referralFactory.createSent(serviceUserCRN = "CRN129876234", createdBy = user)
+
+      whenever(communityAPIOffenderService.getManagedOffendersForDeliusUser(user))
+        .thenReturn(listOf(Offender("CRN129876234")))
+
+      val result = referralService.getSentReferralsForUser(user)
+      assertThat(result).containsExactly(managedAndStartedReferral)
+    }
   }
 
   @Nested


### PR DESCRIPTION
## What does this pull request do?

Removes duplication for managed/started referrals in the PP dashboard.

## How to review?

Commit-by-commit, please -- the first two commits are reorg.

The crux is
- 35ea245: adds the failing test
- 4fb6bd9: adds the fix

## What is the intent behind these changes?

**Expected behaviour**
A single referral shows up once in the probation practitioner's dashboard.

**Actual behaviour**
If a PP user creates a referral for a service user who they manage, their dashboard shows the referral twice.

**What happens if we don't fix this?**
Users would like to make sure they did not duplicate. Quote from user:

> [...] tried to cancel one thinking there were two and I may have cancelled both?