### PR TITLE
IC-2165: Added ability to relocate an existing appointment

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,6 +115,7 @@ community-api:
     ended-referral: "/secure/offenders/crn/{crn}/referral/end/context/{contextName}"
     book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     reschedule-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/reschedule/context/{contextName}"
+    relocate-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/relocate"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
     notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
     offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"


### PR DESCRIPTION
## What does this pull request do?

Added a new community-api endpoint for relocation of an existing appointment.

When rescheduling an appointment but only changing the location (npsOfficeCode) then we need to send a different request to delius. This is because delius only considers rescheduling to be applicable if the appointment timing details are different.

## What is the intent behind these changes?

Unblock the ability to schedule an appointment for an NPS office location.
