### PR TITLE
Use service provider id rather than name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
   @Query(
-    value = """select sentAt,
+    value = """select referralId, sentAt,
 			referenceNumber,
 			assignedToUserName,
 			interventionTitle,
@@ -28,7 +28,7 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
 			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq		
 	from referral r
 			 inner join intervention i on i.id = r.intervention_id
-			 inner join referral_service_user_data rsud on rsud.referral_id = r.id
+			 left join referral_service_user_data rsud on rsud.referral_id = r.id
 			 inner join dynamic_framework_contract dfc on dfc.id = i.dynamic_framework_contract_id
 			 left join dynamic_framework_contract_sub_contractor dfcsc on dfcsc.dynamic_framework_contract_id = dfc.id
 			 left join referral_assignments ra on ra.referral_id = r.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -131,7 +131,7 @@ class ReferralService(
   private fun getSentReferralSummariesForServiceProviderUser(user: AuthUser): List<ServiceProviderSentReferralSummary> {
     val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
 
-    val referralSummaries = referralRepository.referralSummaryForServiceProviders(serviceProviders = serviceProviders.map { serviceProvider -> serviceProvider.name })
+    val referralSummaries = referralRepository.referralSummaryForServiceProviders(serviceProviders = serviceProviders.map { serviceProvider -> serviceProvider.id })
     return referralAccessFilter.serviceProviderReferralSummaries(referralSummaries, user)
   }
 


### PR DESCRIPTION
Use service provider id rather than name for native query to collect referrals summary for sp user. This is used for the sp user dashboard

