### PR TITLE
IC-2013: Hide cancelled referrals from providers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -99,6 +99,8 @@ class Referral(
     return createdBy
   }
 
+  fun cancelled(): Boolean = concludedAt != null && endRequestedAt != null && endOfServiceReport == null
+
   val currentActionPlan: ActionPlan?
     get() = actionPlans?.lastOrNull()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -245,7 +245,7 @@ class ReferralService(
     }
 
     update.serviceUser?.let {
-      if (it.crn != null && it.crn != referral.serviceUserCRN) {
+      if (it.crn != referral.serviceUserCRN) {
         errors.add(FieldError(field = "serviceUser.crn", error = Code.FIELD_CANNOT_BE_CHANGED))
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -111,6 +111,7 @@ class ReferralService(
     val referrals = referralRepository.findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(serviceProviders)
       // todo: query for referrals where the service provider has been granted nominated access only
       .union(referralRepository.findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(serviceProviders))
+      .filterNot { it.cancelled() }
 
     return referralAccessFilter.serviceProviderReferrals(referrals.toList(), user)
   }


### PR DESCRIPTION


## What does this pull request do?

Hide cancelled referrals from providers

## What is the intent behind these changes?

Service providers should not see referrals made to them that were
withdrawn (cancelled) by the probation staff

This is to prevent unnecessary visibility of offender details

🙋‍♂️ Note: it's undefined what is the cut-off point here; we might still want
to keep this if there was a supplier assessment scheduled, but I'm
sticking to the "cancelled" definition here
