### PR TITLE
Use service provider id rather than name for native query to collect …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -131,7 +131,7 @@ class ReferralService(
   private fun getSentReferralSummariesForServiceProviderUser(user: AuthUser): List<ServiceProviderSentReferralSummary> {
     val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
 
-    val referralSummaries = referralRepository.referralSummaryForServiceProviders(serviceProviders = serviceProviders.map { serviceProvider -> serviceProvider.name })
+    val referralSummaries = referralRepository.referralSummaryForServiceProviders(serviceProviders = serviceProviders.map { serviceProvider -> serviceProvider.id })
     return referralAccessFilter.serviceProviderReferralSummaries(referralSummaries, user)
   }
 


### PR DESCRIPTION
…referrals summary for sp user. This is used for the sp user dashboard

## What does this pull request do?
Uses service provide id (not name) to search for referrals.

## What is the intent behind these changes?
To ensure dashboards return correct data