### PR TITLE
Bug fix attendance feedback submitted fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -80,7 +80,7 @@ data class ActionPlanSessionDTO(
           session.currentAppointment?.additionalAttendanceInformation,
           session.currentAppointment?.attendanceBehaviour,
           session.currentAppointment?.notifyPPOfAttendanceBehaviour,
-          session.currentAppointment?.attendanceSubmittedAt != null,
+          session.currentAppointment?.appointmentFeedbackSubmittedAt != null,
           session.currentAppointment?.appointmentFeedbackSubmittedBy,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -81,7 +81,7 @@ data class ActionPlanSessionDTO(
           session.currentAppointment?.attendanceBehaviour,
           session.currentAppointment?.notifyPPOfAttendanceBehaviour,
           session.currentAppointment?.attendanceSubmittedAt != null,
-          session.currentAppointment?.attendanceSubmittedBy,
+          session.currentAppointment?.appointmentFeedbackSubmittedBy,
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AppointmentDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AppointmentDTO.kt
@@ -33,7 +33,7 @@ data class AppointmentDTO(
           appointment.attendanceBehaviour,
           appointment.notifyPPOfAttendanceBehaviour,
           appointment.appointmentFeedbackSubmittedAt != null,
-          appointment.attendanceSubmittedBy,
+          appointment.appointmentFeedbackSubmittedBy,
         ),
         appointmentDeliveryType = appointment.appointmentDelivery?.appointmentDeliveryType,
         appointmentDeliveryAddress = addressDTO,


### PR DESCRIPTION
## What does this pull request do?

Fixes two bugs:

1. The attendance feedback submitted by was being populated from the `attendanceSubmittedBy` and not the `attendanceFeedbackSubmittedBy`. The risk of this is `NONE` because we currently don't do anything with the `submittedBy` field (UI PR is ready but the pact test failed), in addition it would likely be the same officer in 99% of cases.

2. The second bug is where the feedback submitted boolean field was being populated to true or false based on the `attendanceSubmittedAt` and not the `attendanceFeedbackSubmittedAt`. This only applies to action plan appointments and not initial assessment appointments.

This is more serious because it has the effect of the feedback shown as `COMPLETED` if the user fills in the attendance fields but has not yet submitted the feedback. This would occur if the user presses back after completing attendance feedback or if they close their browser.

I tested this locally with the above scenario and this is what I see for the feedback:

![image](https://user-images.githubusercontent.com/83066216/127860390-320aaaf8-31d3-45da-9386-461dee7d24e3.png)

I should expect to be able to `Give feedback` with status `SCHEDULED`.



## What is the intent behind these changes?

Prevent users from being locked out of completing action plan session feedback if they press back.
