### PR TITLE
Scheduled preprod refresh job

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.env_details.prod_to_preprod_refresh_job -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-refresh-script
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -e
+
+    echo "${DB_HOST}:5432:${DB_NAME}:${DB_USER}:${DB_PASS}" > ~/.pgpass
+    echo "${DB_HOST_PREPROD}:5432:${DB_NAME_PREPROD}:${DB_USER_PREPROD}:${DB_PASS_PREPROD}" >> ~/.pgpass
+    chmod 0600 ~/.pgpass
+
+    set -x
+    pg_dump --host="$DB_HOST" --username="$DB_USER" --format=custom --no-privileges --verbose --file=/tmp/db.dump "$DB_NAME"
+    pg_restore --host="$DB_HOST_PREPROD" --username="$DB_USER_PREPROD" --clean --no-owner --verbose --dbname="$DB_NAME_PREPROD" /tmp/db.dump
+
+    rm -v /tmp/db.dump ~/.pgpass
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: db-refresh-job
+spec:
+  schedule: "0 8 * * 0"
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 1200
+      template:
+        spec:
+          securityContext:
+            runAsUser: 999
+          containers:
+            - name: dbrefresh
+              image: "postgres:10"
+              command:
+                - /bin/entrypoint.sh
+              volumeMounts:
+                - name: db-refresh-script
+                  mountPath: /bin/entrypoint.sh
+                  readOnly: true
+                  subPath: entrypoint.sh
+              env:
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres
+                      key: database_name
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres
+                      key: database_username
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres
+                      key: database_password
+                - name: DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres
+                      key: rds_instance_address
+                - name: DB_NAME_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-preprod
+                      key: database_name
+                - name: DB_USER_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-preprod
+                      key: database_username
+                - name: DB_PASS_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-preprod
+                      key: database_password
+                - name: DB_HOST_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-preprod
+                      key: rds_instance_address
+          restartPolicy: "Never"
+          volumes:
+            - name: db-refresh-script
+              configMap:
+                name: db-refresh-script
+                defaultMode: 0755
+{{- end }}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.env_details.prod_to_preprod_refresh_job -}}
+{{- if .Values.env_details.production_env -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.env_details.post_stats_to_team_slack -}}
+{{- if .Values.env_details.production_env -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,8 +13,7 @@ ingress:
 
 env_details:
   contains_live_data: true
-  post_stats_to_team_slack: true
-  prod_to_preprod_refresh_job: true
+  production_env: true
 
 env:
   JAVA_OPTS: "-Xmx512m"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,6 +14,7 @@ ingress:
 env_details:
   contains_live_data: true
   post_stats_to_team_slack: true
+  prod_to_preprod_refresh_job: true
 
 env:
   JAVA_OPTS: "-Xmx512m"


### PR DESCRIPTION
## What does this pull request do?

Introduces a scheduled database refresh job to replace https://github.com/ministryofjustice/hmpps-interventions-ops/blob/4803fcd01bf77748d3659860057d06d2da293409/copy_prod_to_preprod.sh

## What is the intent behind these changes?

Currently coded as a standalone script which requires setting up port-forwarding, this approach can run on the Kubernetes namespace itself to be more secure and quicker

This cronjob can also be executed with `kubectl create job --from=cronjob/db-refresh-job refresh-now-job` for an ad-hoc refresh. (At the time of writing, this requires kubectl 1.19 as the server is still 1.18)

### Notes

- The approach is taken from https://github.com/ministryofjustice/offender-case-notes/tree/27ab394d717d29a3e2af80f7cec5ab7bb1835dda/database_refresh
- Preprod DB credentials were injected to prod via ministryofjustice/cloud-platform-environments#5566