### PR TITLE
Change data extractor back to v1

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -11,7 +11,7 @@ spec:
           restartPolicy: "Never"
           containers:
           - name: data-extractor-analytics
-            image: ministryofjustice/data-engineering-data-extractor:develop
+            image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
             args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             env:


### PR DESCRIPTION
## What does this pull request do?

Reverts ministryofjustice/hmpps-interventions-service#503

The problems initially requiring this change have been rolled out to v1 now.

## Related

- ministryofjustice/hmpps-interventions-service#503
- ministryofjustice/data-engineering-data-extractor#69
- https://github.com/ministryofjustice/data-engineering-data-extractor/releases/tag/v1.1.1