### PR TITLE
Bug fix: Prevent getCaseNote failing due to caseNote not being persisted at time of call

### DIFF
--- a/doc/adr/0003-decouple-transactions-on-asynch-calls.md
+++ b/doc/adr/0003-decouple-transactions-on-asynch-calls.md
@@ -1,0 +1,26 @@
+# 1. Decouple database transactions on asynchronous calls
+
+Date: 2021-09-17
+
+## Status
+
+Accepted
+
+## Context
+
+We need to ensure that when asynchronous calls are made that they do not cause issues with database transactions scopes.
+In normal circumstances (without @Async) a transaction gets propagated through the call hierarchy from one Spring @Component to the other.
+However, when a @Transactional Spring @Component calls a method annotated with @Async this does not happen. 
+The call to the asynchronous method is being scheduled and executed at a later time by a task executor and is thus handled as a 'fresh' call.
+
+## Decision
+
+We decided to prevent issues with @Async calls that we only sent primitive values or DTOs rather than a database entity.
+This ensures that there is no unexcepted behaviour when performing a lazy-fetch of the database entity.
+
+## Consequences
+
+1. The NotificationService should have its own @Transactional annotation separate from the calling class.
+2. Objects should be re-fetched by service classes within the @Asynch class using an id passed into the @Asynch @Component.
+3. Care must be taken that when fetching the same object from the calling class that the entity manager is flushed before calling the @Asynch @Component.
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
@@ -5,17 +5,16 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.CaseNoteController
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CaseNote
+import java.util.UUID
 
-enum class CaseNoteEventType {
-  SENT,
-}
-
-class CaseNoteEvent(
+class CreateCaseNoteEvent(
   source: Any,
-  val type: CaseNoteEventType,
-  val caseNote: CaseNote,
+  val caseNoteId: UUID,
+  val sentBy: AuthUser,
   val detailUrl: String,
+  val referralId: UUID,
 ) : ApplicationEvent(source)
 
 @Component
@@ -25,11 +24,12 @@ class CaseNoteEventPublisher(
 ) {
   fun caseNoteSentEvent(caseNote: CaseNote) {
     applicationEventPublisher.publishEvent(
-      CaseNoteEvent(
+      CreateCaseNoteEvent(
         this,
-        CaseNoteEventType.SENT,
-        caseNote,
-        caseNoteUrl(caseNote)
+        caseNote.id,
+        caseNote.sentBy,
+        caseNoteUrl(caseNote),
+        caseNote.referral.id,
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
@@ -24,10 +24,6 @@ class CaseNoteService(
   val caseNoteEventPublisher: CaseNoteEventPublisher,
 ) {
 
-  fun getCaseNoteById(caseNoteId: UUID): CaseNote? {
-    return caseNoteRepository.findByIdOrNull(caseNoteId)
-  }
-
   fun createCaseNote(referralId: UUID, subject: String, body: String, sentByUser: AuthUser): CaseNote {
     val caseNote = CaseNote(
       id = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisherTest.kt
@@ -27,13 +27,14 @@ internal class CaseNoteEventPublisherTest {
 
     publisher.caseNoteSentEvent(caseNote)
 
-    val eventCaptor = argumentCaptor<CaseNoteEvent>()
+    val eventCaptor = argumentCaptor<CreateCaseNoteEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
     val event = eventCaptor.firstValue
 
     assertThat(event.source).isSameAs(publisher)
-    assertThat(event.type).isSameAs(CaseNoteEventType.SENT)
-    assertThat(event.caseNote).isSameAs(caseNote)
+    assertThat(event.caseNoteId).isSameAs(caseNote.id)
+    assertThat(event.sentBy).isSameAs(caseNote.sentBy)
     assertThat(event.detailUrl).isEqualTo(uri.toString())
+    assertThat(event.referralId).isSameAs(caseNote.referral.id)
   }
 }


### PR DESCRIPTION
Changed CaseNoteEvent to accept a primitive values rather than entity

This is to decouple the entity from asynch event handling. The transaction boundaries are not clear for asynchronous calls; it's best to fetch a new object from the data.

In addition, added @transactional onto CaseNoteNotificationsService.

This is to circumvent an issue we had in production whereby the caseNote.referral.assignedUser was being lazy fetched when the tied entity manager is no longer available as it's outsides the scope of the old transaction session because it's asynchronous.
