### PR TITLE
Add referral to appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -47,7 +47,7 @@ data class Appointment(
   @PrimaryKeyJoinColumn
   var appointmentDelivery: AppointmentDelivery? = null,
 
-  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral,
+  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral? = null,
 
   @Id val id: UUID,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -15,7 +15,6 @@ import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.ManyToOne
-import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.validation.constraints.NotNull
@@ -48,7 +47,7 @@ data class Appointment(
   @PrimaryKeyJoinColumn
   var appointmentDelivery: AppointmentDelivery? = null,
 
-  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral? = null,
+  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral,
 
   @Id val id: UUID,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -12,8 +12,10 @@ import javax.persistence.CascadeType
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.validation.constraints.NotNull
@@ -45,6 +47,8 @@ data class Appointment(
   @OneToOne(cascade = [CascadeType.ALL])
   @PrimaryKeyJoinColumn
   var appointmentDelivery: AppointmentDelivery? = null,
+
+  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral? = null,
 
   @Id val id: UUID,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -84,6 +84,7 @@ class ActionPlanSessionsService(
         appointmentTime = appointmentTime,
         durationInMinutes = durationInMinutes,
         deliusAppointmentId = deliusAppointmentId,
+        referral = session.actionPlan.referral,
       )
       appointmentRepository.saveAndFlush(appointment)
       appointmentService.createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentDeliveryAddress)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -45,7 +45,7 @@ class AppointmentService(
     val initialAppointmentRequired = appointment == null
     if (initialAppointmentRequired) {
       val deliusAppointmentId = communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType)
-      return createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser, appointmentDeliveryType, appointmentDeliveryAddress)
+      return createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser, appointmentDeliveryType, appointmentDeliveryAddress, referral)
     }
 
     val updateCurrentAppointmentRequired = appointment!!.attended == null
@@ -57,7 +57,7 @@ class AppointmentService(
     val additionalAppointmentRequired = appointment.attended == Attended.NO
     if (additionalAppointmentRequired) {
       val deliusAppointmentId = communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType)
-      return createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser, appointmentDeliveryType, appointmentDeliveryAddress)
+      return createAppointment(durationInMinutes, appointmentTime, deliusAppointmentId, createdByUser, appointmentDeliveryType, appointmentDeliveryAddress, referral)
     }
     throw IllegalStateException("Is it not possible to update an appointment that has already been attended")
   }
@@ -150,6 +150,7 @@ class AppointmentService(
     createdByUser: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
     appointmentDeliveryAddress: AddressDTO? = null,
+    referral: Referral,
   ): Appointment {
     val appointment = Appointment(
       id = UUID.randomUUID(),
@@ -157,7 +158,8 @@ class AppointmentService(
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
       createdBy = authUserRepository.save(createdByUser),
-      createdAt = OffsetDateTime.now()
+      createdAt = OffsetDateTime.now(),
+      referral = referral,
     )
     appointmentRepository.saveAndFlush(appointment)
     createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentDeliveryAddress)

--- a/src/main/resources/db/local/V99_2_1__sent_referrals.sql
+++ b/src/main/resources/db/local/V99_2_1__sent_referrals.sql
@@ -25,8 +25,8 @@ insert into supplier_assessment(id, referral_id)
 values ('fbc4a21f-eb15-489d-b16f-b3b82b008722', '81d754aa-d868-4347-9c0f-50690773014e'),
        ('1db491c4-ee7d-4fa7-b42f-7b1aa81039f0', 'f89bd739-b9a2-482e-9947-12a793abcfb1');
 
-insert into appointment(id, appointment_time, duration_in_minutes, created_at, created_by_id)
-values  ('71f0de69-baba-4f29-8f59-62af4bb4c63d', '2021-04-01 12:00:00.000000+00', 120, '2021-03-12 17:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949');
+insert into appointment(id, appointment_time, duration_in_minutes, created_at, created_by_id, referral_id)
+values  ('71f0de69-baba-4f29-8f59-62af4bb4c63d', '2021-04-01 12:00:00.000000+00', 120, '2021-03-12 17:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949', '81d754aa-d868-4347-9c0f-50690773014e');
 
 insert into supplier_assessment_appointment(supplier_assessment_id, appointment_id)
 values ('fbc4a21f-eb15-489d-b16f-b3b82b008722', '71f0de69-baba-4f29-8f59-62af4bb4c63d');

--- a/src/main/resources/db/local/V99_2_2__assigned_referrals.sql
+++ b/src/main/resources/db/local/V99_2_2__assigned_referrals.sql
@@ -44,9 +44,9 @@ insert into action_plan_activity (id, action_plan_id, description, created_at)
 values ('fc8efc3d-fa13-4fde-b12b-22c04f18ea59', '21EA6AFE-C437-4018-9260-BF1A829DE464', 'Identify vacancies and make approach to supported hostel scheme.', '2021-03-11 17:51:34.235464+00'),
        ('e4e9030c-d0b0-4ee1-943f-88f1b74cece6', '21EA6AFE-C437-4018-9260-BF1A829DE464', 'Service user to develop independent living skills and understanding the importance of budgeting.', '2021-03-11 17:51:34.235464+00');
 
-insert into appointment(id, appointment_time, duration_in_minutes, created_at, created_by_id)
-values  ('1b79fba2-42ae-4acb-89ce-571e8ff10719', '2021-04-01 12:00:00.000000+00', 120, '2021-03-12 17:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949'),
-        ('82e2fbbe-1bb4-4967-8ee6-81aa072fd44b' , '2021-04-07 12:00:00.000000+00', 120, '2021-03-12 18:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949');
+insert into appointment(id, appointment_time, duration_in_minutes, created_at, created_by_id, referral_id)
+values  ('1b79fba2-42ae-4acb-89ce-571e8ff10719', '2021-04-01 12:00:00.000000+00', 120, '2021-03-12 17:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949', 'b59d3599-0681-466a-82b2-f6f957e46190'),
+        ('82e2fbbe-1bb4-4967-8ee6-81aa072fd44b' , '2021-04-07 12:00:00.000000+00', 120, '2021-03-12 18:51:34.235464+00', '608955ae-52ed-44cc-884c-011597a77949', 'b59d3599-0681-466a-82b2-f6f957e46190');
 
 insert into action_plan_session (id, action_plan_id, session_number)
 values ('847E253C-DC48-4914-9E5E-771694BB9C01', '2EB8B0DB-EAF1-430A-BA69-39984D501EB9', 1),

--- a/src/main/resources/db/migration/V1_71__appointment_references_referral.sql
+++ b/src/main/resources/db/migration/V1_71__appointment_references_referral.sql
@@ -23,6 +23,3 @@ set referral_id = (
     where app.id = apo.id
 )
 where apo.referral_id is null;
-
-alter table appointment
-    alter column referral_id set not null

--- a/src/main/resources/db/migration/V1_71__appointment_references_referral.sql
+++ b/src/main/resources/db/migration/V1_71__appointment_references_referral.sql
@@ -1,0 +1,28 @@
+alter table appointment
+    add column referral_id UUID,
+    add constraint fk__appointment__referral foreign key (referral_id) references referral;
+
+Update appointment apo
+set referral_id = (
+    select ref.id
+    from referral ref
+             inner join action_plan act on ref.id = act.referral_id
+             inner join action_plan_session aps on aps.action_plan_id = act.id
+             inner join action_plan_session_appointment apsa on apsa.action_plan_session_id = aps.id
+             inner join appointment app on app.id = apsa.appointment_id
+    where app.id = apo.id
+);
+
+Update appointment apo
+set referral_id = (
+    select ref.id
+    from referral ref
+             inner join supplier_assessment sup on sup.referral_id = ref.id
+             inner join supplier_assessment_appointment saa on saa.supplier_assessment_id = sup.id
+             inner join appointment app on app.id = saa.appointment_id
+    where app.id = apo.id
+)
+where apo.referral_id is null;
+
+alter table appointment
+    alter column referral_id set not null

--- a/src/main/resources/db/migration/V1_71__appointment_references_referral.sql
+++ b/src/main/resources/db/migration/V1_71__appointment_references_referral.sql
@@ -1,25 +1,3 @@
 alter table appointment
     add column referral_id UUID,
     add constraint fk__appointment__referral foreign key (referral_id) references referral;
-
-Update appointment apo
-set referral_id = (
-    select ref.id
-    from referral ref
-             inner join action_plan act on ref.id = act.referral_id
-             inner join action_plan_session aps on aps.action_plan_id = act.id
-             inner join action_plan_session_appointment apsa on apsa.action_plan_session_id = aps.id
-             inner join appointment app on app.id = apsa.appointment_id
-    where app.id = apo.id
-);
-
-Update appointment apo
-set referral_id = (
-    select ref.id
-    from referral ref
-             inner join supplier_assessment sup on sup.referral_id = ref.id
-             inner join supplier_assessment_appointment saa on saa.supplier_assessment_id = sup.id
-             inner join appointment app on app.id = saa.appointment_id
-    where app.id = apo.id
-)
-where apo.referral_id is null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -222,9 +222,10 @@ class SetupAssistant(
 
   fun addSupplierAssessmentAppointment(
     supplierAssessment: SupplierAssessment,
-    appointment: Appointment = appointmentFactory.create(createdBy = createPPUser()),
+    referral: Referral = createSentReferral(),
+    appointment: Appointment = appointmentFactory.create(createdBy = createPPUser(), referral = referral),
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentDeliveryAddress: AddressDTO? = null
+    appointmentDeliveryAddress: AddressDTO? = null,
   ) {
     appointmentRepository.save(appointment)
     supplierAssessment.appointments.add(appointment)
@@ -338,6 +339,7 @@ class SetupAssistant(
     notifyPPOfBehaviour: Boolean? = null,
     appointmentDeliveryType: AppointmentDeliveryType? = null,
     appointmentDeliveryAddress: AddressDTO? = null,
+    referral: Referral = createSentReferral()
   ): ActionPlanSession {
     val now = OffsetDateTime.now()
     val user = createSPUser()
@@ -352,6 +354,7 @@ class SetupAssistant(
       attendanceBehaviour = behaviour,
       attendanceBehaviourSubmittedAt = if (behaviour != null) now else null,
       notifyPPOfAttendanceBehaviour = notifyPPOfBehaviour,
+      referral = referral,
     )
     appointmentRepository.save(appointment)
     if (appointmentDeliveryType != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentFactory.kt
@@ -4,11 +4,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class AppointmentFactory(em: TestEntityManager? = null) : EntityFactory(em) {
   private val authUserFactory = AuthUserFactory(em)
+  private val referralFactory = ReferralFactory(em)
 
   fun create(
     id: UUID = UUID.randomUUID(),
@@ -25,6 +27,7 @@ class AppointmentFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     appointmentFeedbackSubmittedAt: OffsetDateTime? = null,
     appointmentFeedbackSubmittedBy: AuthUser? = null,
     deliusAppointmentId: Long? = null,
+    referral: Referral = referralFactory.createSent()
   ): Appointment {
     return save(
       Appointment(
@@ -42,6 +45,7 @@ class AppointmentFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         appointmentFeedbackSubmittedAt = appointmentFeedbackSubmittedAt,
         appointmentFeedbackSubmittedBy = appointmentFeedbackSubmittedBy,
         deliusAppointmentId = deliusAppointmentId,
+        referral = referral,
       )
     )
   }


### PR DESCRIPTION
## What does this pull request do?

Adds a reference to the referral id on an appointment.

## What is the intent behind these changes?

We currently have two types of appointments (supplier assessment & action plan). Finding the referral for a given appointment currently means we have to search the database against both possible paths to an appointment, as we can't go from an appointment entity backwards to action plans/saa to referral.

Having the referral easily accessible from an appointment will allow future changes, where we don't have the referral readily available, but needed, such as the generic appointment/notify services easier and cleaner to develop.