### PR TITLE
ic-1833 initial db change to add referal to action plan session

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanSession.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ActionPlanSession.kt
@@ -24,6 +24,7 @@ data class ActionPlanSession(
 
   @NotNull @ManyToOne val actionPlan: ActionPlan,
   @Id val id: UUID,
+  @ManyToOne val referral: Referral?,
 ) {
   // this class is designed to allow multiple appointments per session,
   // however this functionality is not currently used. to make life

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanSessionsService.kt
@@ -51,6 +51,7 @@ class ActionPlanSessionsService(
     val session = ActionPlanSession(
       id = UUID.randomUUID(),
       sessionNumber = sessionNumber,
+      referral = actionPlan.referral,
       actionPlan = actionPlan,
     )
 

--- a/src/main/resources/db/migration/V1_77_0__associate_action_plan_sessions_with_referrals_schema.sql
+++ b/src/main/resources/db/migration/V1_77_0__associate_action_plan_sessions_with_referrals_schema.sql
@@ -1,0 +1,3 @@
+alter table action_plan_session
+    add column referral_id uuid,
+    add constraint fk_referral_id foreign key (referral_id) references referral;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -470,6 +470,7 @@ class SetupAssistant(
       sessionNumber = sessionNumber,
       appointments = mutableSetOf(appointment),
       actionPlan = actionPlan,
+      referral = actionPlan.referral,
     )
     return actionPlanSessionRepository.save(session)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -299,14 +299,15 @@ internal class ActionPlanServiceTest {
         unattendedAppointments[1],
         lateAppointments[0]
       ),
-      1, actionPlan, UUID.randomUUID()
+      1, actionPlan, UUID.randomUUID(), actionPlan.referral,
     )
 
     val session2 = ActionPlanSession(
       appointments = mutableSetOf(unattendedAppointments[2], attendedAppointments[0]),
       2,
       actionPlan,
-      UUID.randomUUID()
+      UUID.randomUUID(),
+      actionPlan.referral,
     )
 
     val session3 = ActionPlanSession(
@@ -315,7 +316,7 @@ internal class ActionPlanServiceTest {
         unattendedAppointments[4],
         lateAppointments[1]
       ),
-      3, actionPlan, UUID.randomUUID()
+      3, actionPlan, UUID.randomUUID(), actionPlan.referral,
     )
 
     whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan.id)).thenReturn(listOf(session1, session2, session3))
@@ -337,8 +338,8 @@ internal class ActionPlanServiceTest {
     val first = appointmentFactory.create(referral = referral, appointmentTime = OffsetDateTime.now().minusHours(2), attended = Attended.LATE, appointmentFeedbackSubmittedAt = OffsetDateTime.now())
     val second = appointmentFactory.create(referral = referral, appointmentTime = OffsetDateTime.now().minusHours(1), attended = Attended.YES, appointmentFeedbackSubmittedAt = OffsetDateTime.now())
 
-    val session1 = ActionPlanSession(appointments = mutableSetOf(first), 1, actionPlan, UUID.randomUUID())
-    val session2 = ActionPlanSession(appointments = mutableSetOf(second), 2, actionPlan, UUID.randomUUID())
+    val session1 = ActionPlanSession(appointments = mutableSetOf(first), 1, actionPlan, UUID.randomUUID(), actionPlan.referral)
+    val session2 = ActionPlanSession(appointments = mutableSetOf(second), 2, actionPlan, UUID.randomUUID(), actionPlan.referral)
 
     whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan.id)).thenReturn(listOf(session1, session2))
     assertThat(actionPlanService.getFirstAttendedAppointment(actionPlan)).isEqualTo(first)
@@ -351,8 +352,8 @@ internal class ActionPlanServiceTest {
     whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan.id)).thenReturn(emptyList())
     assertThat(actionPlanService.getFirstAttendedAppointment(actionPlan)).isNull()
 
-    val session1 = ActionPlanSession(appointments = mutableSetOf(appointmentFactory.create(referral = referral, appointmentTime = OffsetDateTime.now().minusHours(2), attended = Attended.NO, appointmentFeedbackSubmittedAt = OffsetDateTime.now())), 1, actionPlan, UUID.randomUUID())
-    val session2 = ActionPlanSession(appointments = mutableSetOf(appointmentFactory.create(referral = referral, appointmentTime = OffsetDateTime.now().minusHours(1), attended = Attended.NO, appointmentFeedbackSubmittedAt = OffsetDateTime.now())), 2, actionPlan, UUID.randomUUID())
+    val session1 = ActionPlanSession(appointments = mutableSetOf(appointmentFactory.create(referral = referral, appointmentTime = OffsetDateTime.now().minusHours(2), attended = Attended.NO, appointmentFeedbackSubmittedAt = OffsetDateTime.now())), 1, actionPlan, UUID.randomUUID(), actionPlan.referral)
+    val session2 = ActionPlanSession(appointments = mutableSetOf(appointmentFactory.create(referral = referral, appointmentTime = OffsetDateTime.now().minusHours(1), attended = Attended.NO, appointmentFeedbackSubmittedAt = OffsetDateTime.now())), 2, actionPlan, UUID.randomUUID(), actionPlan.referral)
 
     whenever(actionPlanSessionRepository.findAllByActionPlanId(actionPlan.id)).thenReturn(listOf(session1, session2))
     assertThat(actionPlanService.getFirstAttendedAppointment(actionPlan)).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ActionPlanSessionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ActionPlanSessionFactory.kt
@@ -22,7 +22,8 @@ class ActionPlanSessionFactory(em: TestEntityManager? = null) : EntityFactory(em
         id = id,
         actionPlan = actionPlan,
         sessionNumber = sessionNumber,
-        appointments = mutableSetOf()
+        appointments = mutableSetOf(),
+        referral = actionPlan.referral
       )
     )
   }
@@ -51,7 +52,8 @@ class ActionPlanSessionFactory(em: TestEntityManager? = null) : EntityFactory(em
         id = id,
         actionPlan = actionPlan,
         sessionNumber = sessionNumber,
-        appointments = mutableSetOf(appointment)
+        appointments = mutableSetOf(appointment),
+        referral = actionPlan.referral
       )
     )
   }
@@ -91,7 +93,8 @@ class ActionPlanSessionFactory(em: TestEntityManager? = null) : EntityFactory(em
         id = id,
         actionPlan = actionPlan,
         sessionNumber = sessionNumber,
-        appointments = mutableSetOf(appointment)
+        appointments = mutableSetOf(appointment),
+        referral = actionPlan.referral
       )
     )
   }


### PR DESCRIPTION
## What does this pull request do?

Adds the new referral field to the db, whilst maintaining the action plan field for now.

## What is the intent behind these changes?

Pre-requisite for upcoming changes to move action plan session from being on an action to a referral.
