### PR TITLE
Rename pact test to be in-line with UI pact test name

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/SupplierAssessmentContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/SupplierAssessmentContracts.kt
@@ -12,7 +12,7 @@ class SupplierAssessmentContracts(private val setupAssistant: SetupAssistant) {
     setupAssistant.createSentReferral(id = UUID.fromString("cbf2f82b-4581-4fe1-9de1-1b52465f1afa"))
   }
 
-  @State("a sent referral with ID a38d9184-5498-4049-af16-3d8eb2547962 exists, and it has a supplier assessment appointment booked with no feedback yet submitted")
+  @State("a sent referral with ID a38d9184-5498-4049-af16-3d8eb2547962 exists, and it has a phone call supplier assessment appointment booked with no feedback yet submitted")
   fun `create a sent referral with supplier assessment appointment with no feedback`() {
     val referral = setupAssistant.createSentReferral(id = UUID.fromString("a38d9184-5498-4049-af16-3d8eb2547962"))
     setupAssistant.addSupplierAssessmentAppointment(referral.supplierAssessment!!, appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL)


### PR DESCRIPTION
## What does this pull request do?

Renamed pact test for supplier assessment to ensure that supplier assessment pact tests on UI pass.
