### PR TITLE
IC-1833 approve new action plan if there is an existing approved one

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanSession.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanSession.kt
@@ -22,7 +22,7 @@ data class ActionPlanSession(
   @NotNull @OneToMany @Fetch(FetchMode.JOIN) val appointments: MutableSet<Appointment> = mutableSetOf(),
   @NotNull val sessionNumber: Int,
 
-  @NotNull @ManyToOne val actionPlan: ActionPlan,
+  @NotNull @ManyToOne var actionPlan: ActionPlan,
   @Id val id: UUID,
 ) {
   // this class is designed to allow multiple appointments per session,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -34,9 +34,9 @@ class ActionPlanSessionsService(
   val appointmentService: AppointmentService,
   val appointmentRepository: AppointmentRepository,
 ) {
-  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan) {
+  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan, alreadyCreatedSessions: Int = 0) {
     val numberOfSessions = approvedActionPlan.numberOfSessions!!
-    for (i in 1..numberOfSessions) {
+    for (i in alreadyCreatedSessions + 1..numberOfSessions) {
       createSession(approvedActionPlan, i)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Aut
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DesiredOutcomeRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanSessionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.time.OffsetDateTime
@@ -48,6 +50,7 @@ internal class ActionPlanServiceTest {
   private val referralFactory = ReferralFactory()
   private val actionPlanFactory = ActionPlanFactory()
   private val appointmentFactory = AppointmentFactory()
+  private val actionPlanSessionFactory = ActionPlanSessionFactory()
 
   private val actionPlanService = ActionPlanService(
     authUserRepository,
@@ -229,7 +232,30 @@ internal class ActionPlanServiceTest {
     assertThat(approvedActionPlan.approvedAt).isNotNull
     assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
     verify(actionPlanEventPublisher).actionPlanApprovedEvent(same(actionPlan))
-    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(actionPlan))
+    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(actionPlan), same(1))
+  }
+
+  @Test
+  fun `action plan approval call reassign if there's a previously approved action plan on the referral`() {
+    val newActionPlanId = UUID.randomUUID()
+    val referral = referralFactory.createSent()
+    val previouslyApprovedActionPlan = actionPlanFactory.createApproved(numberOfSessions = 2, referral = referral)
+    val newActionPlan = actionPlanFactory.createSubmitted(id = newActionPlanId, numberOfSessions = 2, referral = referral)
+    referral.actionPlans = mutableListOf(previouslyApprovedActionPlan, newActionPlan)
+
+    val authUser = AuthUser("CRN123", "auth", "user")
+    whenever(actionPlanRepository.findById(newActionPlanId)).thenReturn(of(newActionPlan))
+    whenever(authUserRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<AuthUser>())
+    whenever(actionPlanRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<ActionPlan>())
+    whenever(actionPlanSessionRepository.findAllByActionPlanId(any())).thenReturn(listOf(actionPlanSessionFactory.createAttended(), actionPlanSessionFactory.createAttended()))
+    whenever(actionPlanSessionRepository.save(any())).thenReturn(null)
+
+    val approvedActionPlan = actionPlanService.approveActionPlan(newActionPlanId, authUser)
+    assertThat(approvedActionPlan.approvedAt).isNotNull
+    assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
+    verify(actionPlanEventPublisher).actionPlanApprovedEvent(same(newActionPlan))
+    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(newActionPlan), same(3))
+    verify(actionPlanSessionRepository, times(2)).save(any())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -232,7 +232,7 @@ internal class ActionPlanServiceTest {
     assertThat(approvedActionPlan.approvedAt).isNotNull
     assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
     verify(actionPlanEventPublisher).actionPlanApprovedEvent(same(actionPlan))
-    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(actionPlan), same(1))
+    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(actionPlan), same(0))
   }
 
   @Test
@@ -254,7 +254,7 @@ internal class ActionPlanServiceTest {
     assertThat(approvedActionPlan.approvedAt).isNotNull
     assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
     verify(actionPlanEventPublisher).actionPlanApprovedEvent(same(newActionPlan))
-    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(newActionPlan), same(3))
+    verify(actionPlanSessionsService).createUnscheduledSessionsForActionPlan(same(newActionPlan), same(2))
     verify(actionPlanSessionRepository, times(2)).save(any())
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsServiceTest.kt
@@ -71,6 +71,17 @@ internal class ActionPlanSessionsServiceTest {
   }
 
   @Test
+  fun `create unscheduled sessions where some sessions are already created`() {
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 3)
+    whenever(actionPlanSessionRepository.findByActionPlanIdAndSessionNumber(eq(actionPlan.id), any())).thenReturn(null)
+    whenever(authUserRepository.save(actionPlan.createdBy)).thenReturn(actionPlan.createdBy)
+    whenever(actionPlanSessionRepository.save(any())).thenAnswer { it.arguments[0] }
+
+    actionPlanSessionsService.createUnscheduledSessionsForActionPlan(actionPlan, 1)
+    verify(actionPlanSessionRepository, times(2)).save(any())
+  }
+
+  @Test
   fun `create unscheduled sessions throws exception if session already exists`() {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 1)
 


### PR DESCRIPTION
## What does this pull request do?

Allows the approval of a new draft action plan for a referral when it already has an approved one. This includes transferring all the action plan sessions from the previously approved action plan to the new one, using the existing approval endpoint.

## What is the intent behind these changes?

To allow the approval of a new draft action plan when there has previously been on approved.
