### PR TITLE
netty-codec version upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("com.nimbusds:oauth2-oidc-sdk:9.15")
+  // Issue with 4.1.67.Final from spring-boot-starter-webflux
+  implementation("io.netty:netty-codec:4.1.68.Final")
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
Added a line in build.gradle to specify the version of io.netty:netty-codec so that we may use a later version.

The current version is causing an issue with security via snyk test:

```
Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-1584063] in io.netty:netty-codec@4.1.67.Final
    introduced by org.springframework.boot:spring-boot-starter-webflux@2.5.4 > org.springframework.boot:spring-boot-starter-reactor-netty@2.5.4 > io.projectreactor.netty:reactor-netty-http@1.0.10 > io.netty:netty-codec-http@4.1.67.Final > io.netty:netty-codec@4.1.67.Final and 22 other path(s)
  This issue was fixed in versions: 4.1.68.Final
```

As the version is controlled by uk.gov.justice.hmpps.gradle-spring-boot we will need to add a manual version upgrade for now.