### PR TITLE
IC-2207 Set NotifyPP/ReferToOffengerMgr to true for all non-attended appointments

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIAppointmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIAppointmentEventServiceTest.kt
@@ -10,6 +10,8 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventType.SESSION_FEEDBACK_RECORDED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.LATE
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.YES
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import java.time.OffsetDateTime
@@ -21,20 +23,59 @@ class CommunityAPIAppointmentEventServiceTest {
 
   private val appointmentFactory = AppointmentFactory()
 
-  @Test
-  fun `got service successfully`() {
+  private val communityAPIService = CommunityAPIAppointmentEventService(
+    "http://baseUrl",
+    "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback",
+    "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",
+    "commissioned-rehabilitation-services",
+    communityAPIClient
+  )
 
-    val communityAPIService = CommunityAPIAppointmentEventService(
-      "http://baseUrl",
-      "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback",
-      "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",
-      "commissioned-rehabilitation-services",
-      communityAPIClient
-    )
-    appointmentEvent.appointment.referral.referenceNumber = "X123456"
+  @Test
+  fun `notifies community-api of late attended appointment outcome`() {
+
+    appointmentEvent.appointment.attended = LATE
+    appointmentEvent.appointment.notifyPPOfAttendanceBehaviour = false
 
     communityAPIService.onApplicationEvent(appointmentEvent)
 
+    verifyNotification(LATE.name, false)
+  }
+
+  @Test
+  fun `notifies community-api of attended appointment outcome`() {
+
+    appointmentEvent.appointment.attended = YES
+    appointmentEvent.appointment.notifyPPOfAttendanceBehaviour = false
+
+    communityAPIService.onApplicationEvent(appointmentEvent)
+
+    verifyNotification(YES.name, false)
+  }
+
+  @Test
+  fun `notifies community-api of non attended appointment outcome and notify PP set is always set`() {
+
+    appointmentEvent.appointment.attended = NO
+    appointmentEvent.appointment.notifyPPOfAttendanceBehaviour = false
+
+    communityAPIService.onApplicationEvent(appointmentEvent)
+
+    verifyNotification(NO.name, true)
+  }
+
+  @Test
+  fun `notifies community-api of appointment outcome with notify PP set`() {
+
+    appointmentEvent.appointment.attended = YES
+    appointmentEvent.appointment.notifyPPOfAttendanceBehaviour = true
+
+    communityAPIService.onApplicationEvent(appointmentEvent)
+
+    verifyNotification(YES.name, true)
+  }
+
+  private fun verifyNotification(attended: String, notifyPP: Boolean) {
     val urlCaptor = argumentCaptor<String>()
     val payloadCaptor = argumentCaptor<Any>()
     verify(communityAPIClient).makeAsyncPostRequest(urlCaptor.capture(), payloadCaptor.capture())
@@ -43,8 +84,8 @@ class CommunityAPIAppointmentEventServiceTest {
       AppointmentOutcomeRequest(
         "Session Feedback Recorded for Accommodation Referral X123456 with Prime Provider TOP Service Provider\n" +
           "http://baseUrl/probation-practitioner/referrals/356d0712-5266-4d18-9070-058244873f2c/supplier-assessment/post-session-feedback",
-        "LATE",
-        true
+        attended,
+        notifyPP
       ).toString()
     )
   }
@@ -54,14 +95,12 @@ class CommunityAPIAppointmentEventServiceTest {
     SESSION_FEEDBACK_RECORDED,
     appointmentFactory.create(
       id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
-      referral = SampleData.sampleReferral("CRN123", "TOP Service Provider", UUID.fromString("356d0712-5266-4d18-9070-058244873f2c")),
+      referral = SampleData.sampleReferral("CRN123", "TOP Service Provider", UUID.fromString("356d0712-5266-4d18-9070-058244873f2c"), "X123456"),
       appointmentTime = OffsetDateTime.now(),
       durationInMinutes = 60,
       createdBy = SampleData.sampleAuthUser("userId", "auth", "me"),
-      attended = LATE,
       additionalAttendanceInformation = "dded notes",
       attendanceSubmittedAt = OffsetDateTime.now(),
-      notifyPPOfAttendanceBehaviour = true,
       deliusAppointmentId = 123456L
     ),
     "http://localhost:8080/url/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",


### PR DESCRIPTION
**What does this pull request do?**
Prior to this change a "refer to offender manager" alert was only raised in Delius when the offender's behaviour was bad. After this change, the alert is also raised for all non attendance, both supplier assessments and service delivery.

**What is the intent behind these changes?**
In using R&M, Probation Practitioners were also expecting a ROM alert for non-attendance which was highlighted during feedback sessions.
