### PR TITLE
IC-2058: sql and entity changes for nominated access of referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -36,6 +36,15 @@ class SelectedDesiredOutcomesMapping(
 @Entity
 @Table(indexes = arrayOf(Index(columnList = "created_by_id")))
 class Referral(
+  // nominated access
+  @ManyToMany(fetch = FetchType.LAZY)
+  @JoinTable(
+    name = "referral_nominated_access",
+    joinColumns = [JoinColumn(name = "referral_id")],
+    inverseJoinColumns = [JoinColumn(name = "subcontractor_provider_id")]
+  )
+  var nominatedServiceProviders: MutableList<ServiceProvider>? = null,
+
   // assigned referral fields
   var assignedAt: OffsetDateTime? = null,
   @ManyToOne @Fetch(FetchMode.JOIN) var assignedBy: AuthUser? = null,

--- a/src/main/resources/db/migration/V1_68__referral_nominated_access.sql
+++ b/src/main/resources/db/migration/V1_68__referral_nominated_access.sql
@@ -1,0 +1,6 @@
+create table referral_nominated_access (
+    referral_id uuid not null,
+    subcontractor_provider_id varchar(30) not null,
+    constraint fk_referral_nominated_access_referral_id foreign key(referral_id) references referral,
+    constraint fk_referral_nominated_access_subcontractor_provider_id foreign key(subcontractor_provider_id) references service_provider
+)


### PR DESCRIPTION
## What does this pull request do?

Defines the data structure for nominated access

## What is the intent behind these changes?

To facilitate future development work for nominated access and provide a discussion before starting it.


### Notes

Nominated access has two parts:
1. Service provider sub contractor access rights to the referral.
2. Case assignment based on the access right rules.

The user must select the service providers (subcontractors) which should have access to this referral. It's assumed that the prime provider will always have access.
When access has been granted to one or more (subcontractors) then the user can select the case workers for the service provider categorised based on subcontractor (and prime-provider).
There will eventually be some rules based on assigning a referral and nominated access subcontractors.

Questions:
Are we going to be querying hmpps-auth for all users belonging to a specific role? 
I assume that we don't want to be recording details of user's roles in our database and should be using hmpps-auth for this purpose.