### PR TITLE
Added hmpps auth mock for SP user pact tests.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -188,14 +188,16 @@ class SetupAssistant(
     val contractType = contractTypes["ACC"]!!
     val region = npsRegions['C']!!
 
-    val primeProvider = serviceProviderRepository.save(serviceProviderFactory.create(id = serviceProviderId))
+    var contract = dynamicFrameworkContract
 
-    val contract = dynamicFrameworkContract
-      ?: createDynamicFrameworkContract(
+    if (contract == null) {
+      val primeProvider = serviceProviderRepository.save(serviceProviderFactory.create(id = serviceProviderId))
+      contract = createDynamicFrameworkContract(
         contractType = contractType,
         primeProviderId = primeProvider.id,
         npsRegion = region,
       )
+    }
 
     return interventionRepository.save(interventionFactory.create(id = id, contract = contract, title = interventionTitle))
   }
@@ -333,7 +335,16 @@ class SetupAssistant(
     serviceUserFirstName: String? = null,
     serviceUserLastName: String,
   ): Referral {
-    val intervention = createIntervention(interventionTitle = interventionTitle, serviceProviderId = serviceProviderId)
+    val contractType = contractTypes["ACC"]!!
+    val region = npsRegions['C']!!
+    val primeProvider = serviceProviderRepository.save(serviceProviderFactory.create(id = serviceProviderId))
+    val dynamicFrameworkContract = createDynamicFrameworkContract(
+      contractReference = "PACT_TEST",
+      contractType = contractType,
+      primeProviderId = primeProvider.id,
+      npsRegion = region,
+    )
+    val intervention = createIntervention(interventionTitle = interventionTitle, serviceProviderId = serviceProviderId, dynamicFrameworkContract = dynamicFrameworkContract)
     val ppUser = createPPUser()
     val spUser = if (assignedToUsername != null) createSPUser(assignedToUsername) else null
     val referral = referralRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
@@ -44,6 +44,9 @@ class PactTest : IntegrationTestBase() {
     whenever(communityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any()))
       .thenReturn(ServiceUserAccessResult(true, emptyList()))
 
+    // required for SP user
+    whenever(hmppsAuthService.getUserGroups(any())).thenReturn(listOf("INT_SP_HAPPY_LIVING", "INT_CR_PACT_TEST"))
+
     context.addStateChangeHandlers(
       ActionPlanContracts(setupAssistant),
       InterventionContracts(setupAssistant),


### PR DESCRIPTION
Added hmpps auth mock for SP user pact tests. Hmpps.getUserGroups now returns INT_SP_HAPPY_LIVING and INT_CR_PACT_TEST as default.

This will require creating a contract with reference PACT_TEST and prime provider INT_SP_HAPPY_LIVING.
