### PR TITLE
Notify live deployments in the stakeholder channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
           env: "prod"
           show_changelog: true
           slack_notification: true
-          slack_channel_name: "interventions-alerts"
+          slack_channel_name: "interventions"
           requires:
             - approve_prod
           context:


### PR DESCRIPTION

## What does this pull request do?

Notify live deployments in the stakeholder channel

## What is the intent behind these changes?

To be as open and visible as possible

## Related

- https://github.com/ministryofjustice/hmpps-interventions-ui/pull/761