### PR TITLE
Handle UUIDs between native query and endpoint responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
@@ -15,7 +15,7 @@ class ServiceProviderSentReferralSummaryDTO(
   companion object {
     fun from(sentReferralSummary: ServiceProviderSentReferralSummary): ServiceProviderSentReferralSummaryDTO {
       return ServiceProviderSentReferralSummaryDTO(
-        referralId = sentReferralSummary.referralId,
+        referralId = UUID.fromString(sentReferralSummary.referralId),
         sentAt = OffsetDateTime.ofInstant(sentReferralSummary.sentAt, ZoneOffset.UTC),
         referenceNumber = sentReferralSummary.referenceNumber,
         interventionTitle = sentReferralSummary.interventionTitle,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
 import java.time.Instant
-import java.util.UUID
 
 interface ServiceProviderSentReferralSummary {
-  val referralId: UUID
+  val referralId: String
   val sentAt: Instant
   val referenceNumber: String
   val interventionTitle: String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -10,17 +10,20 @@ import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
   @Query(
-    value = """select referralId, sentAt,
+    value = """select 
+      referralId, 
+      sentAt,
 			referenceNumber,
-			assignedToUserName,
 			interventionTitle,
+      dynamicFrameworkContractId,
+			assignedToUserName,
 			serviceUserFirstName,
 			serviceUserLastName from (	
 	select
 			cast(r.id as varchar) AS referralId,
 			cast(r.sent_at as TIMESTAMP WITH TIME ZONE) as sentAt,
 			r.reference_number as referenceNumber,
-      dfc.id as dynamicFrameworkContractId,
+      cast(dfc.id as varchar) as dynamicFrameworkContractId,
 			au.user_name as assignedToUserName,
 			i.title as interventionTitle,
 			rsud.first_name as serviceUserFirstName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 
 interface ReferralRepository : JpaRepository<Referral, UUID> {
   @Query(
-    value = """select sentAt,
+    value = """select referralId, sentAt,
 			referenceNumber,
 			assignedToUserName,
 			interventionTitle,
@@ -28,7 +28,7 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
 			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq		
 	from referral r
 			 inner join intervention i on i.id = r.intervention_id
-			 inner join referral_service_user_data rsud on rsud.referral_id = r.id
+			 left join referral_service_user_data rsud on rsud.referral_id = r.id
 			 inner join dynamic_framework_contract dfc on dfc.id = i.dynamic_framework_contract_id
 			 left join dynamic_framework_contract_sub_contractor dfcsc on dfcsc.dynamic_framework_contract_id = dfc.id
 			 left join referral_assignments ra on ra.referral_id = r.id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -131,7 +131,7 @@ class ReferralService(
   private fun getSentReferralSummariesForServiceProviderUser(user: AuthUser): List<ServiceProviderSentReferralSummary> {
     val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
 
-    val referralSummaries = referralRepository.referralSummaryForServiceProviders(serviceProviders = serviceProviders.map { serviceProvider -> serviceProvider.name })
+    val referralSummaries = referralRepository.referralSummaryForServiceProviders(serviceProviders = serviceProviders.map { serviceProvider -> serviceProvider.id })
     return referralAccessFilter.serviceProviderReferralSummaries(referralSummaries, user)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/GetServiceProviderReferralsSummaryEndPoint.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/GetServiceProviderReferralsSummaryEndPoint.kt
@@ -1,0 +1,209 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.authorization
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.mock.mockito.MockBean
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIOffenderService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
+
+class GetServiceProviderReferralsSummaryEndPoint : IntegrationTestBase() {
+  @MockBean
+  lateinit var mockHmppsAuthService: HMPPSAuthService
+
+  @MockBean lateinit var mockCommunityAPIOffenderService: CommunityAPIOffenderService
+
+  private lateinit var requestFactory: RequestFactory
+
+  private val tokenFactory = JwtTokenFactory()
+
+  @BeforeEach
+  fun initRequestBuilder() {
+    requestFactory = RequestFactory(webTestClient, setupAssistant)
+  }
+
+  private fun setUserGroups(user: AuthUser, groups: List<String>?) {
+    whenever(mockHmppsAuthService.getUserGroups(user)).thenReturn(groups)
+  }
+
+  private fun createSentReferral(contract: DynamicFrameworkContract): Referral {
+    return setupAssistant.createSentReferral(intervention = setupAssistant.createIntervention(dynamicFrameworkContract = contract))
+  }
+
+  private fun createEncodedTokenForUser(user: AuthUser): String {
+    return tokenFactory.createEncodedToken(userID = user.id, userName = user.userName, authSource = user.authSource)
+  }
+
+  @Test
+  fun `sp user works for prime provider and has all required contract groups`() {
+    val user = setupAssistant.createSPUser()
+
+    setUserGroups(
+      user,
+      listOf(
+        "INT_SP_HARMONY_LIVING",
+        "INT_CR_0001",
+        "INT_CR_0002",
+      )
+    )
+
+    listOf(
+      setupAssistant.createDynamicFrameworkContract(
+        contractReference = "0001",
+        primeProviderId = "HARMONY_LIVING",
+        subContractorServiceProviderIds = emptySet(),
+      ),
+      setupAssistant.createDynamicFrameworkContract(
+        contractReference = "0002",
+        primeProviderId = "HARMONY_LIVING",
+        subContractorServiceProviderIds = emptySet(),
+      )
+    ).forEach {
+      createSentReferral(it)
+    }
+
+    val token = createEncodedTokenForUser(user)
+    var response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token).exchange()
+    response.expectStatus().is2xxSuccessful
+    response.expectBody().jsonPath("$.length()").isEqualTo(2)
+  }
+
+  @Test
+  fun `sp user works for prime and subcontractor providers and has all required contract groups`() {
+    val user = setupAssistant.createSPUser()
+
+    setUserGroups(
+      user,
+      listOf(
+        "INT_SP_HOME_TRUST",
+        "INT_CR_0001",
+        "INT_CR_0002",
+      )
+    )
+
+    listOf(
+      setupAssistant.createDynamicFrameworkContract(
+        contractReference = "0001",
+        primeProviderId = "HARMONY_LIVING",
+        subContractorServiceProviderIds = setOf("HOME_TRUST"),
+      ),
+      setupAssistant.createDynamicFrameworkContract(
+        contractReference = "0002",
+        primeProviderId = "HOME_TRUST",
+        subContractorServiceProviderIds = emptySet(),
+      )
+    ).forEach {
+      createSentReferral(it)
+    }
+
+    val token = createEncodedTokenForUser(user)
+    var response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token).exchange()
+    response.expectStatus().is2xxSuccessful
+    response.expectBody().jsonPath("$.length()").isEqualTo(2)
+  }
+
+  @Test
+  fun `sp user works for prime provider but is missing a required contract group`() {
+    val user = setupAssistant.createSPUser()
+
+    setUserGroups(
+      user,
+      listOf(
+        "INT_SP_HOME_TRUST",
+        "INT_CR_0003",
+      )
+    )
+
+    listOf(
+      setupAssistant.createDynamicFrameworkContract(
+        contractReference = "0001",
+        primeProviderId = "HARMONY_LIVING",
+        subContractorServiceProviderIds = setOf("HOME_TRUST"),
+      ),
+      setupAssistant.createDynamicFrameworkContract(
+        contractReference = "0002",
+        primeProviderId = "HOME_TRUST",
+        subContractorServiceProviderIds = emptySet(),
+      )
+    ).forEach {
+      createSentReferral(it)
+    }
+
+    // valid contract for the user - but no referrals
+    setupAssistant.createDynamicFrameworkContract(
+      contractReference = "0003",
+      primeProviderId = "HOME_TRUST",
+      subContractorServiceProviderIds = emptySet(),
+    )
+
+    val token = createEncodedTokenForUser(user)
+    var response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token).exchange()
+    response.expectStatus().is2xxSuccessful
+    response.expectBody().jsonPath("$.length()").isEqualTo(0)
+  }
+
+  @Test
+  fun `sp user has no valid provider or contract groups`() {
+    val user = setupAssistant.createSPUser()
+
+    setUserGroups(
+      user,
+      listOf(
+        "INT_SP_HOME_TRUST",
+        "INT_CR_0999",
+      )
+    )
+
+    val token = createEncodedTokenForUser(user)
+    val response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token).exchange()
+    response.expectStatus().isForbidden
+    response.expectBody().json(
+      """
+      {"accessErrors": [
+      "unidentified provider 'HOME_TRUST': group does not exist in the reference data",
+      "unidentified contract '0999': group does not exist in the reference data",
+      "no valid service provider groups associated with user",
+      "no valid contract groups associated with user"
+      ]}
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `nomis users can't access sent referrals`() {
+    setupAssistant.createSentReferral()
+    val token = tokenFactory.createEncodedToken("123456", "nomis", "tom")
+
+    val response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token).exchange()
+    response.expectStatus().isForbidden
+    response.expectBody().json(
+      """
+      {"accessErrors": ["logins from nomis are not supported"]}
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `users not found in hmpps auth can't access sent referrals'`() {
+    val user = setupAssistant.createSPUser()
+    setUserGroups(user, null)
+
+    val referral = setupAssistant.createSentReferral()
+    val token = createEncodedTokenForUser(user)
+
+    val response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token, referral.id.toString()).exchange()
+    response.expectStatus().isForbidden
+    response.expectBody().json(
+      """
+      {"accessErrors": [
+      "cannot find user in hmpps auth"
+      ]}
+      """.trimIndent()
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
@@ -19,6 +19,7 @@ enum class Request {
   EndSentReferral,
   GetDraftReferrals,
   GetSentReferrals,
+  GetServiceProviderReferralsSummary,
 }
 
 class RequestFactory(private val webTestClient: WebTestClient, private val setupAssistant: SetupAssistant) {
@@ -44,6 +45,7 @@ class RequestFactory(private val webTestClient: WebTestClient, private val setup
 
       Request.GetDraftReferrals -> webTestClient.get().uri("/draft-referrals")
       Request.GetSentReferrals -> webTestClient.get().uri("/sent-referrals")
+      Request.GetServiceProviderReferralsSummary -> webTestClient.get().uri("/sent-referrals/summary/service-provider")
     }
 
     return if (token != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
@@ -35,6 +35,32 @@ class ReferralContracts(private val setupAssistant: SetupAssistant) {
     setupAssistant.fillReferralFields(referral)
   }
 
+  @State("There is a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 with an assigned user")
+  fun `create a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 with an assigned user`() {
+    setupAssistant.createAssignedReferral(
+      id = UUID.fromString("81d754aa-d868-4347-9c0f-50690773014e"),
+      interventionTitle = "Accommodation Services - West Midlands",
+      serviceProviderId = "HAPPY_LIVING",
+      sentAt = OffsetDateTime.parse("2021-01-26T13:00:00.000000Z"),
+      referenceNumber = "ABCABCA1",
+      assignedToUsername = "bernard.beaks",
+      serviceUserFirstName = "George",
+      serviceUserLastName = "Michael",
+    )
+  }
+
+  @State("There is a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 without an assigned user")
+  fun `create a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 without an assigned user`() {
+    setupAssistant.createAssignedReferral(
+      id = UUID.fromString("81d754aa-d868-4347-9c0f-50690773014e"),
+      interventionTitle = "Accommodation Services - West Midlands",
+      serviceProviderId = "HAPPY_LIVING",
+      sentAt = OffsetDateTime.parse("2021-01-26T13:00:00.000000Z"),
+      referenceNumber = "ABCABCA1",
+      serviceUserLastName = "Michael",
+    )
+  }
+
   @State(
     "There is an existing sent referral with ID of 400be4c6-1aa4-4f52-ae86-cbd5d23309bf and it is unassigned",
     "There are some existing sent referrals sent by a probation practitioner user",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
@@ -38,7 +38,7 @@ class ReferralContracts(private val setupAssistant: SetupAssistant) {
   @State("There is a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 with an assigned user")
   fun `create a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 with an assigned user`() {
     setupAssistant.createAssignedReferral(
-      id = UUID.fromString("81d754aa-d868-4347-9c0f-50690773014e"),
+      id = UUID.fromString("4afb07a0-e50b-490c-a8c1-c858d5a1e912"),
       interventionTitle = "Accommodation Services - West Midlands",
       serviceProviderId = "HAPPY_LIVING",
       sentAt = OffsetDateTime.parse("2021-01-26T13:00:00.000000Z"),
@@ -49,14 +49,15 @@ class ReferralContracts(private val setupAssistant: SetupAssistant) {
     )
   }
 
-  @State("There is a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 without an assigned user")
-  fun `create a sent referral with ID 4afb07a0-e50b-490c-a8c1-c858d5a1e912 without an assigned user`() {
+  @State("There is a sent referral with ID dc94fbd6-354b-4edc-863b-cffc8358f1ec without an assigned user")
+  fun `create a sent referral with ID dc94fbd6-354b-4edc-863b-cffc8358f1ec without an assigned user`() {
     setupAssistant.createAssignedReferral(
-      id = UUID.fromString("81d754aa-d868-4347-9c0f-50690773014e"),
+      id = UUID.fromString("dc94fbd6-354b-4edc-863b-cffc8358f1ec"),
       interventionTitle = "Accommodation Services - West Midlands",
       serviceProviderId = "HAPPY_LIVING",
       sentAt = OffsetDateTime.parse("2021-01-26T13:00:00.000000Z"),
       referenceNumber = "ABCABCA1",
+      serviceUserFirstName = "George",
       serviceUserLastName = "Michael",
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -594,7 +594,7 @@ class ReferralServiceTest @Autowired constructor(
 
       val result = referralService.getServiceProviderSummaries(multiSubUser)
       assertThat(result.size).isEqualTo(5)
-      val referralIds = result.map { summary -> summary.referralId }
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
       assertThat(referralIds).doesNotContain(noAccess.id)
       assertThat(referralIds).containsAll(listOf(primeRef1.id, primeRef2.id, primeAndSubRef.id, refWithAllProvidersBeingSubs.id, subRef.id))
     }
@@ -622,7 +622,7 @@ class ReferralServiceTest @Autowired constructor(
 
       val user = userWithProviders(listOf(provider))
       val result = referralService.getServiceProviderSummaries(user)
-      val referralIds = result.map { summary -> summary.referralId }
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
       assertThat(referralIds).containsExactlyInAnyOrder(refLive.id, refEndedEarly.id)
       assertThat(referralIds).doesNotContain(refCancelled.id)
     }


### PR DESCRIPTION
## What does this pull request do?

Convert UUIDs to UUIDs in the API presentation layer.

## What is the intent behind these changes?

Using UUIDs in native queries is weird; returning text values and converting them to UUIDs works.