### PR TITLE
IC-1116 alter the way the report job processes referrals to reduce the load on the database

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -67,6 +67,6 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
   fun findByCreatedByIdAndSentAtIsNull(userId: String): List<Referral>
 
   // queries for reporting
-  @Query("select r.id from Referral r where r.sentAt > :from and r.sentAt < :to and r.intervention.dynamicFrameworkContract in :contracts")
-  fun serviceProviderReportReferralIds(from: OffsetDateTime, to: OffsetDateTime, contracts: Set<DynamicFrameworkContract>, pageable: Pageable): Page<UUID>
+  @Query("select r from Referral r where r.sentAt > :from and r.sentAt < :to and r.intervention.dynamicFrameworkContract in :contracts")
+  fun serviceProviderReportReferrals(from: OffsetDateTime, to: OffsetDateTime, contracts: Set<DynamicFrameworkContract>, pageable: Pageable): Page<Referral>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
@@ -4,22 +4,19 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
-import java.util.UUID
 
 @Component
 class PerformanceReportProcessor(
-  private val referralRepository: ReferralRepository,
   private val actionPlanService: ActionPlanService,
-) : ItemProcessor<UUID, PerformanceReportData> {
+) : ItemProcessor<Referral, PerformanceReportData> {
   companion object : KLogging()
 
-  override fun process(referralId: UUID): PerformanceReportData {
-    logger.info("processing referral {}", kv("referralId", referralId))
+  override fun process(referral: Referral): PerformanceReportData {
+    logger.info("processing referral {}", kv("referralId", referral.id))
 
-    val referral = referralRepository.findByIdAndSentAtIsNotNull(referralId)
-      ?: throw RuntimeException("invalid referral id passed to report processor")
+    if (referral.sentAt == null) throw RuntimeException("invalid referral passed to report processor; referral has not been sent")
 
     // note: all referrals here are 'sent', we can safely access fields like 'referenceNumber'
     val contract = referral.intervention.dynamicFrameworkContract

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,11 @@ spring:
     concurrency:
       pool-size: 1 # run one job at a time...
       queue-size: 10000 # unless the number of queued jobs exceeds this number
+    jobs:
+      service-provider:
+        performance-report:
+          page-size: 100
+          chunk-size: 20
 
 server:
   port: 8080

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -315,7 +315,7 @@ class ReferralRepositoryTest @Autowired constructor(
     val referral = referralFactory.createSent()
     referralFactory.createSent(sentAt = OffsetDateTime.now().minusHours(2), intervention = referral.intervention)
 
-    val referrals = referralRepository.serviceProviderReportReferralIds(
+    val referrals = referralRepository.serviceProviderReportReferrals(
       OffsetDateTime.now().minusHours(1),
       OffsetDateTime.now().plusHours(1),
       setOf(referral.intervention.dynamicFrameworkContract),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
@@ -1,25 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider.performance.PerformanceReportProcessor
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.lang.RuntimeException
-import java.util.UUID
 
 internal class PerformanceReportDataProcessorTest {
-  private val referralRepository = mock<ReferralRepository>()
   private val actionPlanService = mock<ActionPlanService>()
-  private val processor = PerformanceReportProcessor(referralRepository, actionPlanService)
+  private val processor = PerformanceReportProcessor(actionPlanService)
+
+  private val referralFactory = ReferralFactory()
 
   @Test
   fun `will not process draft referrals`() {
-    whenever(referralRepository.findByIdAndSentAtIsNotNull(any())).thenReturn(null)
+    val referral = referralFactory.createDraft()
 
-    assertThrows<RuntimeException> { processor.process(UUID.randomUUID()) }
+    assertThrows<RuntimeException> { processor.process(referral) }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

loads full referral entities in the reader step
increases page size and chunk size to process more rows at once.

## What is the intent behind these changes?

reduce load on the database when processing referral performance reports.
