### PR TITLE
IC-1116 publish completed performance report to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,24 @@ docker-compose up -d
 SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
 ```
 
-### Running with AWS LocalStack for SNS (Simple Notification Service)
+### Running with AWS LocalStack for SNS (Simple Notification Service) or S3
 
 - Install the AWS CLI with Homebrew: `brew install awscli`
 - Configure the CLI for localstack: `aws configure --profile localstack` and set `AWS Access Key ID = test`, `AWS Secret Access Key = test`, `Default region name = eu-west-2`, `Default output format = json`
 - Run localstack with docker-compose: `docker-compose -f docker-compose-localstack.yml up`
+  
+#### SNS 
+
 - Create an SNS topic: `aws --profile localstack --endpoint-url=http://localhost:4566 sns create-topic --name intervention-events-local`
 - Validate the topic ARN matches: `arn:aws:sns:eu-west-2:000000000000:intervention-events-local`, if not modify the ARN in `application-local.yml`
 - Subscribe to topic: `aws --profile localstack --endpoint-url=http://localhost:4566 sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:intervention-events-local --protocol http --notification-endpoint http://host.docker.internal:5000`
 - Output notifications: `npx http-echo-server 5000`
 - Run the application with the following environment var `AWS_SNS_ENABLED=true`
+
+#### S3
+
+- Create new buckets on startup: Edit 'script/localstack/buckets.sh' e.g. `awslocal s3 mb s3://new-bucket-name`
+- List the contents of a bucket: `aws --profile localstack --endpoint-url=http://localhost:4566 s3 ls s3://new-bucket-name --recursive`
 
 ## Architecture
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,10 @@ dependencies {
 
   // notifications
   implementation("uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE")
+
+  // aws
   implementation("software.amazon.awssdk:sns:2.17.9")
+  implementation("software.amazon.awssdk:s3:2.17.9")
 
   // security
   implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -9,7 +9,7 @@ services:
       - "4566:4566"
       - "4571:4571"
     environment:
-      - LOCALSTACK_SERVICES=${LOCALSTACK_SERVICES-sns}
+      - LOCALSTACK_SERVICES=${LOCALSTACK_SERVICES-sns,s3}
       - LOCALSTACK_DEFAULT_REGION=${LOCALSTACK_DEFAULT_REGION-eu-west-2}
       - LOCALSTACK_DEBUG=${LOCALSTACK_DEBUG- }
       - LOCALSTACK_DATA_DIR=${LOCALSTACK_DATA_DIR- }
@@ -19,3 +19,4 @@ services:
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./script/localstack:/docker-entrypoint-initaws.d"

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -84,4 +84,22 @@ env:
         name: sentry
         key: service_dsn
 
+  - name: AWS_S3_ACCESSKEYID
+    valueFrom:
+      secretKeyRef:
+        name: storage-s3-bucket
+        key: access_key_id
+
+  - name: AWS_S3_SECRETACCESSKEY
+    valueFrom:
+      secretKeyRef:
+        name: storage-s3-bucket
+        key: secret_access_key
+
+  - name: AWS_S3_BUCKET_NAME
+    valueFrom:
+      secretKeyRef:
+        name: storage-s3-bucket
+        key: bucket_name
+
 {{- end -}}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,3 +24,4 @@ env:
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "dev"
+  AWS_S3_ENABLED: "true"

--- a/script/localstack/buckets.sh
+++ b/script/localstack/buckets.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -x
+awslocal s3 mb s3://interventions-bucket-local
+set +x

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
@@ -23,6 +24,7 @@ private data class WorkingScope(
 )
 
 @Component
+@Transactional
 class ServiceProviderAccessScopeMapper(
   private val hmppsAuthService: HMPPSAuthService,
   private val serviceProviderRepository: ServiceProviderRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/S3Configuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/S3Configuration.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import java.net.URI
+
+@Configuration
+class S3Configuration(
+  @Value("\${aws.s3.provider}") private val provider: String,
+  @Value("\${aws.s3.region}") private val region: String,
+  @Value("\${aws.s3.access-key-id}") private val accessKeyId: String,
+  @Value("\${aws.s3.secret-access-key}") private val secretAccessKey: String,
+  @Value("\${aws.s3.endpoint.uri:}") private val uri: String,
+) {
+  @Bean
+  fun s3Client(): S3Client {
+    val builder = S3Client.builder()
+      .region(Region.of(region))
+      .credentialsProvider { AwsBasicCredentials.create(accessKeyId, secretAccessKey) }
+
+    return when (provider) {
+      "aws" -> builder.build()
+      "localstack" ->
+        builder
+          .endpointOverride(URI.create(uri))
+          .build()
+      else -> throw RuntimeException("invalid S3 configuration")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import mu.KLogging
+import net.logstash.logback.argument.StructuredArguments
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.nio.file.Path
+
+@Service
+class S3Service(
+  private val s3Client: S3Client,
+  @Value("\${aws.s3.enabled}") private val s3Enabled: Boolean,
+  @Value("\${aws.s3.bucket.name}") private val s3BucketName: String,
+) {
+  companion object : KLogging()
+
+  fun publishFileToS3(path: Path, keyPrefix: String = "") {
+    if (!s3Enabled) {
+      logger.info("not publishing to s3; s3 disabled")
+      return
+    }
+
+    val key = "${keyPrefix}${path.fileName}"
+    logger.info("publishing file to s3 {}", StructuredArguments.kv("key", key))
+
+    val objectRequest = PutObjectRequest.builder()
+      .bucket(s3BucketName)
+      .key(key)
+      .build()
+
+    s3Client.putObject(objectRequest, RequestBody.fromFile(path))
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,6 +16,13 @@ assess-risks-and-needs:
   baseurl: http://localhost:8094
 
 aws:
+  s3:
+    enabled: false
+    provider: localstack
+    access-key-id: test
+    secret-access-key: test
+    endpoint.uri: http://localhost:4566
+    bucket.name: interventions-bucket-local
   sns:
     enabled: false
     provider: localstack

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -145,6 +145,10 @@ assess-risks-and-needs:
     create-supplementary-risk: "/risks/supplementary"
 
 aws:
+  s3:
+    enabled: false
+    provider: aws
+    region: eu-west-2
   sns:
     enabled: true
     provider: aws


### PR DESCRIPTION

## What does this pull request do?

- makes ServiceProviderAccessScopeMapper transactional so it can be used within the job
- publishes the SP referral performance report to s3 on completion
- adds localstack config for running locally
- adds k8s secrets config for dev s3 deploy

## What is the intent behind these changes?

store the completed report somewhere
