### PR TITLE
Fix broken pact tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -357,6 +357,8 @@ class SetupAssistant(
       )
     )
     val serviceUser = serviceUserFactory.create(firstName = serviceUserFirstName, lastName = serviceUserLastName, referral = referral)
+    referral.serviceUserData = serviceUser
+    referralRepository.save(referral)
     return referral
   }
 


### PR DESCRIPTION
The service user details need to be presisted along with the referral object in order for a link to be created between the two tables
