### PR TITLE
IC-2171 add endpoint to return approved action plans for a referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.server.ServerWebInputException
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers.CancellationReasonMapper
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ApprovedActionPlanSummaryDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ActionPlanSummaryDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EndReferralRequestDTO
@@ -220,12 +220,12 @@ class ReferralController(
     return SupplierAssessmentDTO.from(supplierAssessment)
   }
 
-  @GetMapping("sent-referral/{id}/approved-action-plans")
+  @GetMapping("/sent-referral/{id}/approved-action-plans")
   fun getReferralApprovedActionPlans(
     @PathVariable id: UUID,
-  ): List<ApprovedActionPlanSummaryDTO> {
-    val actionPlans = actionPlanService.getActionPlanByReferral(id)
-    return ApprovedActionPlanSummaryDTO.from(actionPlans)
+  ): List<ActionPlanSummaryDTO> {
+    val actionPlans = actionPlanService.getApprovedActionPlansByReferral(id)
+    return ActionPlanSummaryDTO.from(actionPlans)
   }
 
   private fun getSupplierAssessment(sentReferral: Referral): SupplierAssessment {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.server.ServerWebInputException
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.mappers.CancellationReasonMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ApprovedActionPlanSummaryDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateReferralRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EndReferralRequestDTO
@@ -32,6 +33,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUse
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcluder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService
@@ -45,6 +47,7 @@ class ReferralController(
   private val serviceCategoryService: ServiceCategoryService,
   private val userMapper: UserMapper,
   private val cancellationReasonMapper: CancellationReasonMapper,
+  private val actionPlanService: ActionPlanService,
 ) {
   companion object : KLogging()
 
@@ -215,6 +218,14 @@ class ReferralController(
 
     val supplierAssessment = getSupplierAssessment(sentReferral)
     return SupplierAssessmentDTO.from(supplierAssessment)
+  }
+
+  @GetMapping("sent-referral/{id}/approved-action-plans")
+  fun getReferralApprovedActionPlans(
+    @PathVariable id: UUID,
+  ): List<ApprovedActionPlanSummaryDTO> {
+    val actionPlans = actionPlanService.getActionPlanByReferral(id)
+    return ApprovedActionPlanSummaryDTO.from(actionPlans)
   }
 
   private fun getSupplierAssessment(sentReferral: Referral): SupplierAssessment {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
@@ -66,19 +66,19 @@ data class UpdateActionPlanActivityDTO(
   val description: String,
 )
 
-data class ApprovedActionPlanSummaryDTO(
+data class ActionPlanSummaryDTO(
   val id: UUID,
-  val approvedAt: OffsetDateTime,
+  val approvedAt: OffsetDateTime?,
 ) {
   companion object {
-    fun from(actionPlan: ActionPlan): ApprovedActionPlanSummaryDTO {
-      return ApprovedActionPlanSummaryDTO(
+    fun from(actionPlan: ActionPlan): ActionPlanSummaryDTO {
+      return ActionPlanSummaryDTO(
         id = actionPlan.id,
-        approvedAt = actionPlan.approvedAt!!,
+        approvedAt = actionPlan.approvedAt,
       )
     }
-    fun from(actionPlans: List<ActionPlan>): List<ApprovedActionPlanSummaryDTO> {
-      return actionPlans.filter { it.approvedAt != null }.map { from(it) }
+    fun from(actionPlans: List<ActionPlan>): List<ActionPlanSummaryDTO> {
+      return actionPlans.map { from(it) }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
@@ -65,3 +65,20 @@ data class UpdateActionPlanDTO(
 data class UpdateActionPlanActivityDTO(
   val description: String,
 )
+
+data class ApprovedActionPlanSummaryDTO(
+  val id: UUID,
+  val approvedAt: OffsetDateTime,
+) {
+  companion object {
+    fun from(actionPlan: ActionPlan): ApprovedActionPlanSummaryDTO {
+      return ApprovedActionPlanSummaryDTO(
+        id = actionPlan.id,
+        approvedAt = actionPlan.approvedAt!!,
+      )
+    }
+    fun from(actionPlans: List<ActionPlan>): List<ApprovedActionPlanSummaryDTO> {
+      return actionPlans.filter { it.approvedAt != null }.map { from(it) }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 
 interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
   fun findByIdAndSubmittedAtIsNull(id: UUID): ActionPlan?
-  fun findByReferralId(referralId: UUID): ActionPlan?
+  fun findByReferralId(referralId: UUID): List<ActionPlan>?
 
   @Query(
     "select count(sesh) from ActionPlanSession sesh join sesh.appointments appt " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 
 interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
   fun findByIdAndSubmittedAtIsNull(id: UUID): ActionPlan?
-  fun findAllByReferralIdAndApprovedAtIsNotNull(referralId: UUID): List<ActionPlan>?
+  fun findAllByReferralIdAndApprovedAtIsNotNull(referralId: UUID): List<ActionPlan>
 
   @Query(
     "select count(sesh) from ActionPlanSession sesh join sesh.appointments appt " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 
 interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
   fun findByIdAndSubmittedAtIsNull(id: UUID): ActionPlan?
-  fun findByReferralId(referralId: UUID): List<ActionPlan>?
+  fun findAllByReferralIdAndApprovedAtIsNotNull(referralId: UUID): List<ActionPlan>?
 
   @Query(
     "select count(sesh) from ActionPlanSession sesh join sesh.appointments appt " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -106,7 +106,6 @@ class ActionPlanService(
 
   fun getApprovedActionPlansByReferral(referralId: UUID): List<ActionPlan> {
     return actionPlanRepository.findAllByReferralIdAndApprovedAtIsNotNull(referralId)
-      ?: throw EntityNotFoundException("no action plans found for referral [referralId=$referralId]")
   }
 
   fun getAllAttendedAppointments(actionPlan: ActionPlan): List<Appointment> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -104,8 +104,8 @@ class ActionPlanService(
       ?: throw EntityNotFoundException("action plan not found [id=$id]")
   }
 
-  fun getActionPlanByReferral(referralId: UUID): List<ActionPlan> {
-    return actionPlanRepository.findByReferralId(referralId)
+  fun getApprovedActionPlansByReferral(referralId: UUID): List<ActionPlan> {
+    return actionPlanRepository.findAllByReferralIdAndApprovedAtIsNotNull(referralId)
       ?: throw EntityNotFoundException("no action plans found for referral [referralId=$referralId]")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -104,9 +104,9 @@ class ActionPlanService(
       ?: throw EntityNotFoundException("action plan not found [id=$id]")
   }
 
-  fun getActionPlanByReferral(referralId: UUID): ActionPlan {
+  fun getActionPlanByReferral(referralId: UUID): List<ActionPlan> {
     return actionPlanRepository.findByReferralId(referralId)
-      ?: throw EntityNotFoundException("action plan not found [referralId=$referralId]")
+      ?: throw EntityNotFoundException("no action plans found for referral [referralId=$referralId]")
   }
 
   fun getAllAttendedAppointments(actionPlan: ActionPlan): List<Appointment> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -26,9 +26,11 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAssign
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcluder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -43,13 +45,15 @@ internal class ReferralControllerTest {
   private val authUserRepository = mock<AuthUserRepository>()
   private val userMapper = UserMapper(authUserRepository)
   private val cancellationReasonMapper = mock<CancellationReasonMapper>()
+  private val actionPlanService = mock<ActionPlanService>()
   private val referralController = ReferralController(
-    referralService, referralConcluder, serviceCategoryService, userMapper, cancellationReasonMapper
+    referralService, referralConcluder, serviceCategoryService, userMapper, cancellationReasonMapper, actionPlanService
   )
   private val tokenFactory = JwtTokenFactory()
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
   private val supplierAssessmentFactory = SupplierAssessmentFactory()
+  private val actionPlanFactory = ActionPlanFactory()
 
   @Test
   fun `createDraftReferral handles EntityNotFound exceptions from InterventionsService`() {
@@ -264,5 +268,19 @@ internal class ReferralControllerTest {
       val response = referralController.endSentReferral(referral.id, endReferralDTO, token)
       assertThat(response.endOfServiceReportCreationRequired).isTrue
     }
+  }
+
+  @Test
+  fun `get action plans for referral returns only approved action plans`() {
+    val referralId = UUID.randomUUID()
+    val actionPlanId = UUID.randomUUID()
+    val approvedActionPlan = actionPlanFactory.createApproved(id = actionPlanId)
+    val nonApprovedActionPlan = actionPlanFactory.create()
+
+    whenever(actionPlanService.getActionPlanByReferral(referralId)).thenReturn(listOf(approvedActionPlan, nonApprovedActionPlan))
+    val response = referralController.getReferralApprovedActionPlans(referralId)
+
+    assertThat(response.size).isEqualTo(1)
+    assertThat(response[0].id).isEqualTo(actionPlanId)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -273,14 +273,12 @@ internal class ReferralControllerTest {
   @Test
   fun `get action plans for referral returns only approved action plans`() {
     val referralId = UUID.randomUUID()
-    val actionPlanId = UUID.randomUUID()
-    val approvedActionPlan = actionPlanFactory.createApproved(id = actionPlanId)
+    val approvedActionPlan = actionPlanFactory.createApproved()
     val nonApprovedActionPlan = actionPlanFactory.create()
 
-    whenever(actionPlanService.getActionPlanByReferral(referralId)).thenReturn(listOf(approvedActionPlan, nonApprovedActionPlan))
+    whenever(actionPlanService.getApprovedActionPlansByReferral(referralId)).thenReturn(listOf(approvedActionPlan, nonApprovedActionPlan))
     val response = referralController.getReferralApprovedActionPlans(referralId)
 
-    assertThat(response.size).isEqualTo(1)
-    assertThat(response[0].id).isEqualTo(actionPlanId)
+    assertThat(response.size).isEqualTo(2)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
@@ -125,4 +125,16 @@ class ActionPlanContracts(private val setupAssistant: SetupAssistant) {
       notifyPPOfBehaviour = false
     )
   }
+
+  @State("two approved action plans exists with IDs f3ade2c5-075a-4235-9826-eed289e4d17a and 8f3e1895-9c46-40ad-bdb3-d33eacbb693e")
+  fun `create two action plans for a referral`() {
+    val referralId = UUID.fromString("8d107952-9bde-4854-ad1e-dee09daab992")
+    val actionPlan1Id = UUID.fromString("f3ade2c5-075a-4235-9826-eed289e4d17")
+    val actionPlan2Id = UUID.fromString("8f3e1895-9c46-40ad-bdb3-d33eacbb693e")
+
+    val referral = setupAssistant.createSentReferral(id = referralId)
+
+    setupAssistant.createActionPlan(id = actionPlan1Id, referral = referral)
+    setupAssistant.createActionPlan(id = actionPlan2Id, referral = referral)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -254,17 +254,6 @@ internal class ActionPlanServiceTest {
   }
 
   @Test
-  fun `get action plan using referral id throws exception when not found`() {
-    val referralId = UUID.randomUUID()
-    whenever(actionPlanRepository.findAllByReferralIdAndApprovedAtIsNotNull(referralId)).thenReturn(null)
-
-    val exception = Assertions.assertThrows(EntityNotFoundException::class.java) {
-      actionPlanService.getApprovedActionPlansByReferral(referralId)
-    }
-    assertThat(exception.message).isEqualTo("no action plans found for referral [referralId=$referralId]")
-  }
-
-  @Test
   fun `update action plan activity`() {
     val activity1 = SampleData.sampleActionPlanActivity()
     val activity2 = SampleData.sampleActionPlanActivity()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -248,18 +248,18 @@ internal class ActionPlanServiceTest {
   fun `get action plan using referral id`() {
     val actionPlanId = UUID.randomUUID()
     val actionPlan = actionPlanFactory.create(id = actionPlanId)
-    whenever(actionPlanRepository.findByReferralId(actionPlan.referral.id)).thenReturn(listOf(actionPlan))
+    whenever(actionPlanRepository.findAllByReferralIdAndApprovedAtIsNotNull(actionPlan.referral.id)).thenReturn(listOf(actionPlan))
 
-    assertThat(actionPlanService.getActionPlanByReferral(actionPlan.referral.id)).isEqualTo(listOf(actionPlan))
+    assertThat(actionPlanService.getApprovedActionPlansByReferral(actionPlan.referral.id)).isEqualTo(listOf(actionPlan))
   }
 
   @Test
   fun `get action plan using referral id throws exception when not found`() {
     val referralId = UUID.randomUUID()
-    whenever(actionPlanRepository.findByReferralId(referralId)).thenReturn(null)
+    whenever(actionPlanRepository.findAllByReferralIdAndApprovedAtIsNotNull(referralId)).thenReturn(null)
 
     val exception = Assertions.assertThrows(EntityNotFoundException::class.java) {
-      actionPlanService.getActionPlanByReferral(referralId)
+      actionPlanService.getApprovedActionPlansByReferral(referralId)
     }
     assertThat(exception.message).isEqualTo("no action plans found for referral [referralId=$referralId]")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -247,10 +247,10 @@ internal class ActionPlanServiceTest {
   @Test
   fun `get action plan using referral id`() {
     val actionPlanId = UUID.randomUUID()
-    val actionPlan = SampleData.sampleActionPlan(id = actionPlanId)
-    whenever(actionPlanRepository.findByReferralId(actionPlan.referral.id)).thenReturn(actionPlan)
+    val actionPlan = actionPlanFactory.create(id = actionPlanId)
+    whenever(actionPlanRepository.findByReferralId(actionPlan.referral.id)).thenReturn(listOf(actionPlan))
 
-    assertThat(actionPlanService.getActionPlanByReferral(actionPlan.referral.id)).isSameAs(actionPlan)
+    assertThat(actionPlanService.getActionPlanByReferral(actionPlan.referral.id)).isEqualTo(listOf(actionPlan))
   }
 
   @Test
@@ -261,7 +261,7 @@ internal class ActionPlanServiceTest {
     val exception = Assertions.assertThrows(EntityNotFoundException::class.java) {
       actionPlanService.getActionPlanByReferral(referralId)
     }
-    assertThat(exception.message).isEqualTo("action plan not found [referralId=$referralId]")
+    assertThat(exception.message).isEqualTo("no action plans found for referral [referralId=$referralId]")
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

New endpoint that will return all approved action plan summaries for a referral.

## What is the intent behind these changes?

To provide the front end with a list of approved action plan's for a referral that can be displayed.
