### PR TITLE
Correlate with group setup in local hmpps-auth

### DIFF
--- a/src/main/resources/db/local/V99_0__contracts_and_providers.sql
+++ b/src/main/resources/db/local/V99_0__contracts_and_providers.sql
@@ -7,9 +7,9 @@ insert into dynamic_framework_contract (id, contract_type_id, prime_provider_id,
 values ('1d7f8fcc-aa12-4705-a6a5-0d40467e03e9', '72e60faf-b8e5-4699-9d7c-aef631cca71b', 'HARMONY_LIVING', TO_DATE('2020-12-15', 'YYYY-MM-DD'), TO_DATE('2023-12-15', 'YYYY-MM-DD'), 'G', null, true, true, 18, 25, '0001'),
        ('f9d24b4a-390d-4cc1-a7ee-3e6f022e1599', '72e60faf-b8e5-4699-9d7c-aef631cca71b', 'HARMONY_LIVING', TO_DATE('2020-01-01', 'YYYY-MM-DD'), TO_DATE('2022-12-31', 'YYYY-MM-DD'), 'G', null, true, false, 18, 25, '0002'),
        ('24f7a423-15a6-438d-9d28-063e92b25a9b', '72e60faf-b8e5-4699-9d7c-aef631cca71b', 'HARMONY_LIVING', TO_DATE('2021-12-11', 'YYYY-MM-DD'), TO_DATE('2025-12-11', 'YYYY-MM-DD'), null, 'avon-and-somerset', true, true, 25, null, '0003'),
-       ('c7d39f92-6f43-49a4-bb62-e0f42c864765', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HOME_TRUST', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'G', null, false, true, 18, null, '0004'),
-       ('0b60d842-9c08-408e-8c8d-f6dbf8e5c3f4', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HOME_TRUST', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'J', null, true, true, 18, null, '0005'),
-       ('56ad7d77-94c7-4fbf-a704-29e0f6ad078f', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HOME_TRUST', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'A', null, true, true, 18, null, '0006'),
+       ('c7d39f92-6f43-49a4-bb62-e0f42c864765', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'G', null, false, true, 18, null, '0004'),
+       ('0b60d842-9c08-408e-8c8d-f6dbf8e5c3f4', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'J', null, true, true, 18, null, '0005'),
+       ('56ad7d77-94c7-4fbf-a704-29e0f6ad078f', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HARMONY_LIVING', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'A', null, true, true, 18, null, '0006'),
        ('1435d1c5-0c22-459a-bd1a-ce593fba6c05', 'f9b59d2c-c60b-4eb0-8469-04c975d2e2ee', 'HOME_TRUST', TO_DATE('2021-01-01', 'YYYY-MM-DD'), TO_DATE('2035-05-01', 'YYYY-MM-DD'), 'A', null, true, true, 18, null, '0007');
 
 insert into intervention (id, dynamic_framework_contract_id, created_at, title, description, incoming_referral_distribution_email)


### PR DESCRIPTION


## What does this pull request do?

Correlate with group setup in local hmpps-auth

## What is the intent behind these changes?

In hmpps-auth, the groups are setup as:
https://github.com/ministryofjustice/hmpps-auth/blob/27f576e8de7b838d79cb491246c701212ecf2804/src/main/resources/db/dev/data/auth/V900_0__oauth_sample_data.sql#L334-L340

`TEST_INTERVENTIONS_SP_1` belongs to:
- `INT_SP_HARMONY_LIVING`
- `INT_CR_0001`
- `INT_CR_0002`
- `INT_CR_0003`
- `INT_CR_0004`
- `INT_CR_0005`
- `INT_CR_0006`

which means all the contracts must belong under the same provider,
otherwise this error will occur on sign-in:

- "contract '0004' is not accessible to providers [HARMONY_LIVING]"
- same for 0005 and 0006

So, this change amends contract 4-6 to have `HARMONY_LIVING` as prime
