### PR TITLE
Bump gradle's max memory to 512MB (from 256MB)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
   validate:
     executor: hmpps/java
     docker: *db_docker_config
+    environment:
+      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
       - gradle/with_cache:
@@ -113,6 +115,7 @@ jobs:
     environment:
       PACTBROKER_HOST: "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACTBROKER_AUTH_USERNAME: "interventions"
+      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     executor: hmpps/java
     docker:
       - image: cimg/openjdk:11.0
@@ -178,6 +181,8 @@ jobs:
 
   assemble:
     executor: hmpps/java
+    environment:
+      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
       - gradle/with_cache:


### PR DESCRIPTION

## What does this pull request do?

Bump gradle's max memory to 512MB (from 256MB)
- on all jobs that call `./gradlew`

## What is the intent behind these changes?

The previous value is defined in the hmpps orb and coming from the
`executor: hmpps/java` setting

This change is because we started seeing
```
> Task :compileTestKotlin
Exception: java.lang.OutOfMemoryError
```
on CI
