### PR TITLE
Ic 1397/provide ability to obtain list of case notes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
@@ -71,6 +72,11 @@ class ResourceServerConfiguration(private val tokenVerifier: TokenVerifier) : We
   @Profile("test")
   fun testJwtDecoder(): JwtDecoder {
     return TestJwtDecoder()
+  }
+
+  @Bean
+  fun pageableResolver(): PageableHandlerMethodArgumentResolver? {
+    return PageableHandlerMethodArgumentResolver()
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
@@ -1,7 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -11,12 +16,13 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CaseNoteDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateCaseNoteDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CaseNoteService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
+import java.util.UUID
 
 @RestController
 class CaseNoteController(
   val userMapper: UserMapper,
   val caseNoteService: CaseNoteService,
-  val referralService: ReferralService,
+  val referralService: ReferralService
 ) {
   @PostMapping("/case-note")
   fun createCaseNote(
@@ -34,5 +40,18 @@ class CaseNoteController(
       sentByUser = user
     )
     return CaseNoteDTO.from(caseNote)
+  }
+
+  @GetMapping("/sent-referral/{referralId}/case-notes")
+  fun getCaseNotes(
+    @PageableDefault(page = 0, size = 10, sort = ["sentAt"]) pageable: Pageable,
+    @PathVariable referralId: UUID,
+    authentication: JwtAuthenticationToken
+  ): Page<CaseNoteDTO> {
+    val user = userMapper.fromToken(authentication)
+    val sentReferral = referralService.getSentReferralForUser(referralId, user) ?: throw ResponseStatusException(
+      HttpStatus.NOT_FOUND, "sent referral not found [id=$referralId]"
+    )
+    return caseNoteService.findByReferral(sentReferral.id, pageable).map { caseNote -> CaseNoteDTO.from(caseNote) }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/CaseNoteRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/CaseNoteRepository.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
-import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.PagingAndSortingRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CaseNote
 import java.util.UUID
 
-interface CaseNoteRepository : JpaRepository<CaseNote, UUID>
+interface CaseNoteRepository : PagingAndSortingRepository<CaseNote, UUID> {
+  fun findAllByReferralId(referralId: UUID, pageable: Pageable?): Page<CaseNote>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CaseNote
@@ -28,5 +30,9 @@ class CaseNoteService(
       sentAt = OffsetDateTime.now(),
     )
     return caseNoteRepository.save(caseNote)
+  }
+
+  fun findByReferral(referralId: UUID, pageable: Pageable?): Page<CaseNote> {
+    return caseNoteRepository.findAllByReferralId(referralId, pageable)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.App
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CaseNoteRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ContractTypeRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DesiredOutcomeRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DynamicFrameworkContractRepository
@@ -51,6 +52,7 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var supplierAssessmentRepository: SupplierAssessmentRepository
   @Autowired protected lateinit var appointmentDeliveryRepository: AppointmentDeliveryRepository
   @Autowired protected lateinit var appointmentDeliveryAddressRepository: AppointmentDeliveryAddressRepository
+  @Autowired protected lateinit var caseNoteRepository: CaseNoteRepository
   protected lateinit var setupAssistant: SetupAssistant
 
   @BeforeEach
@@ -72,7 +74,8 @@ abstract class IntegrationTestBase {
       appointmentRepository,
       supplierAssessmentRepository,
       appointmentDeliveryRepository,
-      appointmentDeliveryAddressRepository
+      appointmentDeliveryAddressRepository,
+      caseNoteRepository
     )
     setupAssistant.cleanAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CaseNote
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ComplexityLevel
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ContractType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
@@ -32,6 +33,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.App
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CaseNoteRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ContractTypeRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DesiredOutcomeRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DynamicFrameworkContractRepository
@@ -45,6 +47,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Sup
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentDeliveryAddressFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentDeliveryFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.CaseNoteFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
@@ -80,6 +83,7 @@ class SetupAssistant(
   private val supplierAssessmentRepository: SupplierAssessmentRepository,
   private val appointmentDeliveryRepository: AppointmentDeliveryRepository,
   private val appointmentDeliveryAddressRepository: AppointmentDeliveryAddressRepository,
+  private val caseNoteRepository: CaseNoteRepository,
 ) {
   private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
   private val interventionFactory = InterventionFactory()
@@ -91,6 +95,7 @@ class SetupAssistant(
   private val appointmentDeliveryAddressFactory = AppointmentDeliveryAddressFactory()
   private val supplierAssessmentFactory = SupplierAssessmentFactory()
   private val serviceUserFactory = ServiceUserFactory()
+  private val caseNoteFactory = CaseNoteFactory()
 
   val serviceCategories = serviceCategoryRepository.findAll().associateBy { it.name }
   val npsRegions = npsRegionRepository.findAll().associateBy { it.id }
@@ -526,5 +531,14 @@ class SetupAssistant(
     )
     referral.endOfServiceReport = eosr
     return eosr
+  }
+
+  fun createCaseNote(
+    referral: Referral,
+    subject: String,
+    body: String
+  ): CaseNote {
+    val caseNote = caseNoteFactory.create(referral = referral, subject = subject, body = body)
+    return caseNoteRepository.save(caseNote)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/CaseNoteContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/CaseNoteContracts.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.pact
+
+import au.com.dius.pact.provider.junitsupport.State
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.SetupAssistant
+import java.util.UUID
+
+class CaseNoteContracts(private val setupAssistant: SetupAssistant) {
+  @State("There is an existing sent referral with ID of 03bf1369-00d3-4b7f-88b2-da3cc8cc35b9, and it has 20 case notes")
+  fun `create referral with 20 case notes`() {
+    val referral = setupAssistant.createAssignedReferral(id = UUID.fromString("03bf1369-00d3-4b7f-88b2-da3cc8cc35b9"))
+    for (i in 1..20) {
+      setupAssistant.createCaseNote(referral, subject = "subject for case note $i of 20", body = "body for case note $i of 20")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteServiceTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CaseNoteRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
@@ -12,6 +14,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFacto
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.CaseNoteFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 @RepositoryTest
 class CaseNoteServiceTest @Autowired constructor(
@@ -39,6 +44,81 @@ class CaseNoteServiceTest @Autowired constructor(
       assertThat(caseNote.body).isEqualTo("body")
       assertThat(caseNote.sentAt).isNotNull()
       assertThat(caseNote.sentBy).isEqualTo(user)
+    }
+  }
+
+  @Nested
+  inner class FindByReferral {
+    @Test
+    fun `can find case note by referral id with no pageable parameter`() {
+      val referral = referralFactory.createSent()
+      val caseNote = caseNoteFactory.create(referral = referral, subject = "subject", body = "body")
+
+      val caseNotes = caseNoteService.findByReferral(referralId = referral.id, null)
+
+      assertThat(caseNotes.totalPages).isEqualTo(1)
+      assertThat(caseNotes.numberOfElements).isEqualTo(1)
+      assertThat(caseNotes.number).isEqualTo(0)
+      assertThat(caseNotes.content).isEqualTo(listOf(caseNote))
+    }
+
+    @Test
+    fun `can return the correct page of case notes with provided pageable`() {
+      val referral = referralFactory.createSent()
+      val caseNote5 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 5, 0), ZoneOffset.MAX)
+      )
+      val caseNote1 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 1, 0), ZoneOffset.MAX)
+      )
+      val caseNote2 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 2, 0), ZoneOffset.MAX)
+      )
+      val caseNote4 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 4, 0), ZoneOffset.MAX)
+      )
+      val caseNote7 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 7, 0), ZoneOffset.MAX)
+      )
+      val caseNote6 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 6, 0), ZoneOffset.MAX)
+      )
+      val caseNote3 = caseNoteFactory.create(
+        referral = referral, subject = "subject", body = "body",
+        sentAt = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 3, 0), ZoneOffset.MAX)
+      )
+
+      val caseNotes = caseNoteService.findByReferral(
+        referralId = referral.id,
+        PageRequest.of(
+          1, 3,
+          Sort.by("sentAt")
+        )
+      )
+
+      assertThat(caseNotes.totalPages).isEqualTo(3)
+      assertThat(caseNotes.numberOfElements).isEqualTo(3)
+      assertThat(caseNotes.number).isEqualTo(1)
+      assertThat(caseNotes.content).isEqualTo(listOf(caseNote4, caseNote5, caseNote6))
+    }
+
+    @Test
+    fun `returns empty when page is out of bounds`() {
+      val referral = referralFactory.createSent()
+      caseNoteFactory.create(referral = referral, subject = "subject", body = "body")
+
+      val caseNotes = caseNoteService.findByReferral(referralId = referral.id, PageRequest.of(2, 1))
+
+      assertThat(caseNotes.totalPages).isEqualTo(1)
+      assertThat(caseNotes.numberOfElements).isEqualTo(0)
+      assertThat(caseNotes.number).isEqualTo(2)
+      assertThat(caseNotes.content).isEmpty()
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Provided ability to request for a list of paginated case notes.

The request /sent-referral/{referralId}/case-notes can accept a Pageable request parameters. Pageable is a defined spring interface where each value can be nullable. If none are provided then the default values are used - in this case page-size=10, page-number=0.

PageableHandlerMethodArgumentResolver bean had to be added in order to accept pageable request parameters.

## What is the intent behind these changes?

Ensure that we have a way to obtain a list of case notes for a referral with pagination to reduce stress on the server.
