### PR TITLE
IC-2063 send PP emails to delius responsible officer instead of referral sender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -40,6 +40,8 @@ class ValidationError(override val message: String, val errors: List<FieldError>
 
 class AccessError(val user: AuthUser, override val message: String, val errors: List<String>) : RuntimeException(message)
 
+class InvalidAssumptionError(assumption: String) : RuntimeException("assumption proved invalid: $assumption")
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
   val status: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -91,11 +91,6 @@ class Referral(
   @OneToOne(mappedBy = "referral") @Fetch(JOIN) var endOfServiceReport: EndOfServiceReport? = null,
   @OneToOne(mappedBy = "referral") @Fetch(JOIN) var supplierAssessment: SupplierAssessment? = null,
 ) {
-  fun getResponsibleProbationPractitioner(): AuthUser {
-    // fixme: should this sentBy or createdBy?
-    return createdBy
-  }
-
   fun cancelled(): Boolean = concludedAt != null && endRequestedAt != null && endOfServiceReport == null
 
   val currentActionPlan: ActionPlan?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.InvalidAssumptionError
+
+@Service
+class TelemetryService(
+  private val telemetryClient: TelemetryClient,
+) {
+  fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap(), recoverable: Boolean = true) {
+    telemetryClient.trackEvent(
+      "InterventionsInvalidAssumption",
+      mapOf("assumption" to assumption).plus(information),
+      null
+    )
+
+    if (!recoverable) {
+      throw InvalidAssumptionError(assumption)
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,6 +110,7 @@ community-api:
     offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"
     managed-offenders: "/secure/staff/staffIdentifier/{staffIdentifier}/managedOffenders"
     staff-details: "/secure/staff/username/{username}"
+    offender-managers: "/secure/offenders/crn/{crn}/allOffenderManagers"
   appointments:
     bookings:
       enabled: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 
 class NotifyActionPlanAppointmentServiceTest {
   private val emailSender = mock<EmailSender>()
-  private val hmppsAuthService = mock<HMPPSAuthService>()
+  private val referralService = mock<ReferralService>()
   private val actionPlanSessionFactory = ActionPlanSessionFactory()
 
   private fun appointmentEvent(type: ActionPlanAppointmentEventType, notifyPP: Boolean): ActionPlanAppointmentEvent {
@@ -55,13 +55,13 @@ class NotifyActionPlanAppointmentServiceTest {
       "http://example.com",
       "/pp/action-plan/{id}/appointment/sessionNumber/{sessionNumber}/feedback",
       emailSender,
-      hmppsAuthService,
+      referralService,
     )
   }
 
   @Test
   fun `appointment attendance recorded event does not send email when user details are not available`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
       notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, true))
     }
@@ -76,7 +76,7 @@ class NotifyActionPlanAppointmentServiceTest {
 
   @Test
   fun `appointment attendance recorded event calls email client`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ContactableProbationPractitioner("abc", "abc@abc.com"))
 
     notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -88,7 +88,7 @@ class NotifyActionPlanAppointmentServiceTest {
 
   @Test
   fun `appointment behaviour recorded event does not send email when user details are not available`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
       notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true))
     }
@@ -103,7 +103,7 @@ class NotifyActionPlanAppointmentServiceTest {
 
   @Test
   fun `appointment behaviour recorded event calls email client`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ContactableProbationPractitioner("abc", "abc@abc.com"))
 
     notifyService().onApplicationEvent(appointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 
 class NotifyAppointmentServiceTest {
   private val emailSender = mock<EmailSender>()
-  private val hmppsAuthService = mock<HMPPSAuthService>()
+  private val referralService = mock<ReferralService>()
   private val appointmentFactory = AppointmentFactory()
   private val referralFactory = ReferralFactory()
 
@@ -44,13 +44,13 @@ class NotifyAppointmentServiceTest {
       "/probation-practitioner/referrals/{id}/progress",
       "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback",
       emailSender,
-      hmppsAuthService,
+      referralService,
     )
   }
 
   @Test
   fun `appointment attendance recorded event does not send email when user details are not available`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
       notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
     }
@@ -65,7 +65,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment attendance recorded event calls email client`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ContactableProbationPractitioner("abc", "abc@abc.com"))
 
     notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -77,7 +77,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment behaviour recorded event does not send email when user details are not available`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
       notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
     }
@@ -92,7 +92,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment behaviour recorded event calls email client`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ContactableProbationPractitioner("abc", "abc@abc.com"))
 
     notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -110,7 +110,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment scheduled event sends email to pp`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenReturn(UserDetail("abc", "abc@abc.com"))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ContactableProbationPractitioner("abc", "abc@abc.com"))
 
     notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.SCHEDULED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyEndOfServiceReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyEndOfServiceReportTest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 
 class NotifyEndOfServiceReportTest {
   private val emailSender = mock<EmailSender>()
-  private val hmppsAuthService = mock<HMPPSAuthService>()
+  private val referralService = mock<ReferralService>()
   private val endOfServiceReportFactory = EndOfServiceReportFactory()
 
   private val endOfServiceReportSubmittedEvent = EndOfServiceReportEvent(
@@ -36,13 +36,13 @@ class NotifyEndOfServiceReportTest {
       "http://example.com",
       "/end-of-service-report/{id}",
       emailSender,
-      hmppsAuthService,
+      referralService,
     )
   }
 
   @Test
   fun `end of service report submitted event does not send email when user details are not available`() {
-    whenever(hmppsAuthService.getUserDetail(any())).thenThrow(RuntimeException::class.java)
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenThrow(RuntimeException::class.java)
     assertThrows<RuntimeException> {
       notifyService().onApplicationEvent(endOfServiceReportSubmittedEvent)
     }
@@ -51,8 +51,8 @@ class NotifyEndOfServiceReportTest {
 
   @Test
   fun `end of service report submitted event generates valid url and sends an email`() {
-    whenever(hmppsAuthService.getUserDetail(any()))
-      .thenReturn(UserDetail("abc", "abc@abc.abc"))
+    whenever(referralService.getResponsibleProbationPractitioner(any()))
+      .thenReturn(ContactableProbationPractitioner("abc", "abc@abc.abc"))
 
     notifyService().onApplicationEvent(endOfServiceReportSubmittedEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -95,6 +95,8 @@ class ReferralServiceTest @Autowired constructor(
   private val assessRisksAndNeedsService: RisksAndNeedsService = mock()
   private val communityAPIOffenderService: CommunityAPIOffenderService = mock()
   private val supplierAssessmentService: SupplierAssessmentService = mock()
+  private val hmppsAuthService: HMPPSAuthService = mock()
+  private val telemetryService: TelemetryService = mock()
 
   private val referralService = ReferralService(
     referralRepository,
@@ -115,6 +117,8 @@ class ReferralServiceTest @Autowired constructor(
     assessRisksAndNeedsService,
     communityAPIOffenderService,
     supplierAssessmentService,
+    hmppsAuthService,
+    telemetryService,
   )
 
   // reset before each test


### PR DESCRIPTION
## What does this pull request do?

send PP emails to delius responsible officer instead of referral sender.

there has to be a bunch of defensive code in here to handle cases where RO names or email addresses are missing. we are waiting on info from the business about how to handle these cases (i.e. do we fall back to referral sender)

## What is the intent behind these changes?

get the emails to the most relevent PPs

## Probation context

We are told that people-on-probation (newer term for service users) can be managed by different responsible officers over time. This might be due to workload management of these officers, or other factors. To ensure we and our service providers contact the _current_ person, we need to use the "responsible officer" for a person-on-probation.

We are assuming there's exactly one on record in Delius.