### PR TITLE
IC-1116 Improve the way contracts references are passed to the SP performance report batch job.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
@@ -19,17 +19,14 @@ class ReportingService(
   private val hmppsAuthService: HMPPSAuthService,
 ) {
   fun generateServiceProviderPerformanceReport(from: LocalDate, to: LocalDate, user: AuthUser) {
-    // this is really not ideal - but the intention here is validate the user has
-    // a valid access scope before launching the job (which will also call this method).
-    serviceProviderAccessScopeMapper.fromUser(user)
-
+    val contracts = serviceProviderAccessScopeMapper.fromUser(user).contracts
     val userDetail = hmppsAuthService.getUserDetail(user)
+
     asyncJobLauncher.run(
       performanceReportJob,
       JobParametersBuilder()
+        .addString("contractReferences", contracts.joinToString(",") { it.contractReference })
         .addString("user.id", user.id)
-        .addString("user.authSource", user.authSource)
-        .addString("user.userName", user.userName)
         .addString("user.firstName", userDetail.firstName)
         .addString("user.email", userDetail.email)
         .addDate("from", batchUtils.parseLocalDateToDate(from))


### PR DESCRIPTION
## What does this pull request do?

Instead of passing the auth user fields to the batch job, we construct a comma seperated
list of the contracts. This has a few benefits:
 1) We do not have to load the user access scopes twice (again in the step reader)
 2) The job parameters are more reflective of the actual work being done.
 3) The contracts are logged automatically by the batch framework when the job is launched.
 
 e.g. 
 ```
 2021-08-24 12:57:02.730  INFO 65856 --- [lTaskExecutor-1] o.s.b.c.l.support.SimpleJobLauncher      : Job: [SimpleJob: [name=performanceReportJob]] launched with the following parameters: [{contractReferences=0001,0002,0003,0004,0005,0006, user.id=6c4036b7-e87d-44fb-864f-5a06c1c492f3, user.firstName=Robin, user.email=test.interventions.sp.1@digital.justice.gov.uk, from=1609459200000, to=1640995200000, timestamp=1629806222643}]
```

The maximum length of string job params is 250 chars. This limits us to users with approx 27 contracts associated with their account. This is very unlikely to ever happen. If it does we can increase the size of the string param in the sql migration scripts.
