### PR TITLE
Re-add content assertions to flaky tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -98,8 +98,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(request, token, referral1.id.toString())
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
 
     requestFactory.create(request, token, referral2.id.toString())
       .exchange()
@@ -124,8 +124,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X1233456", intervention.id))
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
 
     requestFactory.create(Request.CreateDraftReferral, token, body = CreateReferralRequestDTO("X5555555", intervention.id))
       .exchange()
@@ -163,8 +163,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(request, token, referral.id.toString())
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
@@ -190,8 +190,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
 
     requestFactory.create(request, token, referral.id.toString())
       .exchange()
-      .expectStatus()
-      .is2xxSuccessful
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
@@ -401,14 +401,17 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     val referral3 = createSentReferral(contract3)
     val token = createEncodedTokenForUser(user)
 
-    val checkReferral1 = requestFactory.create(request, token, referral1.id.toString()).exchange()
-    checkReferral1.expectStatus().is2xxSuccessful
+    requestFactory.create(request, token, referral1.id.toString()).exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
 
-    val checkReferral2 = requestFactory.create(request, token, referral2.id.toString()).exchange()
-    checkReferral2.expectStatus().is2xxSuccessful
+    requestFactory.create(request, token, referral2.id.toString()).exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
 
-    val checkReferral3 = requestFactory.create(request, token, referral3.id.toString()).exchange()
-    checkReferral3.expectStatus().is2xxSuccessful
+    requestFactory.create(request, token, referral3.id.toString()).exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody().jsonPath("id").isNotEmpty
   }
 
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
@@ -482,7 +485,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
   @ParameterizedTest(name = "{displayName} ({argumentsWithNames})")
   @MethodSource("allReferralRequests")
   fun `requests with no auth token can never access anything`(request: Request) {
-    val response = requestFactory.create(request, null, UUID.randomUUID().toString()).exchange()
-    response.expectStatus().isUnauthorized
+    requestFactory.create(request, null, UUID.randomUUID().toString()).exchange()
+      .expectStatus().isUnauthorized
+      .expectBody().isEmpty
   }
 }


### PR DESCRIPTION

## What does this pull request do?

Re-add content assertions to flaky tests

Related to
- #376 
- #378

## What is the intent behind these changes?

Honestly, this is grasping at straws. There's insufficient data about what causes these `.expectStatus().is2xxSuccessful` calls to sometimes (quite often) fail with

```
> POST http://localhost:39473/sent-referral/24121550-20ff-421b-b39f-72a1abca1c77/assign

{"status":500,"error":"unexpected error","message":"Could not commit JPA transaction; ⏎
  nested exception is javax.persistence.RollbackException: Error while committing the transaction"}
```

Adding these might just add delay, _hiding_ the issue behind artificial lag.

However, it's getting very painful on `main` being blocked and needing several retries, so... let's try?