### PR TITLE
Pact test fix for case notes

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -104,6 +104,7 @@ class SetupAssistant(
 
   fun cleanAll() {
     // order of cleanup is important here to avoid breaking foreign key constraints
+    caseNoteRepository.deleteAll()
     actionPlanSessionRepository.deleteAll()
     supplierAssessmentRepository.deleteAll()
     actionPlanRepository.deleteAll()


### PR DESCRIPTION
Case notes must be deleted on clean up for setup assistant. There is a foreign key constraint with referral_id on the case_note table..