### PR TITLE
IC-1116 launch service provider reporting job with an async job launcher

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
+
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.batch.core.launch.support.SimpleJobLauncher
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.SimpleAsyncTaskExecutor
+
+@Configuration
+class BatchConfiguration {
+  @Bean
+  fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
+    val launcher = SimpleJobLauncher()
+    launcher.setJobRepository(jobRepository)
+    launcher.setTaskExecutor(SimpleAsyncTaskExecutor())
+    launcher.afterPropertiesSet()
+    return launcher
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 
 @Service
 class ReportingService(
-  private val jobLauncher: JobLauncher,
+  private val asyncJobLauncher: JobLauncher,
   private val performanceReportJob: Job,
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper,
   private val batchUtils: BatchUtils,
@@ -22,7 +22,7 @@ class ReportingService(
     // a valid access scope before launching the job (which will also call this method).
     serviceProviderAccessScopeMapper.fromUser(user)
 
-    jobLauncher.run(
+    asyncJobLauncher.run(
       performanceReportJob,
       JobParametersBuilder()
         .addString("user.id", user.id)


### PR DESCRIPTION
## What does this pull request do?

launch service provider reporting job with an async job launcher instead of the default synchronous launcher

## What is the intent behind these changes?

ensure the reporting controller method returns without waiting for the job to complete.
