### PR TITLE
Add a native SQL path for obtaining Sent Referral Summary for Service…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
+import java.util.UUID
 
 @Component
 class ReferralAccessFilter(
@@ -14,6 +16,10 @@ class ReferralAccessFilter(
     // fixme: how do equality operators work for these types of comparisons - should we write a custom equals override
     //        that compares contract reference numbers?
     return referrals.filter { userScope.contracts.contains(it.intervention.dynamicFrameworkContract) }
+  }
+  fun serviceProviderReferralSummaries(referrals: List<ServiceProviderSentReferralSummary>, user: AuthUser): List<ServiceProviderSentReferralSummary> {
+    val userScope = serviceProviderAccessScopeMapper.fromUser(user)
+    return referrals.filter { userScope.contracts.map { contract -> contract.id }.contains(UUID.fromString(it.dynamicFrameWorkContractId)) }
   }
 
   fun probationPractitionerReferrals(referrals: List<Referral>, user: AuthUser): List<Referral> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
+import ServiceProviderSentReferralSummaryDTO
 import com.fasterxml.jackson.annotation.JsonView
 import mu.KLogging
 import org.springframework.http.HttpStatus
@@ -102,6 +103,16 @@ class ReferralController(
   ): List<SentReferralSummaryDTO> {
     val user = userMapper.fromToken(authentication)
     return referralService.getSentReferralsForUser(user).map { SentReferralSummaryDTO.from(it) }
+  }
+
+  @Deprecated(message = "This is a temporary solution to by-pass the extremely long wait times in production that occurs with /sent-referrals")
+  @JsonView(Views.SentReferral::class)
+  @GetMapping("/sent-referrals/summary/service-provider")
+  fun getServiceProviderSentReferralsSummary(
+    authentication: JwtAuthenticationToken,
+  ): List<ServiceProviderSentReferralSummaryDTO> {
+    val user = userMapper.fromToken(authentication)
+    return referralService.getServiceProviderSummaries(user).map { ServiceProviderSentReferralSummaryDTO.from(it) }
   }
 
   @JsonView(Views.SentReferral::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
@@ -1,0 +1,25 @@
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class ServiceProviderSentReferralSummaryDTO(
+  val sentAt: OffsetDateTime,
+  val referenceNumber: String,
+  val interventionTitle: String,
+  val assignedToUserName: String?,
+  val serviceUserFirstName: String?,
+  val serviceUserLastName: String?,
+) {
+  companion object {
+    fun from(sentReferralSummary: ServiceProviderSentReferralSummary): ServiceProviderSentReferralSummaryDTO {
+      return ServiceProviderSentReferralSummaryDTO(
+        sentAt = OffsetDateTime.ofInstant(sentReferralSummary.sentAt, ZoneOffset.UTC),
+        referenceNumber = sentReferralSummary.referenceNumber,
+        interventionTitle = sentReferralSummary.interventionTitle,
+        assignedToUserName = sentReferralSummary.assignedToUserName,
+        serviceUserFirstName = sentReferralSummary.serviceUserFirstName,
+        serviceUserLastName = sentReferralSummary.serviceUserLastName,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
@@ -1,8 +1,10 @@
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.UUID
 
 class ServiceProviderSentReferralSummaryDTO(
+  val referralId: UUID,
   val sentAt: OffsetDateTime,
   val referenceNumber: String,
   val interventionTitle: String,
@@ -13,6 +15,7 @@ class ServiceProviderSentReferralSummaryDTO(
   companion object {
     fun from(sentReferralSummary: ServiceProviderSentReferralSummary): ServiceProviderSentReferralSummaryDTO {
       return ServiceProviderSentReferralSummaryDTO(
+        referralId = sentReferralSummary.referralId,
         sentAt = OffsetDateTime.ofInstant(sentReferralSummary.sentAt, ZoneOffset.UTC),
         referenceNumber = sentReferralSummary.referenceNumber,
         interventionTitle = sentReferralSummary.interventionTitle,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import java.time.Instant
+
+interface ServiceProviderSentReferralSummary {
+  val sentAt: Instant
+  val referenceNumber: String
+  val interventionTitle: String
+  val dynamicFrameWorkContractId: String
+  val assignedToUserName: String?
+  val serviceUserFirstName: String?
+  val serviceUserLastName: String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
 import java.time.Instant
+import java.util.UUID
 
 interface ServiceProviderSentReferralSummary {
+  val referralId: UUID
   val sentAt: Instant
   val referenceNumber: String
   val interventionTitle: String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -17,6 +17,7 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
 			serviceUserFirstName,
 			serviceUserLastName from (	
 	select
+			cast(r.id as varchar) AS referralId,
 			cast(r.sent_at as TIMESTAMP WITH TIME ZONE) as sentAt,
 			r.reference_number as referenceNumber,
       dfc.id as dynamicFrameworkContractId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -1,12 +1,49 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
 import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
+  @Query(
+    value = """select sentAt,
+			referenceNumber,
+			assignedToUserName,
+			interventionTitle,
+			serviceUserFirstName,
+			serviceUserLastName from (	
+	select
+			cast(r.sent_at as TIMESTAMP WITH TIME ZONE) as sentAt,
+			r.reference_number as referenceNumber,
+      dfc.id as dynamicFrameworkContractId,
+			au.user_name as assignedToUserName,
+			i.title as interventionTitle,
+			rsud.first_name as serviceUserFirstName,
+			rsud.last_name as serviceUserLastName,
+			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq		
+	from referral r
+			 inner join intervention i on i.id = r.intervention_id
+			 inner join referral_service_user_data rsud on rsud.referral_id = r.id
+			 inner join dynamic_framework_contract dfc on dfc.id = i.dynamic_framework_contract_id
+			 left join dynamic_framework_contract_sub_contractor dfcsc on dfcsc.dynamic_framework_contract_id = dfc.id
+			 left join referral_assignments ra on ra.referral_id = r.id
+			 left join auth_user au on au.id = ra.assigned_to_id
+			 left join end_of_service_report eosr on eosr.referral_id = r.id
+	where
+		  r.sent_at is not null
+		  and not (r.concluded_At is not null
+			and r.end_Requested_At is not null
+			and eosr.id is null)
+		and ( dfc.prime_provider_id in :serviceProviders or dfcsc.subcontractor_provider_id in :serviceProviders )
+) a where assigned_at_desc_seq = 1""",
+    nativeQuery = true
+  )
+  fun referralSummaryForServiceProviders(serviceProviders: List<String>): List<ServiceProviderSentReferralSummary>
+
   // queries for service providers
   fun findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(providers: Iterable<ServiceProvider>): List<Referral>
   fun findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(providers: Iterable<ServiceProvider>): List<Referral>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -1,59 +1,312 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.RandomStringUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
-import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProviderFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceUserFactory
+import java.time.Instant
 import java.time.OffsetDateTime
+import javax.transaction.Transactional
 
+@Transactional
 @RepositoryTest
 class ReferralRepositoryTest @Autowired constructor(
   val entityManager: TestEntityManager,
+  val endOfServiceReportRepository: EndOfServiceReportRepository,
   val referralRepository: ReferralRepository,
+  val interventionRepository: InterventionRepository,
   val authUserRepository: AuthUserRepository,
 ) {
   private val authUserFactory = AuthUserFactory(entityManager)
   private val referralFactory = ReferralFactory(entityManager)
+  private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory(entityManager)
+  private val interventionFactory = InterventionFactory(entityManager)
+  private val serviceProviderFactory = ServiceProviderFactory(entityManager)
   private val serviceUserFactory = ServiceUserFactory(entityManager)
-  @Test
-  fun `removing a referral does not remove associated auth_user`() {
-    val user = authUserFactory.create(id = "referral_repository_test_user_id")
-    val referral = SampleData.sampleReferral("X123456", "Harmony Living", createdBy = user)
-    SampleData.persistReferral(entityManager, referral)
+  private val endOfServiceReport = EndOfServiceReportFactory(entityManager)
 
-    // check that when the referral is deleted, the user is not
-    entityManager.remove(referral)
-    assertThat(referralRepository.findByIdOrNull(referral.id)).isNull()
-    val userAfterDelete = authUserRepository.findByIdOrNull(user.id)
-    assertThat(userAfterDelete).isNotNull
-    assertThat(userAfterDelete).isEqualTo(user)
+  @Nested
+  inner class ServiceProviderSelection {
+
+    @Test
+    fun `can obtain a single referral summary using prime provider`() {
+      val referralWithPrimeSp = createReferral(true)
+      val referralWithAnotherPrimeSp = createReferral(true)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithPrimeSp.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(contains(summaries, expectedSummary(referralWithPrimeSp)))
+    }
+
+    @Test
+    fun `can obtain a single referral summary using subcontractor provider`() {
+      val referralWithSubConSp = createReferral(false)
+      val referralWithAnotherSubConSp = createReferral(false)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithSubConSp.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(contains(summaries, expectedSummary(referralWithSubConSp)))
+    }
+
+    @Test
+    fun `can obtain a multiple referral summaries as subcontractor and as prime provider`() {
+
+      val referralWithPrimeSp = createReferral(true)
+      val referralWithAnotherPrimeSp = createReferral(true)
+      val referralWithSubConSp = createReferral(false)
+      val referralWithAnotherSubConSp = createReferral(false)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithPrimeSp.serviceProvider.id, referralWithSubConSp.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(2)
+      assertThat(contains(summaries, expectedSummary(referralWithPrimeSp)))
+      assertThat(contains(summaries, expectedSummary(referralWithSubConSp)))
+    }
+
+    @Test
+    fun `cannot obtain a single referral summary when provider doesn't match`() {
+
+      val referralWithPrimeSp = createReferral(true)
+      val referralWithSubConSp = createReferral(false)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(random(5)))
+
+      assertThat(summaries.size).isEqualTo(0)
+    }
   }
 
   @Nested
-  inner class ReferralSummaryForServiceProviders {
+  inner class AssignedToReferralSelection {
+
     @Test
-    fun `can obtain a single referral summary`() {
+    fun `can determine assigned user when only one`() {
+      val referralWithSingleAssignee = createReferral(true, 1)
 
-      val user = authUserFactory.create()
-      val referral = referralFactory.createSent(assignments = listOf(ReferralAssignment(OffsetDateTime.now(), assignedBy = user, assignedTo = user)))
-      serviceUserFactory.create("firstName", "lastName", referral)
-
-      val summaries = referralRepository.referralSummaryForServiceProviders(listOf("HARMONY_LIVING"))
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithSingleAssignee.serviceProvider.id))
 
       assertThat(summaries.size).isEqualTo(1)
-      assertThat(summaries.get(0).referenceNumber).isEqualTo("JS18726AC")
-      assertThat(summaries.get(0).interventionTitle).isEqualTo("Sheffield Housing Services")
-      assertThat(summaries.get(0).assignedToUserName).isEqualTo("bernard.beaks")
-      assertThat(summaries.get(0).serviceUserFirstName).isEqualTo("firstName")
-      assertThat(summaries.get(0).serviceUserLastName).isEqualTo("lastName")
+      assertThat(contains(summaries, expectedSummary(referralWithSingleAssignee)))
+    }
+
+    @Test
+    fun `can determine latest assigned user when changed`() {
+      val referralWithChangedAssignee = createReferral(true, 2)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithChangedAssignee.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(contains(summaries, expectedSummary(referralWithChangedAssignee)))
+    }
+
+    @Test
+    fun `can obtain multiple referrals wih latest assigned`() {
+      val referralWithChangedAssignee = createReferral(true, 2)
+      val referralWithMultipleChangedAssignee = createReferral(true, 10)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithChangedAssignee.serviceProvider.id, referralWithMultipleChangedAssignee.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(2)
+      assertThat(contains(summaries, expectedSummary(referralWithChangedAssignee)))
+      assertThat(contains(summaries, expectedSummary(referralWithMultipleChangedAssignee)))
+      summaries.contains(expectedSummary(referralWithChangedAssignee))
+    }
+
+    @Test
+    fun `will not exclude referral when not assigned`() {
+      val referralWithNoAssignee = createReferral(true, 0)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithNoAssignee.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(summaries[0].assignedToUserName).isNull()
+      assertThat(contains(summaries, expectedSummary(referralWithNoAssignee)))
     }
   }
+
+  @Nested
+  inner class StatusExclusion {
+
+    @Test
+    fun `will exclude cancelled referrals`() {
+      val referral = createEndedReferral(
+        true,
+        endRequestedAt = OffsetDateTime.now(),
+        concludedAt = OffsetDateTime.now(),
+        eosR = null,
+      )
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referral.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `can obtain those requested to be ended and not concluded`() {
+      val referral = createEndedReferral(
+        true,
+        endRequestedAt = OffsetDateTime.now(),
+        concludedAt = null,
+        eosR = null,
+      )
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referral.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(contains(summaries, expectedSummary(referral)))
+    }
+
+    @Test
+    fun `can obtain prematurely or completely ended referral`() {
+      val referral = createEndedReferral(
+        true,
+        endRequestedAt = null,
+        concludedAt = OffsetDateTime.now(),
+        eosR = endOfServiceReport.create(),
+      )
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referral.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(contains(summaries, expectedSummary(referral)))
+    }
+
+    @Test
+    fun `will exclude referral if draft`() {
+      val referralWithNoAssignee = createDraftReferral(true)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf(referralWithNoAssignee.serviceProvider.id))
+
+      assertThat(summaries.size).isEqualTo(0)
+    }
+  }
+
+  private fun createReferral(
+    asPrime: Boolean,
+    numberOfAssignedUsers: Int = 1
+  ): Multiple {
+
+    val assignedUsers = mutableListOf<AuthUser>().apply {
+      repeat(numberOfAssignedUsers) { this.add(element = authUserFactory.create(random(6), random(5), random(12))) }
+    }
+
+    val serviceProvider = serviceProviderFactory.create(random(13), random(14))
+    val contract = when {
+      asPrime -> dynamicFrameworkContractFactory.create(primeProvider = serviceProvider, contractReference = random(10))
+      else -> dynamicFrameworkContractFactory.create(subcontractorProviders = setOf(serviceProvider), contractReference = random(10))
+    }
+    val intervention = interventionFactory.create(contract = contract)
+    val referral = referralFactory.createSent(
+      intervention = intervention,
+      assignments = assignedUsers.map { ReferralAssignment(OffsetDateTime.now(), assignedBy = it, assignedTo = it) }
+    )
+    val serviceUser = serviceUserFactory.create(random(15), random(16), referral)
+    return Multiple(referral.currentAssignee, serviceProvider, contract, intervention, referral, serviceUser)
+  }
+
+  private fun createEndedReferral(
+    asPrime: Boolean,
+    endRequestedAt: OffsetDateTime? = null,
+    concludedAt: OffsetDateTime? = null,
+    eosR: EndOfServiceReport? = null,
+  ): Multiple {
+
+    val user = authUserFactory.create(random(6), random(5), random(12))
+    val serviceProvider = serviceProviderFactory.create(random(13), random(14))
+    val contract = when {
+      asPrime -> dynamicFrameworkContractFactory.create(primeProvider = serviceProvider, contractReference = random(10))
+      else -> dynamicFrameworkContractFactory.create(subcontractorProviders = setOf(serviceProvider), contractReference = random(10))
+    }
+    val intervention = interventionFactory.create(contract = contract)
+    val referral = referralFactory.createEnded(
+      intervention = intervention,
+      assignments = listOf(ReferralAssignment(OffsetDateTime.now(), assignedBy = user, assignedTo = user)),
+      endRequestedAt = endRequestedAt,
+      concludedAt = concludedAt,
+      endOfServiceReport = eosR
+    )
+    val serviceUser = serviceUserFactory.create(random(15), random(16), referral)
+    return Multiple(referral.currentAssignee, serviceProvider, contract, intervention, referral, serviceUser)
+  }
+
+  private fun createDraftReferral(
+    asPrime: Boolean
+  ): Multiple {
+
+    val serviceProvider = serviceProviderFactory.create(random(13), random(14))
+    val contract = when {
+      asPrime -> dynamicFrameworkContractFactory.create(primeProvider = serviceProvider, contractReference = random(10))
+      else -> dynamicFrameworkContractFactory.create(subcontractorProviders = setOf(serviceProvider), contractReference = random(10))
+    }
+    val intervention = interventionFactory.create(contract = contract)
+    val referral = referralFactory.createDraft(intervention = intervention)
+    val serviceUser = serviceUserFactory.create(random(15), random(16), referral)
+    return Multiple(referral.currentAssignee, serviceProvider, contract, intervention, referral, serviceUser)
+  }
+
+  private fun random(length: Int): String {
+    return RandomStringUtils.randomAlphabetic(length)
+  }
+
+  private fun contains(summaries: List<ServiceProviderSentReferralSummary>, summary: Summary): Boolean {
+    return summaries.any {
+      it.sentAt == summary.sentAt &&
+        it.referenceNumber == summary.referenceNumber &&
+        it.interventionTitle == summary.interventionTitle &&
+        it.dynamicFrameWorkContractId == summary.dynamicFrameWorkContractId &&
+        it.assignedToUserName == summary.assignedToUserName &&
+        it.serviceUserFirstName == summary.serviceUserFirstName &&
+        it.serviceUserLastName == summary.serviceUserLastName
+    }
+  }
+
+  private fun expectedSummary(referral: Multiple) =
+    Summary(
+      referral.referral.sentAt!!.toInstant(),
+      referral.referral.referenceNumber!!,
+      referral.intervention.title,
+      referral.contract.contractReference,
+      referral.referral.currentAssignee?.id,
+      referral.serviceUser.firstName,
+      referral.serviceUser.lastName
+    )
 }
+
+data class Multiple(
+  val user: AuthUser?,
+  val serviceProvider: ServiceProvider,
+  val contract: DynamicFrameworkContract,
+  val intervention: Intervention,
+  val referral: Referral,
+  val serviceUser: ServiceUserData
+)
+
+data class Summary(
+  override val sentAt: Instant,
+  override val referenceNumber: String,
+  override val interventionTitle: String,
+  override val dynamicFrameWorkContractId: String,
+  override val assignedToUserName: String?,
+  override val serviceUserFirstName: String?,
+  override val serviceUserLastName: String?
+) : ServiceProviderSentReferralSummary

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProvid
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceUserFactory
 import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.UUID
 import javax.transaction.Transactional
 
 @Transactional
@@ -286,7 +287,8 @@ class ReferralRepositoryTest @Autowired constructor(
 
   private fun contains(summaries: List<ServiceProviderSentReferralSummary>, summary: Summary): Boolean {
     return summaries.any {
-      it.sentAt == summary.sentAt &&
+      it.referralId == summary.referralId &&
+        it.sentAt == summary.sentAt &&
         it.referenceNumber == summary.referenceNumber &&
         it.interventionTitle == summary.interventionTitle &&
         it.dynamicFrameWorkContractId == summary.dynamicFrameWorkContractId &&
@@ -298,6 +300,7 @@ class ReferralRepositoryTest @Autowired constructor(
 
   private fun expectedSummary(referral: Referral) =
     Summary(
+      referral.id,
       referral.sentAt!!.toInstant(),
       referral.referenceNumber!!,
       referral.intervention.title,
@@ -309,6 +312,7 @@ class ReferralRepositoryTest @Autowired constructor(
 }
 
 data class Summary(
+  override val referralId: UUID,
   override val sentAt: Instant,
   override val referenceNumber: String,
   override val interventionTitle: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -1,13 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.data.repository.findByIdOrNull
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceUserFactory
+import java.time.OffsetDateTime
 
 @RepositoryTest
 class ReferralRepositoryTest @Autowired constructor(
@@ -16,7 +21,8 @@ class ReferralRepositoryTest @Autowired constructor(
   val authUserRepository: AuthUserRepository,
 ) {
   private val authUserFactory = AuthUserFactory(entityManager)
-
+  private val referralFactory = ReferralFactory(entityManager)
+  private val serviceUserFactory = ServiceUserFactory(entityManager)
   @Test
   fun `removing a referral does not remove associated auth_user`() {
     val user = authUserFactory.create(id = "referral_repository_test_user_id")
@@ -25,9 +31,29 @@ class ReferralRepositoryTest @Autowired constructor(
 
     // check that when the referral is deleted, the user is not
     entityManager.remove(referral)
-    Assertions.assertThat(referralRepository.findByIdOrNull(referral.id)).isNull()
+    assertThat(referralRepository.findByIdOrNull(referral.id)).isNull()
     val userAfterDelete = authUserRepository.findByIdOrNull(user.id)
-    Assertions.assertThat(userAfterDelete).isNotNull
-    Assertions.assertThat(userAfterDelete).isEqualTo(user)
+    assertThat(userAfterDelete).isNotNull
+    assertThat(userAfterDelete).isEqualTo(user)
+  }
+
+  @Nested
+  inner class ReferralSummaryForServiceProviders {
+    @Test
+    fun `can obtain a single referral summary`() {
+
+      val user = authUserFactory.create()
+      val referral = referralFactory.createSent(assignments = listOf(ReferralAssignment(OffsetDateTime.now(), assignedBy = user, assignedTo = user)))
+      serviceUserFactory.create("firstName", "lastName", referral)
+
+      val summaries = referralRepository.referralSummaryForServiceProviders(listOf("HARMONY_LIVING"))
+
+      assertThat(summaries.size).isEqualTo(1)
+      assertThat(summaries.get(0).referenceNumber).isEqualTo("JS18726AC")
+      assertThat(summaries.get(0).interventionTitle).isEqualTo("Sheffield Housing Services")
+      assertThat(summaries.get(0).assignedToUserName).isEqualTo("bernard.beaks")
+      assertThat(summaries.get(0).serviceUserFirstName).isEqualTo("firstName")
+      assertThat(summaries.get(0).serviceUserLastName).isEqualTo("lastName")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ServiceUserFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ServiceUserFactory.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
+
+class ServiceUserFactory(em: TestEntityManager? = null) : EntityFactory(em) {
+  private val referralFactory = ReferralFactory(em)
+  fun create(
+    firstName: String? = null,
+    lastName: String? = null,
+    referral: Referral = referralFactory.createSent()
+  ): ServiceUserData {
+    return save(
+      ServiceUserData(
+        firstName = firstName,
+        lastName = lastName,
+        referral = referral,
+        referralID = referral.id
+      )
+    )
+  }
+}


### PR DESCRIPTION
## What does this pull request do?
Provides a quicker retrieval of SentReferral summary details to be showed on the dashboard for service providers.

## What is the intent behind these changes?

Some users with a lot of referrals are experiencing timeouts. We believe this is caused by too many SQL queries being called for a single request. We're aiming to reduce this request to less than a second in order to stop timeout issues.

### Note

This is a temporarily solution to mitigate issues with production which calls upto a 1000 subquries when fetching SentReferrals for the dashboard.
We suspect that a complete solution will involve pagination.