### PR TITLE
IC-1116 use end requested description instead of code in SP performance report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
@@ -41,7 +41,7 @@ class PerformanceReportProcessor(
       numberOfSessions = approvedActionPlan?.numberOfSessions,
       numberOfSessionsAttended = approvedActionPlan?.let { actionPlanService.getAllAttendedAppointments(it).size },
       endRequestedAt = referral.endRequestedAt,
-      endRequestedReason = referral.endRequestedReason?.code,
+      endRequestedReason = referral.endRequestedReason?.description,
       eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
       concludedAt = referral.concludedAt,
     )


### PR DESCRIPTION
## What does this pull request do?

use end requested description instead of code in SP performance report

## What is the intent behind these changes?

make the report more readable for SPs
