### PR TITLE
Auth user for createCaseNote must be created in SetupAssistant rather than within factory.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -538,8 +538,9 @@ class SetupAssistant(
     subject: String,
     body: String,
     id: UUID = UUID.randomUUID(),
+    authUser: AuthUser = createSPUser(),
   ): CaseNote {
-    val caseNote = caseNoteFactory.create(id = id, referral = referral, subject = subject, body = body)
+    val caseNote = caseNoteFactory.create(id = id, referral = referral, subject = subject, body = body, sentBy = authUser)
     return caseNoteRepository.save(caseNote)
   }
 }


### PR DESCRIPTION
Auth user for createCaseNote must be created in SetupAssistant rather than within factory. This is because the entity manager is not passed into Factory classes in SetupAssistant