### PR TITLE
Make referral id unique for pact tests of case notes

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/CaseNoteContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/CaseNoteContracts.kt
@@ -6,11 +6,11 @@ import java.util.UUID
 
 class CaseNoteContracts(private val setupAssistant: SetupAssistant) {
   @State(
-    "There is an existing sent referral with ID of 03bf1369-00d3-4b7f-88b2-da3cc8cc35b9, and it has 20 case notes",
+    "There is an existing sent referral with ID of 7197d9b1-ca8b-475c-9f44-1fed47778c23, and it has 20 case notes",
     "There is an existing case note with ID of bd048235-c41f-420a-a587-d447abf93889",
   )
   fun `create referral with 20 case notes`() {
-    val referral = setupAssistant.createAssignedReferral(id = UUID.fromString("03bf1369-00d3-4b7f-88b2-da3cc8cc35b9"))
+    val referral = setupAssistant.createAssignedReferral(id = UUID.fromString("7197d9b1-ca8b-475c-9f44-1fed47778c23"))
     for (i in 1..20) {
       val id = if (i == 1) UUID.fromString("bd048235-c41f-420a-a587-d447abf93889") else UUID.randomUUID()
       setupAssistant.createCaseNote(referral, subject = "subject for case note $i of 20", body = "body for case note $i of 20", id = id)


### PR DESCRIPTION
The referal id for case notes needs to be unique. The id was copied from an existing state rather than generating a new one