### PR TITLE
Pass npsOfficeCode to appointment delivery entity when updating an appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -105,8 +105,10 @@ class AppointmentService(
     var appointmentDelivery = appointment.appointmentDelivery
     if (appointmentDelivery == null) {
       appointmentDelivery = AppointmentDelivery(appointmentId = appointment.id, appointmentDeliveryType = appointmentDeliveryType, npsOfficeCode = npsOfficeCode)
+    } else {
+      appointmentDelivery.appointmentDeliveryType = appointmentDeliveryType
+      appointmentDelivery.npsOfficeCode = npsOfficeCode
     }
-    appointmentDelivery.appointmentDeliveryType = appointmentDeliveryType
     appointment.appointmentDelivery = appointmentDelivery
     appointmentRepository.saveAndFlush(appointment)
     if (appointmentDeliveryType == AppointmentDeliveryType.IN_PERSON_MEETING_OTHER) {


### PR DESCRIPTION
## What does this pull request do?

Allows rescheduling an appointment with a new nps office location.

## What is the intent behind these changes?

Ensures that front-end can reschedule with new nps office code

### Note
This was likely "disabled" but forgotten to be reinstated. 