### PR TITLE
IC-1829 use user token for calling ARN API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClient.kt
@@ -3,19 +3,17 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
 import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest
 import reactor.core.publisher.Mono
 
 @Component
 class CommunityAPIClient(
-  private val communityApiWebClient: WebClient,
+  private val communityApiClient: RestClient,
 ) {
   companion object : KLogging()
 
   fun makeAsyncPostRequest(uri: String, requestBody: Any) {
-    communityApiWebClient.post().uri(uri)
-      .body(Mono.just(requestBody), requestBody::class.java)
+    communityApiClient.post(uri, requestBody)
       .retrieve()
       .bodyToMono(Unit::class.java)
       .onErrorResume { e ->
@@ -26,8 +24,7 @@ class CommunityAPIClient(
   }
 
   fun makeAsyncPatchRequest(uri: String, requestBody: Any) {
-    communityApiWebClient.patch().uri(uri)
-      .body(Mono.just(requestBody), requestBody::class.java)
+    communityApiClient.patch(uri, requestBody)
       .retrieve()
       .bodyToMono(Unit::class.java)
       .onErrorResume { e ->
@@ -38,8 +35,7 @@ class CommunityAPIClient(
   }
 
   fun <T : Any> makeSyncPostRequest(uri: String, requestBody: Any, responseBodyClass: Class<T>): T {
-    return communityApiWebClient.post().uri(uri)
-      .body(Mono.just(requestBody), requestBody::class.java)
+    return communityApiClient.post(uri, requestBody)
       .retrieve()
       .bodyToMono(responseBodyClass)
       .onErrorMap { e ->
@@ -50,7 +46,7 @@ class CommunityAPIClient(
   }
 
   fun <T : Any> makeSyncGetRequest(uri: String, responseBodyClass: Class<T>): T {
-    return communityApiWebClient.get().uri(uri)
+    return communityApiClient.get(uri)
       .retrieve()
       .bodyToMono(responseBodyClass)
       .onErrorMap { e ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RestClient.kt
@@ -1,14 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
 
 import org.springframework.http.MediaType
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.util.MultiValueMap
 import org.springframework.web.reactive.function.client.WebClient
 import java.nio.charset.StandardCharsets
 
 class RestClient(
   private val webClient: WebClient,
+  private val oauth2ClientRegistrationId: String,
 ) {
-  fun get(uri: String, queryParams: MultiValueMap<String, String>? = null): WebClient.RequestHeadersSpec<*> {
+  fun get(
+    uri: String,
+    queryParams: MultiValueMap<String, String>? = null,
+    customAuthentication: JwtAuthenticationToken? = null,
+  ): WebClient.RequestHeadersSpec<*> {
     val spec = webClient
       .get()
       .uri {
@@ -18,30 +25,51 @@ class RestClient(
           .build()
       }
 
-    return withDefaultHeaders(spec)
+    return spec
+      .withDefaultHeaders()
+      .withAuth(customAuthentication)
   }
 
-  fun <T> post(uri: String, body: T): WebClient.RequestHeadersSpec<*> {
+  fun <T> post(
+    uri: String,
+    body: T,
+    customAuthentication: JwtAuthenticationToken? = null,
+  ): WebClient.RequestHeadersSpec<*> {
     val spec = webClient
       .post()
       .uri(uri)
       .bodyValue(body)
 
-    return withDefaultHeaders(spec)
+    return spec
+      .withDefaultHeaders()
+      .withAuth(customAuthentication)
   }
 
-  fun <T> patch(uri: String, body: T): WebClient.RequestHeadersSpec<*> {
+  fun <T> patch(
+    uri: String,
+    body: T,
+    customAuthentication: JwtAuthenticationToken? = null,
+  ): WebClient.RequestHeadersSpec<*> {
     val spec = webClient
       .patch()
       .uri(uri)
       .bodyValue(body)
 
-    return withDefaultHeaders(spec)
+    return spec
+      .withDefaultHeaders()
+      .withAuth(customAuthentication)
   }
 
-  private fun withDefaultHeaders(spec: WebClient.RequestHeadersSpec<*>): WebClient.RequestHeadersSpec<*> {
-    return spec
+  private fun WebClient.RequestHeadersSpec<*>.withDefaultHeaders(): WebClient.RequestHeadersSpec<*> {
+    return this
       .accept(MediaType.APPLICATION_JSON)
       .acceptCharset(StandardCharsets.UTF_8)
+  }
+
+  private fun WebClient.RequestHeadersSpec<*>.withAuth(authentication: JwtAuthenticationToken?): WebClient.RequestHeadersSpec<*> {
+    return authentication?.let {
+      this.header("Authorization", "Bearer ${it.token.tokenValue}")
+    }
+      ?: this.attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId(oauth2ClientRegistrationId))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RestClient.kt
@@ -30,6 +30,15 @@ class RestClient(
     return withDefaultHeaders(spec)
   }
 
+  fun <T> patch(uri: String, body: T): WebClient.RequestHeadersSpec<*> {
+    val spec = webClient
+      .patch()
+      .uri(uri)
+      .bodyValue(body)
+
+    return withDefaultHeaders(spec)
+  }
+
   private fun withDefaultHeaders(spec: WebClient.RequestHeadersSpec<*>): WebClient.RequestHeadersSpec<*> {
     return spec
       .accept(MediaType.APPLICATION_JSON)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -33,19 +33,13 @@ class WebClientConfiguration(
   }
 
   @Bean
-  @Deprecated("usage of newer 'RestClient' interface is preferred")
-  fun communityApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
-    return createAuthorizedWebClient(authorizedClientManager, communityApiBaseUrl)
+  fun hmppsAuthApiClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
+    return RestClient(createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl))
   }
 
   @Bean
-  fun hmppsAuthApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
-    return createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl)
-  }
-
-  @Bean
-  fun communityApiRestClient(communityApiWebClient: WebClient): RestClient {
-    return RestClient(communityApiWebClient)
+  fun communityApiClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
+    return RestClient(createAuthorizedWebClient(authorizedClientManager, communityApiBaseUrl))
   }
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -27,19 +27,30 @@ class WebClientConfiguration(
   @Value("\${assess-risks-and-needs.baseurl}") private val assessRisksAndNeedsBaseUrl: String,
   private val webClientBuilder: WebClient.Builder
 ) {
+  private val interventionsClientRegistrationId = "interventions-client"
+
   @Bean
   fun assessRisksAndNeedsClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-    return RestClient(createAuthorizedWebClient(authorizedClientManager, assessRisksAndNeedsBaseUrl))
+    return RestClient(
+      createAuthorizedWebClient(authorizedClientManager, assessRisksAndNeedsBaseUrl),
+      interventionsClientRegistrationId
+    )
   }
 
   @Bean
   fun hmppsAuthApiClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-    return RestClient(createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl))
+    return RestClient(
+      createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl),
+      interventionsClientRegistrationId
+    )
   }
 
   @Bean
   fun communityApiClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-    return RestClient(createAuthorizedWebClient(authorizedClientManager, communityApiBaseUrl))
+    return RestClient(
+      createAuthorizedWebClient(authorizedClientManager, communityApiBaseUrl),
+      interventionsClientRegistrationId
+    )
   }
 
   @Bean
@@ -60,7 +71,6 @@ class WebClientConfiguration(
 
   private fun createAuthorizedWebClient(clientManager: OAuth2AuthorizedClientManager, baseUrl: String): WebClient {
     val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(clientManager)
-    oauth2Client.setDefaultClientRegistrationId("interventions-client")
 
     val httpClient = HttpClient.create()
       .doOnConnected {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -32,14 +32,14 @@ class CommunityAPIOffenderService(
   @Value("\${community-api.locations.offender-access}") private val offenderAccessLocation: String,
   @Value("\${community-api.locations.managed-offenders}") private val managedOffendersLocation: String,
   @Value("\${community-api.locations.staff-details}") private val staffDetailsLocation: String,
-  private val communityApiRestClient: RestClient,
+  private val communityApiClient: RestClient,
 ) {
   fun checkIfAuthenticatedDeliusUserHasAccessToServiceUser(user: AuthUser, crn: String): ServiceUserAccessResult {
     val userAccessPath = UriComponentsBuilder.fromPath(offenderAccessLocation)
       .buildAndExpand(crn, user.userName)
       .toString()
 
-    val response = communityApiRestClient.get(userAccessPath)
+    val response = communityApiClient.get(userAccessPath)
       .retrieve()
       .onStatus({ it.equals(HttpStatus.FORBIDDEN) }, { Mono.empty() })
       .toEntity(UserAccessResponse::class.java)
@@ -61,7 +61,7 @@ class CommunityAPIOffenderService(
       .buildAndExpand(staffIdentifier)
       .toString()
 
-    return communityApiRestClient.get(managedOffendersPath)
+    return communityApiClient.get(managedOffendersPath)
       .retrieve()
       .bodyToFlux(Offender::class.java)
       .collectList()
@@ -73,7 +73,7 @@ class CommunityAPIOffenderService(
       .buildAndExpand(user.userName)
       .toString()
 
-    return communityApiRestClient.get(staffDetailsPath)
+    return communityApiClient.get(staffDetailsPath)
       .retrieve()
       .bodyToMono(StaffDetailsResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) { e ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
@@ -4,6 +4,8 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -47,7 +49,9 @@ class RisksAndNeedsService(
       riskInformation,
     )
 
-    return assessRisksAndNeedsClient.post(createSupplementaryRiskLocation, request)
+    // this endpoint requires user auth tokens for security reasons
+    val authentication = SecurityContextHolder.getContext().authentication as JwtAuthenticationToken
+    return assessRisksAndNeedsClient.post(createSupplementaryRiskLocation, request, customAuthentication = authentication)
       .retrieve()
       .bodyToMono(SupplementaryRiskResponse::class.java)
       .onErrorResume(WebClientResponseException::class.java) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -66,7 +66,7 @@ class CommunityAPIClientTest {
   fun `makes async post request successfully`() {
 
     communityAPIClient = CommunityAPIClient(
-      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build(), "client-registration-id")
     )
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.empty())
 
@@ -84,7 +84,7 @@ class CommunityAPIClientTest {
   fun `makes async patch request successfully`() {
 
     communityAPIClient = CommunityAPIClient(
-      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build(), "client-registration-id")
     )
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.empty())
 
@@ -102,7 +102,7 @@ class CommunityAPIClientTest {
   fun `error was logged on exception during async post request`() {
 
     communityAPIClient = CommunityAPIClient(
-      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build(), "client-registration-id")
     )
     whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException::class.java)
 
@@ -117,7 +117,7 @@ class CommunityAPIClientTest {
   fun `makes sync post request successfully`() {
 
     communityAPIClient = CommunityAPIClient(
-      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build(), "client-registration-id")
     )
     val clientResponse: ClientResponse = ClientResponse
       .create(OK)
@@ -142,7 +142,7 @@ class CommunityAPIClientTest {
   fun `error was logged on exception during sync post request`() {
 
     communityAPIClient = CommunityAPIClient(
-      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build(), "client-registration-id")
     )
     whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException("A problem"))
 
@@ -160,7 +160,7 @@ class CommunityAPIClientTest {
   fun `propogates error response body on exception during sync post request`() {
 
     communityAPIClient = CommunityAPIClient(
-      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build(), "client-registration-id")
     )
     val clientResponse: ClientResponse = ClientResponse
       .create(BAD_REQUEST)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -66,7 +66,7 @@ class CommunityAPIClientTest {
   fun `makes async post request successfully`() {
 
     communityAPIClient = CommunityAPIClient(
-      WebClient.builder().exchangeFunction(exchangeFunction).build()
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
     )
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.empty())
 
@@ -84,7 +84,7 @@ class CommunityAPIClientTest {
   fun `makes async patch request successfully`() {
 
     communityAPIClient = CommunityAPIClient(
-      WebClient.builder().exchangeFunction(exchangeFunction).build()
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
     )
     whenever(exchangeFunction.exchange(any())).thenReturn(Mono.empty())
 
@@ -102,7 +102,7 @@ class CommunityAPIClientTest {
   fun `error was logged on exception during async post request`() {
 
     communityAPIClient = CommunityAPIClient(
-      WebClient.builder().exchangeFunction(exchangeFunction).build()
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
     )
     whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException::class.java)
 
@@ -117,7 +117,7 @@ class CommunityAPIClientTest {
   fun `makes sync post request successfully`() {
 
     communityAPIClient = CommunityAPIClient(
-      WebClient.builder().exchangeFunction(exchangeFunction).build()
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
     )
     val clientResponse: ClientResponse = ClientResponse
       .create(OK)
@@ -142,7 +142,7 @@ class CommunityAPIClientTest {
   fun `error was logged on exception during sync post request`() {
 
     communityAPIClient = CommunityAPIClient(
-      WebClient.builder().exchangeFunction(exchangeFunction).build()
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
     )
     whenever(exchangeFunction.exchange(any())).thenThrow(RuntimeException("A problem"))
 
@@ -160,7 +160,7 @@ class CommunityAPIClientTest {
   fun `propogates error response body on exception during sync post request`() {
 
     communityAPIClient = CommunityAPIClient(
-      WebClient.builder().exchangeFunction(exchangeFunction).build()
+      RestClient(WebClient.builder().exchangeFunction(exchangeFunction).build())
     )
     val clientResponse: ClientResponse = ClientResponse
       .create(BAD_REQUEST)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -39,7 +39,8 @@ internal class CommunityAPIOffenderServiceTest {
           }
           Mono.empty()
         }
-        .build()
+        .build(),
+      "client-registration-id"
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 
 class HMPPSAuthServiceTest {
@@ -18,8 +19,10 @@ class HMPPSAuthServiceTest {
     "/authuser/detail",
     "/user/email",
     "/user/detail",
-    WebClient.create(
-      mockWebServer.url("/").toString()
+    RestClient(
+      WebClient.create(
+        mockWebServer.url("/").toString()
+      )
     )
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceTest.kt
@@ -22,7 +22,8 @@ class HMPPSAuthServiceTest {
     RestClient(
       WebClient.create(
         mockWebServer.url("/").toString()
-      )
+      ),
+      "client-registration-id"
     )
   )
 


### PR DESCRIPTION
## What does this pull request do?

This PR is split into three commits. they do the following:

1. refactor all the existing WebClients to use the new RestClient helper class, which was added recently. its intention is to standardize things like request headers (and as you'll see in a later commit, authentication too).
2. change the spring security webclient config to no longer use a default oauth2 client registration id across all web clients, but instead allow each webclient the ability to specify which registration it wants to use. this is then applied on a per request basis in the RestClient helper class. what this allows us to do is decide on a per request basis if we want to override this client registration with a custom auth token.
3. override calls to the ARN API with the user's auth token instead of the default 'interventions-client' client_credentials token.

## What is the intent behind these changes?

ARN requires user type tokens for security reasons. 
