### PR TITLE
add new dto to return only fields that are needed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EndReferralReq
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAssignmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SelectedDesiredOutcomesDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralSummaryDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDashboardSummaryDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryFullDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SetComplexityLevelRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SupplierAssessmentDTO
@@ -99,9 +99,9 @@ class ReferralController(
   @GetMapping("/sent-referrals")
   fun getSentReferrals(
     authentication: JwtAuthenticationToken,
-  ): List<SentReferralSummaryDTO> {
+  ): List<SentReferralDashboardSummaryDTO> {
     val user = userMapper.fromToken(authentication)
-    return referralService.getSentReferralsForUser(user).map { SentReferralSummaryDTO.from(it) }
+    return referralService.getSentReferralsForUser(user).map { SentReferralDashboardSummaryDTO.from(it) }
   }
 
   @JsonView(Views.SentReferral::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDashboardSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDashboardSummaryDTO.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class SentReferralDashboardSummaryDTO(
+  val id: UUID,
+  val sentAt: OffsetDateTime,
+  val referenceNumber: String,
+  val assignedTo: AuthUserDTO?,
+  val interventionId: UUID,
+  val serviceUser: ServiceUserDTO,
+) {
+  companion object {
+    fun from(referral: Referral): SentReferralDashboardSummaryDTO {
+      return SentReferralDashboardSummaryDTO(
+        id = referral.id,
+        sentAt = referral.sentAt!!,
+        referenceNumber = referral.referenceNumber!!,
+        assignedTo = referral.currentAssignee?.let { AuthUserDTO.from(it) },
+        interventionId = referral.intervention.id,
+        serviceUser = ServiceUserDTO.from(referral.serviceUserCRN, referral.serviceUserData),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -263,4 +263,15 @@ internal class ReferralControllerTest {
       assertThat(response.endOfServiceReportCreationRequired).isTrue
     }
   }
+
+  @Test
+  fun `get all sent referrals`() {
+    val user = authUserFactory.create()
+    val token = tokenFactory.create(userID = user.id, userName = user.userName, authSource = user.authSource)
+
+    val referral = referralFactory.createSent()
+    whenever(referralService.getSentReferralsForUser(any())).thenReturn(listOf(referral))
+    val result = referralController.getSentReferrals(token)
+    assertThat(result.size).isEqualTo(1)
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Returns a new DTO from the `sent-referrals` endpoint. This will only return the fields needed for the front end dashboard.

## What is the intent behind these changes?

There are currently performance issues in loading the front end dashboard. This change hopes to be a quick fix to contribute towards helping to minimise that, by reducing the amount of extra sql calls that may be lazily loaded as part of the old DTO. Only the fields needed by the front end for this call are now returned.
