### PR TITLE
Make pagination requests non zero indexed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
@@ -72,11 +71,6 @@ class ResourceServerConfiguration(private val tokenVerifier: TokenVerifier) : We
   @Profile("test")
   fun testJwtDecoder(): JwtDecoder {
     return TestJwtDecoder()
-  }
-
-  @Bean
-  fun pageableResolver(): PageableHandlerMethodArgumentResolver? {
-    return PageableHandlerMethodArgumentResolver()
   }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,10 @@ spring:
         performance-report:
           page-size: 100
           chunk-size: 20
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
 
 server:
   port: 8080


### PR DESCRIPTION
## What does this pull request do?

Removes an unnecessary bean.

Makes pageable requests to start from 1 instead of 0.

## What is the intent behind these changes?

Makes it easier for caller as they don't have to decrement the page number; naturally page numbers will start from 1 rather than 0 from the UI.
