### PR TITLE
change data extractor version to 'develop' 

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -11,7 +11,7 @@ spec:
           restartPolicy: "Never"
           containers:
           - name: data-extractor-analytics
-            image: ministryofjustice/data-engineering-data-extractor:v1
+            image: ministryofjustice/data-engineering-data-extractor:develop
             imagePullPolicy: Always
             args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             env:


### PR DESCRIPTION

## What does this pull request do?

changes the version of the data extractor image. i have been advised to do this to help fix some issues with the latest v1 version of the tool. this should be a temporary change.
