### PR TITLE
Audit: track authorised scope of service providers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -64,6 +64,7 @@ class ServiceProviderAccessScopeMapper(
         "InterventionsAuthorizedProvider",
         mapOf(
           "userId" to user.id,
+          "userName" to user.userName,
           "userAuthSource" to user.authSource,
           "contracts" to it.contracts.joinToString(",") { c -> c.contractReference },
           "providers" to it.serviceProviders.joinToString(",") { p -> p.id },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapper.kt
@@ -121,7 +121,7 @@ class ServiceProviderAccessScopeMapper(
     unidentifiedProviders.forEach { undefinedProvider ->
       configErrors.add("unidentified provider '$undefinedProvider': group does not exist in the reference data")
     }
-    return providers
+    return providers.sortedBy { it.id }
   }
 
   private fun getContracts(contractGroups: List<String>, configErrors: MutableList<String>): List<DynamicFrameworkContract> {
@@ -130,6 +130,6 @@ class ServiceProviderAccessScopeMapper(
     unidentifiedContracts.forEach { undefinedContract ->
       configErrors.add("unidentified contract '$undefinedContract': group does not exist in the reference data")
     }
-    return contracts
+    return contracts.sortedBy { it.contractReference }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
@@ -37,6 +37,7 @@ class SNSPublisher(
         "event" to eventType,
         "referralId" to referralId.toString(),
         "actorUserId" to actor.id,
+        "actorUserName" to actor.userName,
       ),
       null
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -60,6 +60,7 @@ class ErrorConfiguration(private val telemetryClient: TelemetryClient) {
       "InterventionsAuthorizationError",
       mapOf(
         "userId" to e.user.id,
+        "userName" to e.user.userName,
         "userAuthSource" to e.user.authSource,
         "message" to e.message,
         "issues" to e.errors.toString()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
@@ -1,0 +1,113 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
+
+import com.microsoft.applicationinsights.TelemetryClient
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DynamicFrameworkContractRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceProviderRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
+
+class ServiceProviderAccessScopeMapperTest {
+  private lateinit var mapper: ServiceProviderAccessScopeMapper
+  private val userTypeChecker = UserTypeChecker()
+
+  private val hmppsAuthService = mock<HMPPSAuthService>()
+  private val serviceProviderRepository = mock<ServiceProviderRepository>()
+  private val dynamicFrameworkContractRepository = mock<DynamicFrameworkContractRepository>()
+  private val telemetryClient = mock<TelemetryClient>()
+
+  private val spUser =
+    AuthUser(id = "b40ac52d-037d-4732-a3cd-bf5484c6ab6a", userName = "test@test.example.org", authSource = "auth")
+  private val ppUser = AuthUser(id = "123456789", userName = "TEST_USER", authSource = "delius")
+
+  @BeforeEach
+  fun setup() {
+    mapper = ServiceProviderAccessScopeMapper(
+      hmppsAuthService = hmppsAuthService,
+      serviceProviderRepository = serviceProviderRepository,
+      dynamicFrameworkContractRepository = dynamicFrameworkContractRepository,
+      userTypeChecker = userTypeChecker,
+      telemetryClient = telemetryClient
+    )
+  }
+
+  @Test
+  fun `throws AccessError if the user is not a service provider`() {
+    val error = assertThrows<AccessError> { mapper.fromUser(ppUser) }
+    assertThat(error.user).isEqualTo(ppUser)
+    assertThat(error.message).isEqualTo("could not map service provider user to access scope")
+    assertThat(error.errors).containsExactly("user is not a service provider")
+  }
+
+  @Test
+  fun `throws AccessError if the user's auth groups cannot be retrieved`() {
+    whenever(hmppsAuthService.getUserGroups(spUser)).thenReturn(null)
+
+    val error = assertThrows<AccessError> { mapper.fromUser(spUser) }
+    assertThat(error.user).isEqualTo(spUser)
+    assertThat(error.message).isEqualTo("could not map service provider user to access scope")
+    assertThat(error.errors).containsExactly("cannot find user in hmpps auth")
+  }
+
+  // the business behaviour is tested through integration tests at
+  // src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization
+
+  @Nested
+  @DisplayName("for valid provider scopes")
+  inner class ForValidScope {
+    private lateinit var providers: List<ServiceProvider>
+    private lateinit var contracts: List<DynamicFrameworkContract>
+
+    @BeforeEach
+    fun setup() {
+      whenever(hmppsAuthService.getUserGroups(spUser))
+        .thenReturn(listOf("INT_SP_TEST_P1", "INT_SP_TEST_P2", "INT_CR_TEST_C0001", "INT_CR_TEST_C0002"))
+
+      val p1 = ServiceProvider(id = "TEST_P1", name = "Test 1 Ltd")
+      val p2 = ServiceProvider(id = "TEST_P2", name = "Test 2 Ltd")
+      providers = listOf(p1, p2)
+      whenever(serviceProviderRepository.findAllById(listOf("TEST_P1", "TEST_P2")))
+        .thenReturn(providers)
+
+      val c1 = SampleData.sampleContract(contractReference = "TEST_C0001", primeProvider = p1)
+      val c2 = SampleData.sampleContract(contractReference = "TEST_C0002", primeProvider = p2)
+      contracts = listOf(c1, c2)
+      whenever(dynamicFrameworkContractRepository.findAllByContractReferenceIn(listOf("TEST_C0001", "TEST_C0002")))
+        .thenReturn(contracts)
+    }
+
+    @Test
+    fun `returns the access scope`() {
+      val scope = mapper.fromUser(spUser)
+      assertThat(scope.serviceProviders).containsExactlyElementsOf(providers)
+      assertThat(scope.contracts).containsExactlyElementsOf(contracts)
+    }
+
+    @Test
+    fun `tracks the event in AppInsights telemetry`() {
+      mapper.fromUser(spUser)
+      verify(telemetryClient).trackEvent(
+        "InterventionsAuthorizedProvider",
+        mapOf(
+          "userId" to "b40ac52d-037d-4732-a3cd-bf5484c6ab6a",
+          "userAuthSource" to "auth",
+          "contracts" to "TEST_C0001,TEST_C0002",
+          "providers" to "TEST_P1,TEST_P2",
+        ),
+        null
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
@@ -102,6 +102,7 @@ class ServiceProviderAccessScopeMapperTest {
         "InterventionsAuthorizedProvider",
         mapOf(
           "userId" to "b40ac52d-037d-4732-a3cd-bf5484c6ab6a",
+          "userName" to "test@test.example.org",
           "userAuthSource" to "auth",
           "contracts" to "TEST_C0001,TEST_C0002",
           "providers" to "TEST_P1,TEST_P2",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
@@ -73,26 +73,31 @@ class ServiceProviderAccessScopeMapperTest {
     @BeforeEach
     fun setup() {
       whenever(hmppsAuthService.getUserGroups(spUser))
-        .thenReturn(listOf("INT_SP_TEST_P1", "INT_SP_TEST_P2", "INT_CR_TEST_C0001", "INT_CR_TEST_C0002"))
+        .thenReturn(listOf("INT_SP_TEST_P1", "INT_SP_TEST_A2", "INT_CR_TEST_C0001", "INT_CR_TEST_A0002"))
 
       val p1 = ServiceProvider(id = "TEST_P1", name = "Test 1 Ltd")
-      val p2 = ServiceProvider(id = "TEST_P2", name = "Test 2 Ltd")
+      val p2 = ServiceProvider(id = "TEST_A2", name = "Test 2 Ltd")
       providers = listOf(p1, p2)
-      whenever(serviceProviderRepository.findAllById(listOf("TEST_P1", "TEST_P2")))
+      whenever(serviceProviderRepository.findAllById(listOf("TEST_P1", "TEST_A2")))
         .thenReturn(providers)
 
       val c1 = SampleData.sampleContract(contractReference = "TEST_C0001", primeProvider = p1)
-      val c2 = SampleData.sampleContract(contractReference = "TEST_C0002", primeProvider = p2)
+      val c2 = SampleData.sampleContract(contractReference = "TEST_A0002", primeProvider = p2)
       contracts = listOf(c1, c2)
-      whenever(dynamicFrameworkContractRepository.findAllByContractReferenceIn(listOf("TEST_C0001", "TEST_C0002")))
+      whenever(dynamicFrameworkContractRepository.findAllByContractReferenceIn(listOf("TEST_C0001", "TEST_A0002")))
         .thenReturn(contracts)
     }
 
     @Test
-    fun `returns the access scope`() {
+    fun `returns the access scope with providers sorted by their ID`() {
       val scope = mapper.fromUser(spUser)
-      assertThat(scope.serviceProviders).containsExactlyElementsOf(providers)
-      assertThat(scope.contracts).containsExactlyElementsOf(contracts)
+      assertThat(scope.serviceProviders.map { it.id }).containsExactly("TEST_A2", "TEST_P1")
+    }
+
+    @Test
+    fun `returns the access scope with contracts sorted by their contract reference`() {
+      val scope = mapper.fromUser(spUser)
+      assertThat(scope.contracts.map { it.contractReference }).containsExactly("TEST_A0002", "TEST_C0001")
     }
 
     @Test
@@ -104,8 +109,8 @@ class ServiceProviderAccessScopeMapperTest {
           "userId" to "b40ac52d-037d-4732-a3cd-bf5484c6ab6a",
           "userName" to "test@test.example.org",
           "userAuthSource" to "auth",
-          "contracts" to "TEST_C0001,TEST_C0002",
-          "providers" to "TEST_P1,TEST_P2",
+          "contracts" to "TEST_A0002,TEST_C0001",
+          "providers" to "TEST_A2,TEST_P1",
         ),
         null
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
@@ -24,7 +24,7 @@ class SNSPublisherTest {
   private val telemetryClient = mock<TelemetryClient>()
 
   private val aReferralId = UUID.fromString("82138d14-3835-442b-b39b-9f8a07650bbe")
-  private val aUser = AuthUser("d7c4c3a7a7", "irrelevant", "irrelevant")
+  private val aUser = AuthUser("d7c4c3a7a7", "irrelevant", "d7c4c3a7a7@example.org")
 
   val event = EventDTO(
     "intervention.test.event",
@@ -58,6 +58,7 @@ class SNSPublisherTest {
         "event" to "intervention.test.event",
         "referralId" to "82138d14-3835-442b-b39b-9f8a07650bbe",
         "actorUserId" to "d7c4c3a7a7",
+        "actorUserName" to "d7c4c3a7a7@example.org",
       ),
       null
     )
@@ -84,6 +85,7 @@ class SNSPublisherTest {
         "event" to "intervention.test.event",
         "referralId" to "82138d14-3835-442b-b39b-9f8a07650bbe",
         "actorUserId" to "d7c4c3a7a7",
+        "actorUserName" to "d7c4c3a7a7@example.org",
       ),
       null
     )


### PR DESCRIPTION
## What does this pull request do?

🕵️ Track authorised scope of service providers (9e684ed9)
🕵️ (bonus) Track user names when we track user IDs (53836209)
📐 Predictability: ensures providers and contracts are ordered in the scope (8e7ee35e)

## What is the intent behind these changes?

Currently, we can prove what information we have in our database and we have tests that give us confidence that the filtering behaviour is correct

However, provider users also take external input to the filtering, which is what providers and groups were active at the time on their auth profile

**Hypothesis**
Logging this data point allows us to completely reproduce the filter for the `/sent-referrals` query