### PR TITLE
Add superseded flag to assignments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralAssignment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralAssignment.kt
@@ -11,4 +11,5 @@ class ReferralAssignment(
   val assignedAt: OffsetDateTime,
   @ManyToOne @Fetch(FetchMode.JOIN) val assignedBy: AuthUser,
   @ManyToOne @Fetch(FetchMode.JOIN) val assignedTo: AuthUser,
+  var superseded: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -98,6 +98,7 @@ class ReferralService(
       authUserRepository.save(assignedBy),
       authUserRepository.save(assignedTo)
     )
+    referral.assignments.forEach { it.superseded = true }
     referral.assignments.add(assignment)
 
     val assignedReferral = referralRepository.save(referral)

--- a/src/main/resources/db/migration/V1_74__superseded_flag_for_assignments.sql
+++ b/src/main/resources/db/migration/V1_74__superseded_flag_for_assignments.sql
@@ -1,0 +1,10 @@
+-- to enable querying the single "live" entry via `AND superseded = false`
+ALTER TABLE referral_assignments
+    ADD COLUMN superseded bool NOT NULL DEFAULT false;
+
+-- migrating the values to "true" will be done in a subsequent deploy, to avoid race conditions where
+-- • we migrate the data
+-- • assignments happen with the old code not using `superseded`
+-- • then new code takes over
+
+-- instead, we'll deploy in one go, _then_ migrate all the old data once the new code is live and ensures consistency


### PR DESCRIPTION
## What does this pull request do?

Add superseded flag to assignments

**But** not backfill "superseded" flags to true, yet, to avoid gaps created by old deployment still in use after the migration runs.

## What is the intent behind these changes?

To make it easier to select the latest assignment in queries (which should remove the need for `row_number` and be able to do a JOIN ON without subqueries) and debugging sessions