### PR TITLE
Appointment emails

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.RecordAppointm
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentAttendanceDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
@@ -87,7 +88,7 @@ class SupplierAssessmentController(
   ): AppointmentDTO {
     val user = userMapper.fromToken(authentication)
     val supplierAssessmentAppointment = getSupplierAssessmentAppointment(referralId, user)
-    return AppointmentDTO.from(appointmentService.submitSessionFeedback(supplierAssessmentAppointment, user))
+    return AppointmentDTO.from(appointmentService.submitSessionFeedback(supplierAssessmentAppointment, user, AppointmentType.SUPPLIER_ASSESSMENT))
   }
 
   private fun getSupplierAssessmentAppointment(referralId: UUID, user: AuthUser): Appointment {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
@@ -7,38 +7,38 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.Location
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.ActionPlanSessionController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 
-enum class AppointmentEventType {
+enum class ActionPlanAppointmentEventType {
   ATTENDANCE_RECORDED,
   BEHAVIOUR_RECORDED,
   SESSION_FEEDBACK_RECORDED,
 }
 
-class AppointmentEvent(source: Any, val type: AppointmentEventType, val actionPlanSession: ActionPlanSession, val detailUrl: String, val notifyPP: Boolean) : ApplicationEvent(source) {
+class ActionPlanAppointmentEvent(source: Any, val type: ActionPlanAppointmentEventType, val actionPlanSession: ActionPlanSession, val detailUrl: String, val notifyPP: Boolean) : ApplicationEvent(source) {
   override fun toString(): String {
     return "AppointmentEvent(type=$type, appointment=${actionPlanSession.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 
 @Component
-class AppointmentEventPublisher(
+class ActionPlanAppointmentEventPublisher(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val locationMapper: LocationMapper
 ) {
   fun attendanceRecordedEvent(session: ActionPlanSession, notifyPP: Boolean) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.ATTENDANCE_RECORDED, session, getAppointmentURL(session), notifyPP)
+      ActionPlanAppointmentEvent(this, ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, session, getAppointmentURL(session), notifyPP)
     )
   }
 
   fun behaviourRecordedEvent(session: ActionPlanSession, notifyPP: Boolean) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.BEHAVIOUR_RECORDED, session, getAppointmentURL(session), notifyPP)
+      ActionPlanAppointmentEvent(this, ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, session, getAppointmentURL(session), notifyPP)
     )
   }
 
   fun sessionFeedbackRecordedEvent(session: ActionPlanSession, notifyPP: Boolean) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.SESSION_FEEDBACK_RECORDED, session, getAppointmentURL(session), notifyPP)
+      ActionPlanAppointmentEvent(this, ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED, session, getAppointmentURL(session), notifyPP)
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
@@ -15,7 +15,7 @@ enum class ActionPlanAppointmentEventType {
 
 class ActionPlanAppointmentEvent(source: Any, val type: ActionPlanAppointmentEventType, val actionPlanSession: ActionPlanSession, val detailUrl: String, val notifyPP: Boolean) : ApplicationEvent(source) {
   override fun toString(): String {
-    return "AppointmentEvent(type=$type, appointment=${actionPlanSession.id}, detailUrl='$detailUrl', source=$source)"
+    return "ActionPlanAppointmentEvent(type=$type, appointment=${actionPlanSession.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
+
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+
+enum class AppointmentEventType {
+  ATTENDANCE_RECORDED,
+  BEHAVIOUR_RECORDED,
+  SESSION_FEEDBACK_RECORDED,
+}
+
+class AppointmentEvent(source: Any, val type: AppointmentEventType, val appointment: Appointment, val detailUrl: String,
+                       val notifyPP: Boolean, val appointmentType: AppointmentType) : ApplicationEvent(source) {
+  override fun toString(): String {
+    return "AppointmentEvent(type=$type, appointment=${appointment.id}, detailUrl='$detailUrl', source=$source)"
+  }
+}
+
+@Component
+class AppointmentEventPublisher(
+  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val locationMapper: LocationMapper
+) {
+  fun attendanceRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
+    applicationEventPublisher.publishEvent(
+      AppointmentEvent(this, AppointmentEventType.ATTENDANCE_RECORDED, appointment, getAppointmentURL(appointment), notifyPP, appointmentType)
+    )
+  }
+
+  fun behaviourRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
+    applicationEventPublisher.publishEvent(
+      AppointmentEvent(this, AppointmentEventType.BEHAVIOUR_RECORDED, appointment, getAppointmentURL(appointment), notifyPP, appointmentType)
+    )
+  }
+
+  fun sessionFeedbackRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
+    applicationEventPublisher.publishEvent(
+      AppointmentEvent(this, AppointmentEventType.SESSION_FEEDBACK_RECORDED, appointment, getAppointmentURL(appointment), notifyPP, appointmentType)
+    )
+  }
+
+  private fun getAppointmentURL(appointment: Appointment, appointmentType: AppointmentType): String {
+//    val path = locationMapper.getPathFromControllerMethod(AppointmentController::getSession)
+//    return locationMapper.expandPathToCurrentRequestBaseUrl(path, session.actionPlan.id, session.sessionNumber).toString()
+    return "aaaa"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -4,7 +4,6 @@ import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
-
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.ReferralController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -4,8 +4,11 @@ import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
+
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.ReferralController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.NotifyAppointmentService
 
 enum class AppointmentEventType {
   ATTENDANCE_RECORDED,
@@ -13,8 +16,14 @@ enum class AppointmentEventType {
   SESSION_FEEDBACK_RECORDED,
 }
 
-class AppointmentEvent(source: Any, val type: AppointmentEventType, val appointment: Appointment, val detailUrl: String,
-                       val notifyPP: Boolean, val appointmentType: AppointmentType) : ApplicationEvent(source) {
+class AppointmentEvent(
+  source: Any,
+  val type: AppointmentEventType,
+  val appointment: Appointment,
+  val detailUrl: String,
+  val notifyPP: Boolean,
+  val appointmentType: AppointmentType
+) : ApplicationEvent(source) {
   override fun toString(): String {
     return "AppointmentEvent(type=$type, appointment=${appointment.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -27,25 +36,53 @@ class AppointmentEventPublisher(
 ) {
   fun attendanceRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.ATTENDANCE_RECORDED, appointment, getAppointmentURL(appointment), notifyPP, appointmentType)
+      AppointmentEvent(
+        this,
+        AppointmentEventType.ATTENDANCE_RECORDED,
+        appointment,
+        getAppointmentURL(appointment, appointmentType),
+        notifyPP,
+        appointmentType
+      )
     )
   }
 
   fun behaviourRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.BEHAVIOUR_RECORDED, appointment, getAppointmentURL(appointment), notifyPP, appointmentType)
+      AppointmentEvent(
+        this,
+        AppointmentEventType.BEHAVIOUR_RECORDED,
+        appointment,
+        getAppointmentURL(appointment, appointmentType),
+        notifyPP,
+        appointmentType
+      )
     )
   }
 
   fun sessionFeedbackRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
     applicationEventPublisher.publishEvent(
-      AppointmentEvent(this, AppointmentEventType.SESSION_FEEDBACK_RECORDED, appointment, getAppointmentURL(appointment), notifyPP, appointmentType)
+      AppointmentEvent(
+        this,
+        AppointmentEventType.SESSION_FEEDBACK_RECORDED,
+        appointment,
+        getAppointmentURL(appointment, appointmentType),
+        notifyPP,
+        appointmentType
+      )
     )
   }
 
   private fun getAppointmentURL(appointment: Appointment, appointmentType: AppointmentType): String {
-//    val path = locationMapper.getPathFromControllerMethod(AppointmentController::getSession)
-//    return locationMapper.expandPathToCurrentRequestBaseUrl(path, session.actionPlan.id, session.sessionNumber).toString()
-    return "aaaa"
+    when (appointmentType) {
+      AppointmentType.SERVICE_DELIVERY -> run {
+        NotifyAppointmentService.logger.error("action plan session should not be using the shared appointment notify service.")
+        return ""
+      }
+      AppointmentType.SUPPLIER_ASSESSMENT -> run {
+        val path = locationMapper.getPathFromControllerMethod(ReferralController::getSupplierAssessmentAppointment)
+        return locationMapper.expandPathToCurrentRequestBaseUrl(path, appointment.referral.id).toString()
+      }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -48,7 +48,6 @@ data class Appointment(
   var appointmentDelivery: AppointmentDelivery? = null,
 
   @ManyToOne(fetch = FetchType.LAZY) var referral: Referral,
-
   @Id val id: UUID,
 ) {
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
@@ -28,7 +28,7 @@ class ActionPlanSessionsService(
   val actionPlanSessionRepository: ActionPlanSessionRepository,
   val actionPlanRepository: ActionPlanRepository,
   val authUserRepository: AuthUserRepository,
-  val appointmentEventPublisher: AppointmentEventPublisher,
+  val actionPlanAppointmentEventPublisher: ActionPlanAppointmentEventPublisher,
   val communityAPIBookingService: CommunityAPIBookingService,
   val appointmentService: AppointmentService,
   val appointmentRepository: AppointmentRepository,
@@ -154,13 +154,13 @@ class ActionPlanSessionsService(
     appointment.appointmentFeedbackSubmittedBy = authUserRepository.save(submitter)
     actionPlanSessionRepository.save(session)
 
-    appointmentEventPublisher.attendanceRecordedEvent(session, appointment.attended!! == Attended.NO)
+    actionPlanAppointmentEventPublisher.attendanceRecordedEvent(session, appointment.attended!! == Attended.NO)
 
     if (appointment.attendanceBehaviourSubmittedAt != null) { // excluding the case of non attendance
-      appointmentEventPublisher.behaviourRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour!!)
+      actionPlanAppointmentEventPublisher.behaviourRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour!!)
     }
 
-    appointmentEventPublisher.sessionFeedbackRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour ?: false)
+    actionPlanAppointmentEventPublisher.sessionFeedbackRecordedEvent(session, appointment.notifyPPOfAttendanceBehaviour ?: false)
     return session
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -113,7 +113,7 @@ class AppointmentService(
       appointmentEventPublisher.behaviourRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour!!, appointmentType)
     }
 
-    appointmentEventPublisher.sessionFeedbackRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour ?: false, appointmentType)
+//    appointmentEventPublisher.sessionFeedbackRecordedEvent(appointment, appointment.notifyPPOfAttendanceBehaviour ?: false, appointmentType)
 
     return appointment
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -8,8 +8,8 @@ import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType.SESSION_FEEDBACK_RECORDED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
@@ -185,10 +185,10 @@ class CommunityAPIAppointmentEventService(
   @Value("\${community-api.locations.appointment-outcome-request}") private val communityAPIAppointmentOutcomeLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   private val communityAPIClient: CommunityAPIClient,
-) : ApplicationListener<AppointmentEvent>, CommunityAPIService {
+) : ApplicationListener<ActionPlanAppointmentEvent>, CommunityAPIService {
   companion object : KLogging()
 
-  override fun onApplicationEvent(event: AppointmentEvent) {
+  override fun onApplicationEvent(event: ActionPlanAppointmentEvent) {
     when (event.type) {
       SESSION_FEEDBACK_RECORDED -> {
         val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -6,10 +6,10 @@ import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyService.kt
@@ -7,8 +7,8 @@ import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSender
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
@@ -103,9 +103,9 @@ class NotifyAppointmentService(
   @Value("\${interventions-ui.locations.probation-practitioner.session-feedback}") private val ppSessionFeedbackLocation: String,
   private val emailSender: EmailSender,
   private val hmppsAuthService: HMPPSAuthService,
-) : ApplicationListener<AppointmentEvent>, NotifyService {
+) : ApplicationListener<ActionPlanAppointmentEvent>, NotifyService {
   @AsyncEventExceptionHandling
-  override fun onApplicationEvent(event: AppointmentEvent) {
+  override fun onApplicationEvent(event: ActionPlanAppointmentEvent) {
     if (event.notifyPP) {
       val referral = event.actionPlanSession.actionPlan.referral
       val ppDetails = hmppsAuthService.getUserDetail(referral.getResponsibleProbationPractitioner())
@@ -117,7 +117,7 @@ class NotifyAppointmentService(
       )
 
       when (event.type) {
-        AppointmentEventType.ATTENDANCE_RECORDED -> {
+        ActionPlanAppointmentEventType.ATTENDANCE_RECORDED -> {
           emailSender.sendEmail(
             appointmentNotAttendedTemplateID,
             ppDetails.email,
@@ -128,7 +128,7 @@ class NotifyAppointmentService(
             )
           )
         }
-        AppointmentEventType.BEHAVIOUR_RECORDED -> {
+        ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED -> {
           emailSender.sendEmail(
             concerningBehaviourTemplateID,
             ppDetails.email,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -6,8 +6,8 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPubli
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
@@ -83,12 +83,12 @@ class SNSReferralService(
 @Service
 class SNSAppointmentService(
   private val snsPublisher: SNSPublisher,
-) : ApplicationListener<AppointmentEvent>, SNSService {
+) : ApplicationListener<ActionPlanAppointmentEvent>, SNSService {
 
   @AsyncEventExceptionHandling
-  override fun onApplicationEvent(event: AppointmentEvent) {
+  override fun onApplicationEvent(event: ActionPlanAppointmentEvent) {
     when (event.type) {
-      AppointmentEventType.ATTENDANCE_RECORDED -> {
+      ActionPlanAppointmentEventType.ATTENDANCE_RECORDED -> {
         val referral = event.actionPlanSession.actionPlan.referral
         val appointment = event.actionPlanSession.currentAppointment
           ?: throw RuntimeException("event triggered for session with no appointments")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -4,10 +4,10 @@ import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,7 @@ interventions-ui:
       supplier-assessment: "/probation-practitioner/referrals/{id}/supplier-assessment"
       action-plan: "/probation-practitioner/referrals/{id}/action-plan"
       session-feedback: "/probation-practitioner/action-plan/{id}/appointment/{sessionNumber}/post-session-feedback"
+      supplier-assessment-feedback: "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback"
       end-of-service-report: "/probation-practitioner/end-of-service-report/{id}"
 
 community-api:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.RecordAppointm
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentAttendanceDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
@@ -251,7 +252,7 @@ class SupplierAssessmentControllerTest {
       supplierAssessment.referral.supplierAssessment = supplierAssessment
       whenever(referralService.getSentReferralForUser(eq(referralId), eq(submittedBy))).thenReturn(supplierAssessment.referral)
       whenever(userMapper.fromToken(token)).thenReturn(submittedBy)
-      whenever(appointmentService.submitSessionFeedback(eq(supplierAssessment!!.currentAppointment!!), eq(submittedBy))).thenReturn(appointmentFactory.create())
+      whenever(appointmentService.submitSessionFeedback(eq(supplierAssessment!!.currentAppointment!!), eq(submittedBy), eq(AppointmentType.SUPPLIER_ASSESSMENT))).thenReturn(appointmentFactory.create())
 
       val result = supplierAssessmentController.submitFeedback(referralId, token)
       assertThat(result).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanActionPlanAppointmentEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanActionPlanAppointmentEventPublisherTest.kt
@@ -15,10 +15,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSes
 import java.net.URI
 import java.time.OffsetDateTime
 
-class AppointmentEventPublisherTest {
+class ActionPlanActionPlanAppointmentEventPublisherTest {
   private val eventPublisher = mock<ApplicationEventPublisher>()
   private val locationMapper = mock<LocationMapper>()
-  private val publisher = AppointmentEventPublisher(eventPublisher, locationMapper)
+  private val publisher = ActionPlanAppointmentEventPublisher(eventPublisher, locationMapper)
 
   @BeforeEach
   fun setup() {
@@ -33,12 +33,12 @@ class AppointmentEventPublisherTest {
 
     publisher.attendanceRecordedEvent(session, false)
 
-    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    val eventCaptor = argumentCaptor<ActionPlanAppointmentEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
     val event = eventCaptor.firstValue
 
     Assertions.assertThat(event.source).isSameAs(publisher)
-    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.ATTENDANCE_RECORDED)
+    Assertions.assertThat(event.type).isSameAs(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED)
     Assertions.assertThat(event.actionPlanSession).isSameAs(session)
     Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/action-plan/123/appointments/1")
     Assertions.assertThat(event.notifyPP).isFalse
@@ -50,12 +50,12 @@ class AppointmentEventPublisherTest {
 
     publisher.behaviourRecordedEvent(appointment, true)
 
-    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    val eventCaptor = argumentCaptor<ActionPlanAppointmentEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
     val event = eventCaptor.firstValue
 
     Assertions.assertThat(event.source).isSameAs(publisher)
-    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.BEHAVIOUR_RECORDED)
+    Assertions.assertThat(event.type).isSameAs(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED)
     Assertions.assertThat(event.actionPlanSession).isSameAs(appointment)
     Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/action-plan/123/appointments/1")
     Assertions.assertThat(event.notifyPP).isTrue
@@ -71,12 +71,12 @@ class AppointmentEventPublisherTest {
 
     publisher.sessionFeedbackRecordedEvent(appointment, true)
 
-    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    val eventCaptor = argumentCaptor<ActionPlanAppointmentEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
     val event = eventCaptor.firstValue
 
     Assertions.assertThat(event.source).isSameAs(publisher)
-    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.SESSION_FEEDBACK_RECORDED)
+    Assertions.assertThat(event.type).isSameAs(ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED)
     Assertions.assertThat(event.actionPlanSession).isSameAs(appointment)
     Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/action-plan/123/appointments/1")
     Assertions.assertThat(event.notifyPP).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisherTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSes
 import java.net.URI
 import java.time.OffsetDateTime
 
-class ActionPlanActionPlanAppointmentEventPublisherTest {
+class ActionPlanAppointmentEventPublisherTest {
   private val eventPublisher = mock<ApplicationEventPublisher>()
   private val locationMapper = mock<LocationMapper>()
   private val publisher = ActionPlanAppointmentEventPublisher(eventPublisher, locationMapper)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisherTest.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
+import java.net.URI
+
+class AppointmentEventPublisherTest {
+  private val eventPublisher = mock<ApplicationEventPublisher>()
+  private val locationMapper = mock<LocationMapper>()
+  private val appointmentFactory = AppointmentFactory()
+  private val publisher = AppointmentEventPublisher(eventPublisher, locationMapper)
+
+  @BeforeEach
+  fun setup() {
+    whenever(locationMapper.getPathFromControllerMethod(any())).thenReturn("")
+    whenever(locationMapper.expandPathToCurrentRequestBaseUrl(any(), any()))
+      .thenReturn(URI.create("http://localhost/sent-referral/123/supplier-assessment"))
+  }
+
+  @Test
+  fun `builds an appointment attendance recorded event and publishes it`() {
+    val appointment = appointmentFactory.create()
+
+    publisher.attendanceRecordedEvent(appointment, false, AppointmentType.SUPPLIER_ASSESSMENT)
+
+    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    verify(eventPublisher).publishEvent(eventCaptor.capture())
+    val event = eventCaptor.firstValue
+
+    Assertions.assertThat(event.source).isSameAs(publisher)
+    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.ATTENDANCE_RECORDED)
+    Assertions.assertThat(event.appointment).isSameAs(appointment)
+    Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/sent-referral/123/supplier-assessment")
+    Assertions.assertThat(event.notifyPP).isFalse
+  }
+
+  @Test
+  fun `builds an appointment behaviour recorded event and publishes it`() {
+    val appointment = appointmentFactory.create()
+
+    publisher.behaviourRecordedEvent(appointment, true, AppointmentType.SUPPLIER_ASSESSMENT)
+
+    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    verify(eventPublisher).publishEvent(eventCaptor.capture())
+    val event = eventCaptor.firstValue
+
+    Assertions.assertThat(event.source).isSameAs(publisher)
+    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.BEHAVIOUR_RECORDED)
+    Assertions.assertThat(event.appointment).isSameAs(appointment)
+    Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/sent-referral/123/supplier-assessment")
+    Assertions.assertThat(event.notifyPP).isTrue
+  }
+
+  @Test
+  fun `builds an appointment session feedback event and publishes it`() {
+    val appointment = appointmentFactory.create()
+
+    publisher.sessionFeedbackRecordedEvent(appointment, true, AppointmentType.SUPPLIER_ASSESSMENT)
+
+    val eventCaptor = argumentCaptor<AppointmentEvent>()
+    verify(eventPublisher).publishEvent(eventCaptor.capture())
+    val event = eventCaptor.firstValue
+
+    Assertions.assertThat(event.source).isSameAs(publisher)
+    Assertions.assertThat(event.type).isSameAs(AppointmentEventType.SESSION_FEEDBACK_RECORDED)
+    Assertions.assertThat(event.appointment).isSameAs(appointment)
+    Assertions.assertThat(event.detailUrl).isEqualTo("http://localhost/sent-referral/123/supplier-assessment")
+    Assertions.assertThat(event.notifyPP).isTrue
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DynamicFrameworkContractRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DynamicFrameworkContractRepositoryTest.kt
@@ -27,17 +27,20 @@ class DynamicFrameworkContractRepositoryTest @Autowired constructor(
 
   @BeforeEach
   fun setup() {
+
+    appointmentRepository.deleteAll()
     actionPlanSessionRepository.deleteAll()
     actionPlanRepository.deleteAll()
     endOfServiceReportRepository.deleteAll()
-    appointmentRepository.deleteAll()
     supplierAssessmentRepository.deleteAll()
 
     entityManager.flush()
 
     referralRepository.deleteAll()
     interventionRepository.deleteAll()
+    dynamicFrameworkContractRepository.deleteAll()
     authUserRepository.deleteAll()
+    entityManager.flush()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceTest.kt
@@ -17,7 +17,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SERVICE_DELIVERY
@@ -40,7 +40,7 @@ internal class ActionPlanSessionsServiceTest {
   private val actionPlanRepository: ActionPlanRepository = mock()
   private val actionPlanSessionRepository: ActionPlanSessionRepository = mock()
   private val authUserRepository: AuthUserRepository = mock()
-  private val appointmentEventPublisher: AppointmentEventPublisher = mock()
+  private val actionPlanAppointmentEventPublisher: ActionPlanAppointmentEventPublisher = mock()
   private val communityAPIBookingService: CommunityAPIBookingService = mock()
   private val appointmentRepository: AppointmentRepository = mock()
   private val appointmentService: AppointmentService = mock()
@@ -50,7 +50,7 @@ internal class ActionPlanSessionsServiceTest {
 
   private val actionPlanSessionsService = ActionPlanSessionsService(
     actionPlanSessionRepository, actionPlanRepository,
-    authUserRepository, appointmentEventPublisher,
+    authUserRepository, actionPlanAppointmentEventPublisher,
     communityAPIBookingService, appointmentService, appointmentRepository,
   )
 
@@ -443,10 +443,10 @@ internal class ActionPlanSessionsServiceTest {
     actionPlanSessionsService.recordAppointmentAttendance(user, actionPlanId, 1, Attended.YES, "")
     actionPlanSessionsService.recordBehaviour(user, actionPlanId, 1, "bad", true)
 
-    actionPlanSessionsService.submitSessionFeedback(actionPlanId, 1, user)
-    verify(appointmentEventPublisher).attendanceRecordedEvent(session, false)
-    verify(appointmentEventPublisher).behaviourRecordedEvent(session, true)
-    verify(appointmentEventPublisher).sessionFeedbackRecordedEvent(session, true)
+    actionPlanSessionsService.submitSessionFeedback(actionPlanId, 1, session.actionPlan.createdBy)
+    verify(actionPlanAppointmentEventPublisher).attendanceRecordedEvent(session, false)
+    verify(actionPlanAppointmentEventPublisher).behaviourRecordedEvent(session, true)
+    verify(actionPlanAppointmentEventPublisher).sessionFeedbackRecordedEvent(session, true)
   }
 
   @Test
@@ -487,8 +487,8 @@ internal class ActionPlanSessionsServiceTest {
     actionPlanSessionsService.submitSessionFeedback(actionPlanId, 1, user)
 
     verify(actionPlanSessionRepository, atLeastOnce()).save(session)
-    verify(appointmentEventPublisher).attendanceRecordedEvent(session, true)
-    verify(appointmentEventPublisher).sessionFeedbackRecordedEvent(session, false)
+    verify(actionPlanAppointmentEventPublisher).attendanceRecordedEvent(session, true)
+    verify(actionPlanAppointmentEventPublisher).sessionFeedbackRecordedEvent(session, false)
   }
 
   @Test
@@ -505,7 +505,7 @@ internal class ActionPlanSessionsServiceTest {
     actionPlanSessionsService.submitSessionFeedback(actionPlanId, 1, user)
 
     verify(actionPlanSessionRepository, atLeastOnce()).save(session)
-    verify(appointmentEventPublisher).attendanceRecordedEvent(session, false)
-    verify(appointmentEventPublisher).sessionFeedbackRecordedEvent(session, false)
+    verify(actionPlanAppointmentEventPublisher).attendanceRecordedEvent(session, false)
+    verify(actionPlanAppointmentEventPublisher).sessionFeedbackRecordedEvent(session, false)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIActionPlanAppointmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIActionPlanAppointmentEventServiceTest.kt
@@ -6,15 +6,15 @@ import com.nhaarman.mockitokotlin2.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType.SESSION_FEEDBACK_RECORDED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.LATE
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSessionFactory
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class CommunityAPIAppointmentEventServiceTest {
+class CommunityAPIActionPlanAppointmentEventServiceTest {
 
   private val communityAPIClient = mock<CommunityAPIClient>()
 
@@ -49,7 +49,7 @@ class CommunityAPIAppointmentEventServiceTest {
     )
   }
 
-  private val appointmentEvent = AppointmentEvent(
+  private val appointmentEvent = ActionPlanAppointmentEvent(
     "source",
     SESSION_FEEDBACK_RECORDED,
     actionPlanSessionFactory.createAttended(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSes
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class NotifyAppointmentServiceTest {
+class NotifyActionPlanAppointmentServiceTest {
   private val emailSender = mock<EmailSender>()
   private val hmppsAuthService = mock<HMPPSAuthService>()
   private val actionPlanSessionFactory = ActionPlanSessionFactory()
@@ -48,8 +48,8 @@ class NotifyAppointmentServiceTest {
     )
   }
 
-  private fun notifyService(): NotifyAppointmentService {
-    return NotifyAppointmentService(
+  private fun notifyService(): NotifyActionPlanAppointmentService {
+    return NotifyActionPlanAppointmentService(
       "template",
       "template",
       "http://example.com",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
@@ -11,8 +11,8 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSender
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSessionFactory
@@ -24,8 +24,8 @@ class NotifyAppointmentServiceTest {
   private val hmppsAuthService = mock<HMPPSAuthService>()
   private val actionPlanSessionFactory = ActionPlanSessionFactory()
 
-  private fun appointmentEvent(type: AppointmentEventType, notifyPP: Boolean): AppointmentEvent {
-    return AppointmentEvent(
+  private fun appointmentEvent(type: ActionPlanAppointmentEventType, notifyPP: Boolean): ActionPlanAppointmentEvent {
+    return ActionPlanAppointmentEvent(
       "source",
       type,
       actionPlanSessionFactory.createAttended(
@@ -63,14 +63,14 @@ class NotifyAppointmentServiceTest {
   fun `appointment attendance recorded event does not send email when user details are not available`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
-      notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
+      notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, true))
     }
     verifyZeroInteractions(emailSender)
   }
 
   @Test
   fun `appointment attendance recorded event does not send email when notifyPP is false`() {
-    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, false))
+    notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, false))
     verifyZeroInteractions(emailSender)
   }
 
@@ -78,7 +78,7 @@ class NotifyAppointmentServiceTest {
   fun `appointment attendance recorded event calls email client`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
 
-    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
+    notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
@@ -90,14 +90,14 @@ class NotifyAppointmentServiceTest {
   fun `appointment behaviour recorded event does not send email when user details are not available`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
-      notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
+      notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true))
     }
     verifyZeroInteractions(emailSender)
   }
 
   @Test
   fun `appointment behaviour recorded event does not send email when notifyPP is false`() {
-    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, false))
+    notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, false))
     verifyZeroInteractions(emailSender)
   }
 
@@ -105,7 +105,7 @@ class NotifyAppointmentServiceTest {
   fun `appointment behaviour recorded event calls email client`() {
     whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
 
-    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
+    notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSender
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import java.util.UUID
+
+class NotifyAppointmentServiceTest {
+  private val emailSender = mock<EmailSender>()
+  private val hmppsAuthService = mock<HMPPSAuthService>()
+  private val appointmentFactory = AppointmentFactory()
+  private val referralFactory = ReferralFactory()
+
+  private fun appointmentEvent(type: AppointmentEventType, notifyPP: Boolean, appointmentType: AppointmentType = AppointmentType.SUPPLIER_ASSESSMENT): AppointmentEvent {
+    return AppointmentEvent(
+      "source",
+      type,
+      appointmentFactory.create(referral = referralFactory.createSent(id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"))),
+      "http://localhost:8080/appointment/42c7d267-0776-4272-a8e8-a673bfe30d0d",
+      notifyPP,
+      appointmentType
+    )
+  }
+
+  private fun notifyService(): NotifyAppointmentService {
+    return NotifyAppointmentService(
+      "template",
+      "template",
+      "http://example.com",
+      "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback",
+      emailSender,
+      hmppsAuthService,
+    )
+  }
+
+  @Test
+  fun `appointment attendance recorded event does not send email when user details are not available`() {
+    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    assertThrows<RuntimeException> {
+      notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
+    }
+    verifyZeroInteractions(emailSender)
+  }
+
+  @Test
+  fun `appointment attendance recorded event does not send email when notifyPP is false`() {
+    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, false))
+    verifyZeroInteractions(emailSender)
+  }
+
+  @Test
+  fun `appointment attendance recorded event calls email client`() {
+    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+
+    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
+    val personalisationCaptor = argumentCaptor<Map<String, String>>()
+    verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
+    Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
+    Assertions.assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("JS18726AC")
+    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/probation-practitioner/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/supplier-assessment/post-session-feedback")
+  }
+
+  @Test
+  fun `appointment behaviour recorded event does not send email when user details are not available`() {
+    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    assertThrows<RuntimeException> {
+      notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
+    }
+    verifyZeroInteractions(emailSender)
+  }
+
+  @Test
+  fun `appointment behaviour recorded event does not send email when notifyPP is false`() {
+    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, false))
+    verifyZeroInteractions(emailSender)
+  }
+
+  @Test
+  fun `appointment behaviour recorded event calls email client`() {
+    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+
+    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
+    val personalisationCaptor = argumentCaptor<Map<String, String>>()
+    verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
+    Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
+    Assertions.assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("JS18726AC")
+    Assertions.assertThat(personalisationCaptor.firstValue["sessionUrl"]).isEqualTo("http://example.com/probation-practitioner/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/supplier-assessment/post-session-feedback")
+  }
+
+  @Test
+  fun `appointment event does not send email for appointment event time service delivery`() {
+    notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, false, AppointmentType.SERVICE_DELIVERY))
+    verifyZeroInteractions(emailSender)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSAppointmentServiceTest.kt
@@ -9,8 +9,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEvent
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSessionFactory
@@ -27,9 +27,9 @@ internal class SNSAppointmentServiceTest {
     referral = ReferralFactory().createSent(id = UUID.fromString("56b40f96-0657-4e01-925c-da208a6fbcfd"))
   )
   private val now = OffsetDateTime.now()
-  private fun attendanceRecordedEvent(attendance: Attended) = AppointmentEvent(
+  private fun attendanceRecordedEvent(attendance: Attended) = ActionPlanAppointmentEvent(
     "source",
-    AppointmentEventType.ATTENDANCE_RECORDED,
+    ActionPlanAppointmentEventType.ATTENDANCE_RECORDED,
     actionPlanSessionFactory.createAttended(
       actionPlan = actionPlan,
       createdBy = actionPlan.createdBy,


### PR DESCRIPTION
## What does this pull request do?

Adds the functionality to send emails for appointment behaviour & attendance upon submission.
Create a generic NotifyAppointmentService and rename the old one too NotifyActionPlanAppointmentService. In the future both supplier assessment and action plans will use the appointment service methods

## What is the intent behind these changes?

Allows supplier assessment behaviour and attendance email to be sent.
