### PR TITLE
Update NDMIS report to no longer assume a single action plan per referral

### DIFF
--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -15,15 +15,10 @@ COPY (
       where attended IS NOT NULL
       group by aps.action_plan_id
   ),
-  first_submitted_action_plans AS (
-    select referral_id, min(submitted_at) as submitted_at
+  first_submitted_and_approved_action_plans AS (
+    select referral_id, min(submitted_at) as first_submitted_at, min(approved_at) as first_approved_at
     from action_plan
     group by referral_id
-  ),
-  first_approved_action_plans AS (
-     select referral_id, min(approved_at) as approved_at
-     from action_plan
-     group by referral_id
   ),
   current_action_plans AS (
       select id, referral_id, number_of_sessions from action_plan
@@ -46,8 +41,8 @@ COPY (
     r.sent_at               AS date_referral_received,
     TIMESTAMP WITH TIME ZONE '3000-01-01+00' AS date_saa_booked,                    -- default value, coming later
     TIMESTAMP WITH TIME ZONE '3000-01-01+00' AS date_saa_attended,                  -- default value, coming later
-    fsap.submitted_at       AS date_first_action_plan_submitted,
-    faap.approved_at        AS date_of_first_action_plan_approval,
+    fsaap.first_submitted_at       AS date_first_action_plan_submitted,
+    fsaap.first_approved_at        AS date_of_first_action_plan_approval,
     shows.first_appointment AS date_of_first_session,
     (
       select count(o.desired_outcome_id)
@@ -74,8 +69,7 @@ COPY (
     JOIN dynamic_framework_contract c ON (i.dynamic_framework_contract_id = c.id)
     JOIN contract_type ct ON (c.contract_type_id = ct.id)
     JOIN service_provider prime ON (c.prime_provider_id = prime.id)
-    LEFT JOIN first_submitted_action_plans fsap ON (fsap.referral_id = r.id)
-    LEFT JOIN first_approved_action_plans faap ON (faap.referral_id = r.id)
+    LEFT JOIN first_submitted_and_approved_action_plans fsaap ON (fsaap.referral_id = r.id)
     LEFT JOIN current_action_plans cap ON (cap.referral_id = r.id)
     LEFT JOIN attended_sessions shows ON (shows.action_plan_id = cap.id) --❗️should be linked to referrals instead, sessions are static
     LEFT JOIN attempted_sessions atts ON (atts.action_plan_id = cap.id) --❗️should be linked to referrals instead, sessions are static

--- a/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/crs_performance_report.sql
@@ -14,6 +14,20 @@ COPY (
         join action_plan_session aps on apsa.action_plan_session_id = aps.id
       where attended IS NOT NULL
       group by aps.action_plan_id
+  ),
+  first_submitted_action_plans AS (
+    select referral_id, min(submitted_at) as submitted_at
+    from action_plan
+    group by referral_id
+  ),
+  current_action_plans AS (
+      select id, referral_id, number_of_sessions from action_plan
+      where (referral_id, created_at) in
+        (
+          select referral_id, max(created_at)
+          from action_plan
+          group by referral_id
+        )
   )
   SELECT
     r.reference_number      AS referral_ref,
@@ -27,7 +41,7 @@ COPY (
     r.sent_at               AS date_referral_received,
     TIMESTAMP WITH TIME ZONE '3000-01-01+00' AS date_saa_booked,                    -- default value, coming later
     TIMESTAMP WITH TIME ZONE '3000-01-01+00' AS date_saa_attended,                  -- default value, coming later
-    ap.submitted_at         AS date_first_action_plan_submitted,
+    fsap.submitted_at         AS date_first_action_plan_submitted,
     TIMESTAMP WITH TIME ZONE '3000-01-01+00' AS date_of_first_action_plan_approval, -- default value, coming later
     shows.first_appointment AS date_of_first_session,
     (
@@ -36,7 +50,7 @@ COPY (
       where o.referral_id = r.id
     )                       AS outcomes_to_be_achieved_count,
     9000                    AS outcomes_progress,                                   -- default value, coming later
-    ap.number_of_sessions   AS count_of_sessions_expected,
+    cap.number_of_sessions   AS count_of_sessions_expected,
     shows.attended          AS count_of_sessions_attended,
     r.concluded_at          AS date_intervention_ended,
     (
@@ -44,8 +58,8 @@ COPY (
         -- ❗️ need to confirm if we need to only select the 'latest' of the session appointment
         -- example: session no.2. has (yesterday: missed, today: pending) appointment -- do we say 1 or 0?
         WHEN r.concluded_at IS NOT NULL AND eosr.id IS NULL THEN 'cancelled'
-        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NOT NULL AND ap.number_of_sessions > atts.attempted THEN 'ended'
-        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NOT NULL AND ap.number_of_sessions = atts.attempted THEN 'completed'
+        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NOT NULL AND cap.number_of_sessions > atts.attempted THEN 'ended'
+        WHEN r.concluded_at IS NOT NULL AND eosr.id IS NOT NULL AND cap.number_of_sessions = atts.attempted THEN 'completed'
       END
     )                       AS intervention_end_reason,
     eosr.submitted_at       AS date_end_of_service_report_submitted
@@ -55,9 +69,10 @@ COPY (
     JOIN dynamic_framework_contract c ON (i.dynamic_framework_contract_id = c.id)
     JOIN contract_type ct ON (c.contract_type_id = ct.id)
     JOIN service_provider prime ON (c.prime_provider_id = prime.id)
-    LEFT JOIN action_plan ap ON (ap.referral_id = r.id) --❗️assumes a SINGLE action plan
-    LEFT JOIN attended_sessions shows ON (shows.action_plan_id = ap.id) --❗️should be linked to referrals instead, sessions are static
-    LEFT JOIN attempted_sessions atts ON (atts.action_plan_id = ap.id) --❗️should be linked to referrals instead, sessions are static
+    LEFT JOIN first_submitted_action_plans fsap ON (fsap.referral_id = r.id)
+    LEFT JOIN current_action_plans cap ON (cap.referral_id = r.id)
+    LEFT JOIN attended_sessions shows ON (shows.action_plan_id = cap.id) --❗️should be linked to referrals instead, sessions are static
+    LEFT JOIN attempted_sessions atts ON (atts.action_plan_id = cap.id) --❗️should be linked to referrals instead, sessions are static
     LEFT JOIN end_of_service_report eosr ON (eosr.referral_id = r.id)
   WHERE
     r.sent_at IS NOT NULL


### PR DESCRIPTION
To achieve this we add two new subqueries, one to select the first created action
plans, and one to select the most recently created action plans. We populate
'date_first_action_plan_submitted' from the formed query and other action plan
related values e.g. 'number of sessions' and the derived 'concluded_at' from
the latter.

here we have also added the code to populate the 'date_of_first_action_plan_approval' field (in e0f47b49093aa2fd18d96a5a6786f2d9b55d27bb)

## What is the intent behind these changes?

fix NDMIS report which currently has duplicate referrals id rows.
