### PR TITLE
IC-2130: Added details of the caseworker who submitted the appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -66,6 +67,7 @@ data class ActionPlanSessionDTO(
         }
         else -> null
       }
+
       return ActionPlanSessionDTO(
         id = session.id,
         sessionNumber = session.sessionNumber,
@@ -79,6 +81,7 @@ data class ActionPlanSessionDTO(
           session.currentAppointment?.attendanceBehaviour,
           session.currentAppointment?.notifyPPOfAttendanceBehaviour,
           session.currentAppointment?.attendanceSubmittedAt != null,
+          session.currentAppointment?.attendanceSubmittedBy,
         ),
       )
     }
@@ -92,6 +95,7 @@ data class SessionFeedbackDTO(
   val attendance: AttendanceDTO,
   val behaviour: BehaviourDTO,
   val submitted: Boolean,
+  val submittedBy: AuthUserDTO?,
 ) {
   companion object {
     fun from(
@@ -100,11 +104,13 @@ data class SessionFeedbackDTO(
       behaviourDescription: String?,
       notifyProbationPractitioner: Boolean?,
       submitted: Boolean,
+      submittedBy: AuthUser?,
     ): SessionFeedbackDTO {
       return SessionFeedbackDTO(
         AttendanceDTO(attended = attended, additionalAttendanceInformation = additionalAttendanceInformation),
         BehaviourDTO(behaviourDescription, notifyProbationPractitioner),
         submitted,
+        submittedBy?.let { AuthUserDTO.from(it) },
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AppointmentDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AppointmentDTO.kt
@@ -33,6 +33,7 @@ data class AppointmentDTO(
           appointment.attendanceBehaviour,
           appointment.notifyPPOfAttendanceBehaviour,
           appointment.appointmentFeedbackSubmittedAt != null,
+          appointment.attendanceSubmittedBy,
         ),
         appointmentDeliveryType = appointment.appointmentDelivery?.appointmentDeliveryType,
         appointmentDeliveryAddress = addressDTO,


### PR DESCRIPTION
## What does this pull request do?

Adds a new `submittedBy` field onto SessionFeedBackDTO. This is required by the front-end to display the caseworker who was responsible for the feedback submission.

## What is the intent behind these changes?

Allow UI to deduce who was the caseworker who submitted the feedback