### PR TITLE
Added CaseNoteContracts to PactTests.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
@@ -70,6 +70,7 @@ class PactTest : IntegrationTestBase() {
       EndOfServiceReportContracts(setupAssistant),
       SupplierAssessmentContracts(setupAssistant),
       ReportingContracts(setupAssistant),
+      CaseNoteContracts(setupAssistant)
     )
   }
 


### PR DESCRIPTION
 Added CaseNoteContracts to PactTests. Currently the case note contracts are not activated for pact testing.
