### PR TITLE
add data migration & make referral on appointment not null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -47,7 +47,7 @@ data class Appointment(
   @PrimaryKeyJoinColumn
   var appointmentDelivery: AppointmentDelivery? = null,
 
-  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral? = null,
+  @ManyToOne(fetch = FetchType.LAZY) var referral: Referral,
 
   @Id val id: UUID,
 ) {

--- a/src/main/resources/db/migration/V1_72__appointment_referral_data.sql
+++ b/src/main/resources/db/migration/V1_72__appointment_referral_data.sql
@@ -1,0 +1,22 @@
+Update appointment apo
+set referral_id = (
+    select ref.id
+    from referral ref
+             inner join action_plan act on ref.id = act.referral_id
+             inner join action_plan_session aps on aps.action_plan_id = act.id
+             inner join action_plan_session_appointment apsa on apsa.action_plan_session_id = aps.id
+             inner join appointment app on app.id = apsa.appointment_id
+    where app.id = apo.id
+)
+where apo.referral_id is null;
+
+Update appointment apo
+set referral_id = (
+    select ref.id
+    from referral ref
+             inner join supplier_assessment sup on sup.referral_id = ref.id
+             inner join supplier_assessment_appointment saa on saa.supplier_assessment_id = sup.id
+             inner join appointment app on app.id = saa.appointment_id
+    where app.id = apo.id
+)
+where apo.referral_id is null;


### PR DESCRIPTION
## What does this pull request do?

The second part of [pr-417](https://github.com/ministryofjustice/hmpps-interventions-service/pull/417). This adds a new migration that will update the existing appointments with a referral_id. Then finally make referral not null on the appointment.

## What is the intent behind these changes?

To ensure that all appointments have a referral_id going forward.