### PR TITLE
IC-1116 complete SP performance report schema

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 import javax.persistence.CollectionTable
 import javax.persistence.ElementCollection
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -18,7 +19,7 @@ import javax.validation.constraints.NotNull
 @Table(name = "end_of_service_report")
 data class EndOfServiceReport(
   @Id val id: UUID,
-  @OneToOne val referral: Referral,
+  @OneToOne(fetch = FetchType.LAZY) val referral: Referral,
 
   @NotNull val createdAt: OffsetDateTime,
   @NotNull @ManyToOne @Fetch(FetchMode.JOIN) val createdBy: AuthUser,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReport.kt
@@ -33,4 +33,13 @@ data class EndOfServiceReport(
   @CollectionTable(name = "end_of_service_report_outcome", joinColumns = [JoinColumn(name = "end_of_service_report_id")])
   @NotNull val outcomes: MutableSet<EndOfServiceReportOutcome> = mutableSetOf(),
 
-)
+) {
+  val achievementScore: Float
+    get() = if (submittedAt != null) outcomes.fold(0.0F) { score, outcome ->
+      score + when (outcome.achievementLevel) {
+        AchievementLevel.ACHIEVED -> 1F
+        AchievementLevel.PARTIALLY_ACHIEVED -> 0.5F
+        else -> 0F
+      }
+    } else 0F
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -93,6 +93,9 @@ class Referral(
 ) {
   fun cancelled(): Boolean = concludedAt != null && endRequestedAt != null && endOfServiceReport == null
 
+  val approvedActionPlan: ActionPlan?
+    get() = actionPlans?.filter { it.approvedAt != null }?.maxByOrNull { it.createdAt }
+
   val currentActionPlan: ActionPlan?
     get() = actionPlans?.maxByOrNull { it.createdAt }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SupplierAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SupplierAssessment.kt
@@ -4,6 +4,7 @@ import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
 import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.JoinTable
@@ -16,7 +17,7 @@ import javax.validation.constraints.NotNull
 @Table(name = "supplier_assessment")
 data class SupplierAssessment(
   @Id val id: UUID,
-  @NotNull @OneToOne val referral: Referral,
+  @NotNull @OneToOne(fetch = FetchType.LAZY) val referral: Referral,
 
   @JoinTable(
     name = "supplier_assessment_appointment",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportData.kt
@@ -2,17 +2,79 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.service
 
 import java.time.OffsetDateTime
 import java.util.UUID
-import kotlin.reflect.full.memberProperties
 
 data class PerformanceReportData(
-  val id: UUID,
+  // val referralLink: String,
   val referralReference: String,
-  val serviceUserCRN: String,
-  val dateReferralReceived: OffsetDateTime,
+  val referralId: UUID,
   val contractReference: String,
   val organisationId: String,
+  // val referringOfficerEmail: String,
+  val currentAssigneeId: String?,
+  val serviceUserCRN: String,
+  val dateReferralReceived: OffsetDateTime,
+  val initialAssessmentBookedAt: OffsetDateTime?,
+  val initialAssessmentAttendedAt: OffsetDateTime?,
+  val firstActionPlanSubmittedAt: OffsetDateTime?,
+  val firstActionPlanApprovedAt: OffsetDateTime?,
+  val firstSessionAttendedAt: OffsetDateTime?,
+  val numberOfOutcomes: Int?,
+  val achievementScore: Float?,
+  val numberOfSessions: Int?,
+  val numberOfSessionsAttended: Int?,
+  val endRequestedAt: OffsetDateTime?,
+  val endRequestedReason: String?,
+  val eosrSubmittedAt: OffsetDateTime?,
+  val concludedAt: OffsetDateTime?,
 ) {
   companion object {
-    val fields = PerformanceReportData::class.memberProperties.map { it.name }.sorted()
+    // it would be neater to use reflection to get the fields, but we cannot guarantee the order
+    val fields = listOf(
+      // "referralLink",
+      "referralReference",
+      "referralId",
+      "contractReference",
+      "organisationId",
+      // "referringOfficerEmail",
+      "currentAssigneeId",
+      "serviceUserCRN",
+      "dateReferralReceived",
+      "initialAssessmentBookedAt",
+      "initialAssessmentAttendedAt",
+      "firstActionPlanSubmittedAt",
+      "firstActionPlanApprovedAt",
+      "firstSessionAttendedAt",
+      "numberOfOutcomes",
+      "achievementScore",
+      "numberOfSessions",
+      "numberOfSessionsAttended",
+      "endRequestedAt",
+      "endRequestedReason",
+      "eosrSubmittedAt",
+      "concludedAt",
+    )
+    val headers = listOf(
+      // "referral_link",
+      "referral_ref",
+      "referral_id",
+      "organisation_id",
+      // "referring_officer_email",
+      "caseworker_id",
+      "service_user_crn",
+      "date_referral_received",
+      "date_saa_booked",
+      "date_saa_attended",
+      "date_first_action_plan_submitted",
+      "date_of_first_action_plan_approval",
+      "date_of_first_attended_session",
+      "outcomes_to_be_achieved_count",
+      "outcomes_achieved",
+      "count_of_sessions_expected",
+      "count_of_sessions_attended",
+      "end_requested_by_pp_at",
+      "end_requested_by_pp_reason",
+      "date_eosr_submitted",
+      "concluded_at",
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
@@ -60,7 +60,7 @@ class PerformanceReportJobConfiguration(
     return batchUtils.csvFileWriter(
       "performanceReportWriter",
       FileSystemResource(path),
-      PerformanceReportData.fields,
+      PerformanceReportData.headers,
       PerformanceReportData.fields
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
@@ -4,12 +4,17 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanSessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.util.UUID
 
 @Component
 class PerformanceReportProcessor(
   private val referralRepository: ReferralRepository,
+  private val actionPlanSessionRepository: ActionPlanSessionRepository,
 ) : ItemProcessor<UUID, PerformanceReportData> {
   companion object : KLogging()
 
@@ -20,13 +25,50 @@ class PerformanceReportProcessor(
       ?: throw RuntimeException("invalid referral id passed to report processor")
 
     // note: all referrals here are 'sent', we can safely access fields like 'referenceNumber'
+    val contract = referral.intervention.dynamicFrameworkContract
+    val initialAssessmentAppointment = referral.supplierAssessment?.currentAppointment
+
     return PerformanceReportData(
-      id = referral.id,
       referralReference = referral.referenceNumber!!,
+      referralId = referral.id,
+      contractReference = contract.contractReference,
+      organisationId = contract.primeProvider.id,
+      currentAssigneeId = referral.currentAssignee?.id,
       serviceUserCRN = referral.serviceUserCRN,
       dateReferralReceived = referral.sentAt!!,
-      contractReference = referral.intervention.dynamicFrameworkContract.contractReference,
-      organisationId = referral.intervention.dynamicFrameworkContract.primeProvider.id,
+      initialAssessmentBookedAt = initialAssessmentAppointment?.createdAt,
+      initialAssessmentAttendedAt = initialAssessmentAppointment?.attended?.let { initialAssessmentAppointment.appointmentTime },
+      firstActionPlanSubmittedAt = referral.actionPlans?.mapNotNull { it.submittedAt }?.minOrNull(),
+      firstActionPlanApprovedAt = referral.actionPlans?.mapNotNull { it.approvedAt }?.minOrNull(),
+      firstSessionAttendedAt = getFirstAttendedDeliveryAppointment(referral)?.appointmentTime,
+      numberOfOutcomes = referral.selectedDesiredOutcomes?.size,
+      achievementScore = referral.endOfServiceReport?.achievementScore,
+      numberOfSessions = referral.approvedActionPlan?.numberOfSessions,
+      numberOfSessionsAttended = getAllAttendedDeliveryAppointments(referral).size,
+      endRequestedAt = referral.endRequestedAt,
+      endRequestedReason = referral.endRequestedReason?.code,
+      eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
+      concludedAt = referral.concludedAt,
     )
+  }
+
+  fun getAllAttendedDeliveryAppointments(referral: Referral): List<Appointment> {
+    // a referral can have multiple action plans, each action plan can have multiple
+    // sessions, each session can have multiple appointments. action plans may or
+    // may not contain references to the same sessions and appointments depending
+    // on implementation details. to be safe we get a list of all unique attended
+    // appointments for all action plans and sessions associated with this referral.
+    return referral.actionPlans?.flatMap { actionPlan ->
+      actionPlanSessionRepository.findAllByActionPlanId(actionPlan.id)
+        .flatMap { session -> session.appointments }
+        .filter { appointment ->
+          appointment.appointmentFeedbackSubmittedAt != null &&
+            listOf(Attended.LATE, Attended.YES).contains(appointment.attended)
+        }
+    }?.distinctBy { appointment -> appointment.id }.orEmpty()
+  }
+
+  fun getFirstAttendedDeliveryAppointment(referral: Referral): Appointment? {
+    return getAllAttendedDeliveryAppointments(referral).minByOrNull { it.appointmentTime }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/EndOfServiceReportTest.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DesiredOutcomesFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
+import java.time.OffsetDateTime
+
+internal class EndOfServiceReportTest {
+  private val endOfServiceReportFactory = EndOfServiceReportFactory()
+  private val desiredOutcomesFactory = DesiredOutcomesFactory()
+
+  @Nested
+  inner class AchievementScore {
+    @Test
+    fun `achievementScore returns 0 when the eosr is not submitted`() {
+      val desiredOutcomes = desiredOutcomesFactory.create(number = 4)
+      val eosr = endOfServiceReportFactory.create(
+        outcomes = mutableSetOf(
+          EndOfServiceReportOutcome(desiredOutcomes[0], AchievementLevel.ACHIEVED),
+          EndOfServiceReportOutcome(desiredOutcomes[1], AchievementLevel.ACHIEVED),
+          EndOfServiceReportOutcome(desiredOutcomes[2], AchievementLevel.PARTIALLY_ACHIEVED),
+          EndOfServiceReportOutcome(desiredOutcomes[3], AchievementLevel.NOT_ACHIEVED),
+        )
+      )
+      assertThat(eosr.achievementScore).isEqualTo(0f)
+    }
+
+    @Test
+    fun `achievementScore returns a correct floating point value`() {
+      val desiredOutcomes = desiredOutcomesFactory.create(number = 4)
+      val eosr = endOfServiceReportFactory.create(
+        submittedAt = OffsetDateTime.now(),
+        outcomes = mutableSetOf(
+          EndOfServiceReportOutcome(desiredOutcomes[0], AchievementLevel.ACHIEVED),
+          EndOfServiceReportOutcome(desiredOutcomes[1], AchievementLevel.ACHIEVED),
+          EndOfServiceReportOutcome(desiredOutcomes[2], AchievementLevel.PARTIALLY_ACHIEVED),
+          EndOfServiceReportOutcome(desiredOutcomes[3], AchievementLevel.NOT_ACHIEVED),
+        )
+      )
+
+      assertThat(eosr.achievementScore).isEqualTo(2.5f)
+    }
+
+    @Test
+    fun `achievementScore returns 0 when there are no outcomes`() {
+      val eosr = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+      assertThat(eosr.achievementScore).isEqualTo(0f)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
@@ -3,13 +3,16 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.time.OffsetDateTime
+import java.util.UUID
 
 internal class ReferralTest {
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
+  private val actionPlanFactory = ActionPlanFactory()
 
   @Nested
   inner class Assignments {
@@ -39,6 +42,32 @@ internal class ReferralTest {
       )
 
       assertThat(referral.currentAssignee).isEqualTo(currentAssignee)
+    }
+  }
+
+  @Nested inner class ActionPlans {
+    @Test
+    fun `approvedActionPlan returns null if there are no approved action plan`() {
+      val referral = referralFactory.createSent(
+        actionPlans = mutableListOf(
+          actionPlanFactory.createSubmitted()
+        )
+      )
+
+      assertThat(referral.approvedActionPlan).isNull()
+    }
+
+    @Test
+    fun `approvedActionPlan returns most recent approved action plan`() {
+      val correctId = UUID.randomUUID()
+      val referral = referralFactory.createSent(
+        actionPlans = mutableListOf(
+          actionPlanFactory.createSubmitted(),
+          actionPlanFactory.createApproved(createdAt = OffsetDateTime.now().minusHours(1)),
+          actionPlanFactory.createApproved(createdAt = OffsetDateTime.now(), id = correctId)
+        )
+      )
+      assertThat(referral.approvedActionPlan?.id).isEqualTo(correctId)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
@@ -3,21 +3,100 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.service
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlanSession
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanSessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider.performance.PerformanceReportProcessor
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.lang.RuntimeException
+import java.time.OffsetDateTime
 import java.util.UUID
 
 internal class PerformanceReportDataProcessorTest {
   private val referralRepository = mock<ReferralRepository>()
-  private val processor = PerformanceReportProcessor(referralRepository)
+  private val actionPlanSessionRepository = mock<ActionPlanSessionRepository>()
+  private val processor = PerformanceReportProcessor(referralRepository, actionPlanSessionRepository)
+  private val actionPlanFactory = ActionPlanFactory()
+  private val referralFactory = ReferralFactory()
+  private val appointmentFactory = AppointmentFactory()
 
   @Test
   fun `will not process draft referrals`() {
     whenever(referralRepository.findByIdAndSentAtIsNotNull(any())).thenReturn(null)
 
     assertThrows<RuntimeException> { processor.process(UUID.randomUUID()) }
+  }
+
+  @Test
+  fun `getAllAttendedDeliveryAppointments gets appointments from all action plans and all sessions`() {
+    val referral = referralFactory.createSent()
+
+    // start by making a couple of action plans. we will intentionally duplicate sessions and appointments
+    // on these to validate that the logic does not include duplicate attended appointments
+    val actionPlan1 = actionPlanFactory.createApproved(referral = referral)
+    val actionPlan2 = actionPlanFactory.createApproved(referral = referral)
+    val actionPlan3 = actionPlanFactory.createSubmitted(referral = referral)
+    referral.actionPlans = mutableListOf(actionPlan1, actionPlan2, actionPlan3)
+
+    // then make a bunch of appointments
+    val unattendedAppointments = (1..5).map {
+      appointmentFactory.create(referral = referral)
+    }
+    val attendedAppointments = (1..5).map {
+      appointmentFactory.create(referral = referral, attended = Attended.YES, appointmentFeedbackSubmittedAt = OffsetDateTime.now())
+    }
+    val lateAppointments = (1..5).map {
+      appointmentFactory.create(referral = referral, attended = Attended.LATE, appointmentFeedbackSubmittedAt = OffsetDateTime.now())
+    }
+
+    // now we'll make a bunch of sessions with various unattended and attended appointments on them
+    val session1 = ActionPlanSession(
+      appointments = mutableSetOf(
+        unattendedAppointments[0],
+        unattendedAppointments[1],
+        lateAppointments[0]
+      ),
+      1, actionPlan1, UUID.randomUUID()
+    )
+
+    val session2 = ActionPlanSession(
+      appointments = mutableSetOf(unattendedAppointments[2], attendedAppointments[0]),
+      2,
+      actionPlan1,
+      UUID.randomUUID()
+    )
+
+    val session3 = ActionPlanSession(
+      appointments = mutableSetOf(
+        unattendedAppointments[3],
+        unattendedAppointments[4],
+        lateAppointments[1]
+      ),
+      3, actionPlan1, UUID.randomUUID()
+    )
+
+    whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan1.id)).thenReturn(listOf(session1, session2, session3))
+    // weird duplicate behaviour is intended - even though it's not very realistic
+    whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan2.id)).thenReturn(listOf(session1, session2, session3))
+    whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan3.id)).thenReturn(emptyList())
+
+    assertThat(processor.getAllAttendedDeliveryAppointments(referral)).hasSameElementsAs(listOf(lateAppointments[0], lateAppointments[1], attendedAppointments[0]))
+  }
+
+  @Test
+  fun `getAllAttendedDeliveryAppointments returns empty list when referral has null or no action plans`() {
+    val referral = referralFactory.createSent()
+    referral.actionPlans = null
+    assertThat(processor.getAllAttendedDeliveryAppointments(referral)).isEqualTo(emptyList<Appointment>())
+
+    referral.actionPlans = mutableListOf()
+    assertThat(processor.getAllAttendedDeliveryAppointments(referral)).isEqualTo(emptyList<Appointment>())
   }
 }


### PR DESCRIPTION
## What does this pull request do?

adds the required fields to generate the service provider performance report in full.

see https://docs.google.com/spreadsheets/d/1OYTTW-xG3djMsrp9dRRAQkEgXNq1uKoZkRD1ZSe7-OE/edit#gid=1131579949 for further explanations of these fields. 

## What is the intent behind these changes?

make the report useful to SPs.
