### PR TITLE
ensure all assignments in the new table are not null

### DIFF
--- a/src/main/resources/db/migration/V1_70_1__remove_null_assignments.sql
+++ b/src/main/resources/db/migration/V1_70_1__remove_null_assignments.sql
@@ -1,0 +1,10 @@
+delete from referral_assignments where assigned_at is null;
+
+alter table referral_assignments
+    alter column assigned_at set not null;
+
+alter table referral_assignments
+    alter column assigned_by_id set not null;
+
+alter table referral_assignments
+    alter column assigned_to_id set not null;


### PR DESCRIPTION
## What does this pull request do?

ensure all assignments in the new table are not null

## What is the intent behind these changes?

we erroneously copied from referrals that were not assigned into the new table. this just tidies that up, and adds not null constraints on the new referral_assignemnt table.
