### PR TITLE
IC-707 Add GET /case-note/{id} endpoint to get an individual case note

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateCaseNote
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CaseNoteService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import java.util.UUID
+import javax.persistence.EntityNotFoundException
 
 @RestController
 class CaseNoteController(
@@ -53,5 +54,12 @@ class CaseNoteController(
       HttpStatus.NOT_FOUND, "sent referral not found [id=$referralId]"
     )
     return caseNoteService.findByReferral(sentReferral.id, pageable).map { caseNote -> CaseNoteDTO.from(caseNote) }
+  }
+
+  @GetMapping("/case-note/{id}")
+  fun getCaseNote(@PathVariable id: UUID, authentication: JwtAuthenticationToken): CaseNoteDTO {
+    return caseNoteService.getCaseNoteForUser(id, userMapper.fromToken(authentication))
+      ?.let { CaseNoteDTO.from(it) }
+      ?: throw EntityNotFoundException("case note not found [id=$id]")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CaseNote
@@ -17,6 +18,7 @@ import javax.transaction.Transactional
 class CaseNoteService(
   val caseNoteRepository: CaseNoteRepository,
   val referralRepository: ReferralRepository,
+  val referralService: ReferralService,
   val authUserRepository: AuthUserRepository,
 ) {
 
@@ -34,5 +36,16 @@ class CaseNoteService(
 
   fun findByReferral(referralId: UUID, pageable: Pageable?): Page<CaseNote> {
     return caseNoteRepository.findAllByReferralId(referralId, pageable)
+  }
+
+  fun getCaseNoteForUser(id: UUID, user: AuthUser): CaseNote? {
+    val caseNote = caseNoteRepository.findByIdOrNull(id)
+
+    // validate that the user has access to the associated referral
+    caseNote?.let {
+      referralService.getSentReferralForUser(it.id, user)
+    }
+
+    return caseNote
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -536,9 +536,10 @@ class SetupAssistant(
   fun createCaseNote(
     referral: Referral,
     subject: String,
-    body: String
+    body: String,
+    id: UUID = UUID.randomUUID(),
   ): CaseNote {
-    val caseNote = caseNoteFactory.create(referral = referral, subject = subject, body = body)
+    val caseNote = caseNoteFactory.create(id = id, referral = referral, subject = subject, body = body)
     return caseNoteRepository.save(caseNote)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/CaseNoteContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/CaseNoteContracts.kt
@@ -5,11 +5,15 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.SetupA
 import java.util.UUID
 
 class CaseNoteContracts(private val setupAssistant: SetupAssistant) {
-  @State("There is an existing sent referral with ID of 03bf1369-00d3-4b7f-88b2-da3cc8cc35b9, and it has 20 case notes")
+  @State(
+    "There is an existing sent referral with ID of 03bf1369-00d3-4b7f-88b2-da3cc8cc35b9, and it has 20 case notes",
+    "There is an existing case note with ID of bd048235-c41f-420a-a587-d447abf93889",
+  )
   fun `create referral with 20 case notes`() {
     val referral = setupAssistant.createAssignedReferral(id = UUID.fromString("03bf1369-00d3-4b7f-88b2-da3cc8cc35b9"))
     for (i in 1..20) {
-      setupAssistant.createCaseNote(referral, subject = "subject for case note $i of 20", body = "body for case note $i of 20")
+      val id = if (i == 1) UUID.fromString("bd048235-c41f-420a-a587-d447abf93889") else UUID.randomUUID()
+      setupAssistant.createCaseNote(referral, subject = "subject for case note $i of 20", body = "body for case note $i of 20", id = id)
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Add GET /case-note/{id} endpoint to get an individual case note

## What is the intent behind these changes?

allow a single case not to be retrieved 
