### PR TITLE
Changed extractor image tag to v1

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -11,7 +11,7 @@ spec:
           restartPolicy: "Never"
           containers:
           - name: data-extractor-analytics
-            image: ministryofjustice/data-engineering-data-extractor:develop
+            image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
             args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             env:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-reporting.yaml
@@ -16,7 +16,7 @@ spec:
               defaultMode: 0755
           containers:
           - name: data-extractor-reporting
-            image: ministryofjustice/data-engineering-data-extractor:develop
+            image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
             args: ["mkdir -p 'export/csv/reports' && psql -v ON_ERROR_STOP=1 --file=/reports/crs_performance_report.sql > 'export/csv/reports/crs_performance_report.csv' && transfer_local_to_s3.sh"]
             volumeMounts:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -30,7 +30,7 @@ spec:
               defaultMode: 0755
           containers:
           - name: data-extractor-reporting
-            image: ministryofjustice/data-engineering-data-extractor:develop
+            image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
             args:
               - |


### PR DESCRIPTION
## What does this pull request do?

Set the image tag for the extractor to release v1

## What is the intent behind these changes?

To provide stability in the use of the extractor for the transfer of data and producing of kpis