### PR TITLE
Experimental fix to flaky 5xx errors

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -98,8 +98,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(request, token, referral1.id.toString())
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody()
 
     requestFactory.create(request, token, referral2.id.toString())
       .exchange()
@@ -124,8 +124,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X1233456", intervention.id))
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody()
 
     requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X5555555", intervention.id))
       .exchange()
@@ -163,8 +163,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(request, token, referral.id.toString())
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody()
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
@@ -190,8 +190,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(request, token, referral.id.toString())
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody()
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
@@ -401,14 +401,17 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     val referral3 = createSentReferral(contract3)
     val token = createEncodedTokenForUser(user)
 
-    val checkReferral1 = requestFactory.create(request, token, referral1.id.toString()).exchange()
-    checkReferral1.expectStatus().is2xxSuccessful
+    requestFactory.create(request, token, referral1.id.toString()).exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody()
 
-    val checkReferral2 = requestFactory.create(request, token, referral2.id.toString()).exchange()
-    checkReferral2.expectStatus().is2xxSuccessful
+    requestFactory.create(request, token, referral2.id.toString()).exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody()
 
-    val checkReferral3 = requestFactory.create(request, token, referral3.id.toString()).exchange()
-    checkReferral3.expectStatus().is2xxSuccessful
+    requestFactory.create(request, token, referral3.id.toString()).exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody()
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
@@ -482,7 +485,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
   @MethodSource("allReferralRequests")
   fun `requests with no auth token can never access anything`(request: Request) {
-    val response = requestFactory.create(request, null, UUID.randomUUID().toString()).exchange()
-    response.expectStatus().isUnauthorized
+    requestFactory.create(request, null, UUID.randomUUID().toString()).exchange()
+      .expectStatus().isUnauthorized
+      .expectBody()
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Experimental fix to flaky 5xx errors

We had a series of flaky errors in `SingleReferralEndpoints` test class
```
Test sp user works for prime provider and has required contract group(Request) (request=AssignSentReferral) FAILED

java.lang.AssertionError: Range for response status value 500 INTERNAL_SERVER_ERROR expected:<SUCCESSFUL> but was:<SERVER_ERROR>
    at uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.authorization.SingleReferralEndpoints.sp user works for prime provider and has required contract group(SingleReferralEndpoints.kt:167)
```

When logs were added, the errors reduced significantly (did not have any), hinting at async timing problems

Then I removed logging during tests and added [`build/test-results/test/binary/output.bin`](https://12157-312544431-gh.circle-artifacts.com/0/build/test-results/test/binary/output.bin) storing and the caught exception said:
```
> POST http://localhost:39473/sent-referral/24121550-20ff-421b-b39f-72a1abca1c77/assign

{"status":500,"error":"unexpected error","message":"Could not commit JPA transaction; ⏎
  nested exception is javax.persistence.RollbackException: Error while committing the transaction"}
```
which further pointed to async timing issues

----

**Based on:**
- The documentation of `exchange()` says "Perform the exchange without a request body"
- None of the `expectBody` calls were flaky, only the standalone `expectStatus` ones (in our test history) 

**Hypothesis:** the test assertion is processed as soon as the response headers are read, then moves on, creating a race condition

**Experimental solution:** make all assertions depend on the full resolution of the response body, thus forcing the request to complete before moving on

(❓ Is there a better way?)

## What is the intent behind these changes?

Fix flaky tests to reduce delays in continuous integration and deployment