### PR TITLE
Bug fix: Email not always sent for case notes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
@@ -24,6 +24,10 @@ class CaseNoteService(
   val caseNoteEventPublisher: CaseNoteEventPublisher,
 ) {
 
+  fun getCaseNoteById(caseNoteId: UUID): CaseNote? {
+    return caseNoteRepository.findByIdOrNull(caseNoteId)
+  }
+
   fun createCaseNote(referralId: UUID, subject: String, body: String, sentByUser: AuthUser): CaseNote {
     val caseNote = CaseNote(
       id = UUID.randomUUID(),


### PR DESCRIPTION
To fix a bug in production:
```
This statement has been closed.
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral in getCurrentAssignment at line 140
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral in getCurrentAssignee at line 106
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CaseNotesNotificationsService in emailAssignedCaseWorker at line 66
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CaseNotesNotificationsService in onApplicationEvent at line 32
```
Which is caused by failing to lazy fetch the currentAssignee from the referral because the session has been closed.

To fix, we fetch the case notes again so it can be lazy loaded.