### PR TITLE
IC-1275 Notification to Delius of End of Service report is now synchronous

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -65,7 +65,7 @@ class CommunityAPIReferralEventService(
         // However a race condition arises with the referral end
         // notification. To Avoid a NSI not found in community-api
         // this must be sent and processed before referral end
-        postNotificationRequest(event.referral.endOfServiceReport)
+        postSyncNotificationRequest(event.referral.endOfServiceReport)
 
         val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
           .path(ppEndOfServiceReportLocation)
@@ -96,7 +96,7 @@ class CommunityAPIReferralEventService(
     communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, referralEndRequest)
   }
 
-  private fun postNotificationRequest(endOfServiceReport: EndOfServiceReport?) {
+  private fun postSyncNotificationRequest(endOfServiceReport: EndOfServiceReport?) {
 
     endOfServiceReport?.submittedAt ?: run {
       throw IllegalStateException("End of service report not submitted so should not get to this point")
@@ -107,10 +107,10 @@ class CommunityAPIReferralEventService(
       .buildAndExpand(endOfServiceReport!!.id)
       .toString()
 
-    postNotificationRequest(endOfServiceReport, url)
+    postSyncNotificationRequest(endOfServiceReport, url)
   }
 
-  private fun postNotificationRequest(endOfServiceReport: EndOfServiceReport, url: String) {
+  private fun postSyncNotificationRequest(endOfServiceReport: EndOfServiceReport, url: String) {
 
     val referral = endOfServiceReport.referral
 
@@ -126,7 +126,7 @@ class CommunityAPIReferralEventService(
       .buildAndExpand(referral.serviceUserCRN, referral.relevantSentenceId!!, integrationContext)
       .toString()
 
-    communityAPIClient.makeAsyncPostRequest(communityApiSentReferralPath, request)
+    communityAPIClient.makeSyncPostRequest(communityApiSentReferralPath, request, Unit::class.java)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIReferralEventServiceTest.kt
@@ -71,7 +71,7 @@ class CommunityAPIReferralEventServiceTest {
 
     val inOrder = inOrder(communityAPIClient)
 
-    inOrder.verify(communityAPIClient).makeAsyncPostRequest(
+    inOrder.verify(communityAPIClient).makeSyncPostRequest(
       "secure/offenders/crn/X123456/sentence/123456789/notifications/context/commissioned-rehabilitation-services",
       NotificationCreateRequestDTO(
         "ACC",
@@ -80,7 +80,8 @@ class CommunityAPIReferralEventServiceTest {
         submittedAtDefault,
         "End of Service Report Submitted for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/pp/referral/120b1a45-8ac7-4920-b05b-acecccf4734b/end-of-service-report",
-      )
+      ),
+      Unit::class.java
     )
 
     inOrder.verify(communityAPIClient).makeAsyncPostRequest(
@@ -113,7 +114,7 @@ class CommunityAPIReferralEventServiceTest {
 
     val inOrder = inOrder(communityAPIClient)
 
-    inOrder.verify(communityAPIClient).makeAsyncPostRequest(
+    inOrder.verify(communityAPIClient).makeSyncPostRequest(
       "secure/offenders/crn/X123456/sentence/123456789/notifications/context/commissioned-rehabilitation-services",
       NotificationCreateRequestDTO(
         "ACC",
@@ -122,7 +123,8 @@ class CommunityAPIReferralEventServiceTest {
         submittedAtDefault,
         "End of Service Report Submitted for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/pp/referral/120b1a45-8ac7-4920-b05b-acecccf4734b/end-of-service-report",
-      )
+      ),
+      Unit::class.java
     )
 
     inOrder.verify(communityAPIClient).makeAsyncPostRequest(


### PR DESCRIPTION
## What does this pull request do?
Notification to Delius of End of Service report is now synchronous.

## What is the intent behind these changes?
Prior to this PR, the notification was initiated before Referral End but was sent asynchronously. However, to avoid simultaneous object modification issues in Delius it must complete before referral end is sent. This was always the intention