### PR TITLE
IC-1116 add missing 'contract_ref' header to SP performance report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportData.kt
@@ -57,6 +57,7 @@ data class PerformanceReportData(
       // "referral_link",
       "referral_ref",
       "referral_id",
+      "contract_ref",
       "organisation_id",
       // "referring_officer_email",
       "caseworker_id",


### PR DESCRIPTION
## What does this pull request do?

add missing 'contract_reference' header to SP performance report

## What is the intent behind these changes?

fix the alignment of the headers in the generated csv file.
