### PR TITLE
IC-1116 add configuration options for concurrent report processing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -3,17 +3,26 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.task.SimpleAsyncTaskExecutor
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
 @Configuration
-class BatchConfiguration {
+class BatchConfiguration(
+  @Value("\${spring.batch.concurrency.pool-size}") private val poolSize: Int,
+  @Value("\${spring.batch.concurrency.queue-size}") private val queueSize: Int,
+) {
   @Bean
   fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
+    val taskExecutor = ThreadPoolTaskExecutor()
+    taskExecutor.corePoolSize = poolSize
+    taskExecutor.setQueueCapacity(queueSize)
+    taskExecutor.afterPropertiesSet()
+
     val launcher = SimpleJobLauncher()
     launcher.setJobRepository(jobRepository)
-    launcher.setTaskExecutor(SimpleAsyncTaskExecutor())
+    launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,9 @@ spring:
       enabled: false  # don't run jobs at application startup
     jdbc:
       initialize-schema: never # we manage the spring batch schema with our own migrations
+    concurrency:
+      pool-size: 1 # run one job at a time...
+      queue-size: 10000 # unless the number of queued jobs exceeds this number
 
 server:
   port: 8080


### PR DESCRIPTION
## What does this pull request do?

add configuration options for concurrent report processing.

this doesn't change the behaviour - the old task executor runs reports one at a time, however this uses a more sophisticated mechanism to queue and run the jobs. 

## What is the intent behind these changes?

improve the configurability of the batch processing framework,.
