### PR TITLE
add 'messageAttributes' to SNS events to allow us to filter them in subscriptions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
@@ -6,6 +6,7 @@ import mu.KLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
@@ -45,7 +46,11 @@ class SNSPublisher(
 
   private fun buildRequestAndPublish(event: EventDTO) {
     val message = objectMapper.writeValueAsString(event)
+    val messageAttributes = mapOf(
+      "eventType" to MessageAttributeValue.builder().stringValue(event.eventType).build()
+    )
     val request = PublishRequest.builder()
+      .messageAttributes(messageAttributes)
       .message(message)
       .topicArn(arn)
       .build()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
@@ -45,8 +45,8 @@ class SNSPublisherTest {
 
     val requestCaptor = argumentCaptor<PublishRequest>()
     verify(snsClient).publish(requestCaptor.capture())
-    val response = (requestCaptor.firstValue.message())
-    assertThat(response).isEqualTo("{}")
+    assertThat(requestCaptor.firstValue.messageAttributes()["eventType"]!!.stringValue()).isEqualTo(event.eventType)
+    assertThat(requestCaptor.firstValue.message()).isEqualTo("{}")
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

adds the eventType field as a message attribute.

## What is the intent behind these changes?

 this allows us to filter messages from SNS using filter policies
