### PR TITLE
Show changelog on notifications about deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: main
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.0.4
+  hmpps: ministryofjustice/hmpps@3.5
   gradle: circleci/gradle@2.2.0
   kubernetes: circleci/kubernetes@0.11.2
   mem: circleci/rememborb@0.0.1
@@ -291,6 +291,7 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_research
           env: "research"
+          show_changelog: true
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
           requires:
@@ -305,6 +306,7 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
+          show_changelog: true
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
           requires:
@@ -320,6 +322,7 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_prod
           env: "prod"
+          show_changelog: true
           slack_notification: true
           slack_channel_name: "interventions-alerts"
           requires:


### PR DESCRIPTION
## What does this pull request do?

Show changelog on deployment notifications on

- ⛔️ dev (because it's always deployed, we know it equals top of `main`)
- ✅ research
- ✅ pre-prod
- ✅ prod

Related UI PR: https://github.com/ministryofjustice/hmpps-interventions-ui/pull/501

It will look like:

<img width="712" alt="image" src="https://user-images.githubusercontent.com/1526295/123667255-e44a3e00-d831-11eb-9510-90895c41e146.png">


## What is the intent behind these changes?

As we have manual approvals at the moment, it's not trivial to know what is being released at any given time

This will automatically put the log on the deployment job _and_ the Slack notification