### PR TITLE
Do not upgrade awssdk with patch level changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "software.amazon.awssdk:*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION


## What does this pull request do?

Do not upgrade awssdk with patch level changes

## What is the intent behind these changes?

All of the AWS SDK libraries get updated at the same time, and most of
the time the updates are not relevant

Any relevant updates will be posted via minor version changes