### PR TITLE
Fix performance report job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
@@ -28,6 +28,8 @@ class ReportingService(
       performanceReportJob,
       JobParametersBuilder()
         .addString("user.id", user.id)
+        .addString("user.authSource", user.authSource)
+        .addString("user.userName", user.userName)
         .addString("user.firstName", userDetail.firstName)
         .addString("user.email", userDetail.email)
         .addDate("from", batchUtils.parseLocalDateToDate(from))


### PR DESCRIPTION
Replaced user.id parameter in performanceReportReader Job with authUser. This variable now holds the AuthUser entity.

The reason for this change is because the job was failing for some users because they didn't have any user details persisted into the database.
The job was trying to retrieve the user details from the db based on the user id passed in the job.

Since the contracts are held on the authUser passed in via Auth we don't need to persist and retrieve it from the database.
