### PR TITLE
Added nps office code onto action plan appointment.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanSessionsDTO.kt
@@ -50,6 +50,7 @@ data class ActionPlanSessionDTO(
   val appointmentTime: OffsetDateTime?,
   val durationInMinutes: Int?,
   val appointmentDeliveryType: AppointmentDeliveryType?,
+  val npsOfficeCode: String?,
   val appointmentDeliveryAddress: AddressDTO?,
   val sessionFeedback: SessionFeedbackDTO,
 ) {
@@ -75,6 +76,7 @@ data class ActionPlanSessionDTO(
         durationInMinutes = session.currentAppointment?.durationInMinutes,
         appointmentDeliveryType = session.currentAppointment?.appointmentDelivery?.appointmentDeliveryType,
         appointmentDeliveryAddress = address,
+        npsOfficeCode = session.currentAppointment?.appointmentDelivery?.npsOfficeCode,
         sessionFeedback = SessionFeedbackDTO.from(
           session.currentAppointment?.attended,
           session.currentAppointment?.additionalAttendanceInformation,


### PR DESCRIPTION
## What does this pull request do?

Adds npsOfficeCode onto an action plan appointment. (Change already exists for initial assessment appointments)
This allows for displaying the correctly chosen NPS office on the UI.

Note: The UI changes haven't been merged yet, so thus this change will not have any effect.

## What is the intent behind these changes?

Provides NPS office selection for action plan appointments.