### PR TITLE
fix SNS event publisher by specifying eventType data type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
@@ -47,7 +47,10 @@ class SNSPublisher(
   private fun buildRequestAndPublish(event: EventDTO) {
     val message = objectMapper.writeValueAsString(event)
     val messageAttributes = mapOf(
-      "eventType" to MessageAttributeValue.builder().stringValue(event.eventType).build()
+      "eventType" to MessageAttributeValue.builder()
+        .dataType("String")
+        .stringValue(event.eventType)
+        .build()
     )
     val request = PublishRequest.builder()
       .messageAttributes(messageAttributes)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
@@ -45,6 +45,7 @@ class SNSPublisherTest {
 
     val requestCaptor = argumentCaptor<PublishRequest>()
     verify(snsClient).publish(requestCaptor.capture())
+    assertThat(requestCaptor.firstValue.messageAttributes()["eventType"]!!.dataType()).isEqualTo("String")
     assertThat(requestCaptor.firstValue.messageAttributes()["eventType"]!!.stringValue()).isEqualTo(event.eventType)
     assertThat(requestCaptor.firstValue.message()).isEqualTo("{}")
   }


### PR DESCRIPTION
## What does this pull request do?

adds the 'String' data type to the 'eventType' message attribute.

## What is the intent behind these changes?

Fixes

```
Value null at 'messageAttributes.eventType.member.dataType' failed to satisfy constraint: Member must not be null
```
