### PR TITLE
Track who submitted appointment attendance & behaviour for delivery sessions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanSessionController.kt
@@ -69,21 +69,36 @@ class ActionPlanSessionController(
     @PathVariable(name = "id") actionPlanId: UUID,
     @PathVariable sessionNumber: Int,
     @RequestBody update: UpdateAppointmentAttendanceDTO,
+    authentication: JwtAuthenticationToken,
   ): ActionPlanSessionDTO {
+    val user = userMapper.fromToken(authentication)
     val updatedSession = actionPlanSessionsService.recordAppointmentAttendance(
-      actionPlanId, sessionNumber, update.attended, update.additionalAttendanceInformation
+      user, actionPlanId, sessionNumber, update.attended, update.additionalAttendanceInformation
     )
 
     return ActionPlanSessionDTO.from(updatedSession)
   }
 
   @PostMapping("/action-plan/{actionPlanId}/appointment/{sessionNumber}/record-behaviour")
-  fun recordBehaviour(@PathVariable actionPlanId: UUID, @PathVariable sessionNumber: Int, @RequestBody recordBehaviourDTO: RecordAppointmentBehaviourDTO): ActionPlanSessionDTO {
-    return ActionPlanSessionDTO.from(actionPlanSessionsService.recordBehaviour(actionPlanId, sessionNumber, recordBehaviourDTO.behaviourDescription, recordBehaviourDTO.notifyProbationPractitioner))
+  fun recordBehaviour(
+    @PathVariable actionPlanId: UUID,
+    @PathVariable sessionNumber: Int,
+    @RequestBody recordBehaviourDTO: RecordAppointmentBehaviourDTO,
+    authentication: JwtAuthenticationToken
+  ): ActionPlanSessionDTO {
+    val user = userMapper.fromToken(authentication)
+    val updatedSession = actionPlanSessionsService.recordBehaviour(
+      user, actionPlanId, sessionNumber, recordBehaviourDTO.behaviourDescription, recordBehaviourDTO.notifyProbationPractitioner
+    )
+    return ActionPlanSessionDTO.from(updatedSession)
   }
 
   @PostMapping("/action-plan/{actionPlanId}/appointment/{sessionNumber}/submit")
-  fun submitSessionFeedback(@PathVariable actionPlanId: UUID, @PathVariable sessionNumber: Int, authentication: JwtAuthenticationToken): ActionPlanSessionDTO {
+  fun submitSessionFeedback(
+    @PathVariable actionPlanId: UUID,
+    @PathVariable sessionNumber: Int,
+    authentication: JwtAuthenticationToken,
+  ): ActionPlanSessionDTO {
     val user = userMapper.fromToken(authentication)
     return ActionPlanSessionDTO.from(actionPlanSessionsService.submitSessionFeedback(actionPlanId, sessionNumber, user))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -24,15 +24,16 @@ data class Appointment(
   @Type(type = "attended") @Enumerated(EnumType.STRING) var attended: Attended? = null,
   var additionalAttendanceInformation: String? = null,
   var attendanceSubmittedAt: OffsetDateTime? = null,
+  @ManyToOne @Fetch(FetchMode.JOIN) var attendanceSubmittedBy: AuthUser? = null,
 
   var attendanceBehaviour: String? = null,
   var attendanceBehaviourSubmittedAt: OffsetDateTime? = null,
   @ManyToOne @Fetch(FetchMode.JOIN) var attendanceBehaviourSubmittedBy: AuthUser? = null,
+
   var notifyPPOfAttendanceBehaviour: Boolean? = null,
 
   var appointmentFeedbackSubmittedAt: OffsetDateTime? = null,
   @ManyToOne @Fetch(FetchMode.JOIN) var appointmentFeedbackSubmittedBy: AuthUser? = null,
-  @ManyToOne @Fetch(FetchMode.JOIN) var attendanceSubmittedBy: AuthUser? = null,
 
   var deliusAppointmentId: Long? = null,
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanSessionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ActionPlanSessionControllerTest.kt
@@ -35,7 +35,7 @@ internal class ActionPlanSessionControllerTest {
   @Test
   fun `updates a session`() {
     val user = authUserFactory.create()
-    val userToken = jwtTokenFactory.create(userID = user.id, userName = user.userName, authSource = user.authSource)
+    val userToken = jwtTokenFactory.create(user)
     val actionPlanSession = actionPlanSessionFactory.createScheduled(createdBy = user)
     val actionPlanId = actionPlanSession.actionPlan.id
     val sessionNumber = actionPlanSession.sessionNumber
@@ -90,6 +90,8 @@ internal class ActionPlanSessionControllerTest {
 
   @Test
   fun `updates session appointment with attendance details`() {
+    val user = authUserFactory.create()
+    val userToken = jwtTokenFactory.create(user)
     val update = UpdateAppointmentAttendanceDTO(Attended.YES, "more info")
     val actionPlan = actionPlanFactory.create()
     val sessionNumber = 1
@@ -103,12 +105,12 @@ internal class ActionPlanSessionControllerTest {
 
     whenever(
       sessionsService.recordAppointmentAttendance(
-        actionPlan.id, sessionNumber, update.attended,
+        user, actionPlan.id, sessionNumber, update.attended,
         update.additionalAttendanceInformation
       )
     ).thenReturn(updatedSession)
 
-    val sessionResponse = sessionsController.recordAttendance(actionPlan.id, sessionNumber, update)
+    val sessionResponse = sessionsController.recordAttendance(actionPlan.id, sessionNumber, update, userToken)
 
     assertThat(sessionResponse.sessionFeedback.attendance.additionalAttendanceInformation).isEqualTo("more info")
   }


### PR DESCRIPTION
## What does this pull request do?

Tracks who submitted appointment attendance & behaviour for delivery sessions

## What is the intent behind these changes?

To be able to conform to [ADR-4: Store time and actor information in data](https://github.com/ministryofjustice/hmpps-interventions-docs/blob/main/doc/adr/0004-store-actors-and-time-instead-of-state.md)