### PR TITLE
Add filtering params to get sent referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization
 
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification.ReferralSpecifications
 import java.util.UUID
 
 @Component
@@ -17,6 +19,12 @@ class ReferralAccessFilter(
     //        that compares contract reference numbers?
     return referrals.filter { userScope.contracts.contains(it.intervention.dynamicFrameworkContract) }
   }
+
+  fun serviceProviderReferrals(referralSpec: Specification<Referral>, user: AuthUser): Specification<Referral> {
+    val userScope = serviceProviderAccessScopeMapper.fromUser(user)
+    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts))
+  }
+
   fun serviceProviderReferralSummaries(referrals: List<ServiceProviderSentReferralSummary>, user: AuthUser): List<ServiceProviderSentReferralSummary> {
     val userScope = serviceProviderAccessScopeMapper.fromUser(user)
     return referrals.filter { userScope.contracts.map { contract -> contract.id }.contains(UUID.fromString(it.dynamicFrameWorkContractId)) }
@@ -25,5 +33,10 @@ class ReferralAccessFilter(
   fun probationPractitionerReferrals(referrals: List<Referral>, user: AuthUser): List<Referral> {
     // todo: filter out referrals for limited access offenders (LAOs)
     return referrals
+  }
+
+  fun probationPractitionerReferrals(referralSpec: Specification<Referral>, user: AuthUser): Specification<Referral> {
+    // todo: filter out referrals for limited access offenders (LAOs)
+    return referralSpec
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebInputException
@@ -38,6 +39,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralCo
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService
 import java.util.UUID
+import javax.annotation.Nullable
 import javax.persistence.EntityNotFoundException
 
 @RestController
@@ -103,9 +105,13 @@ class ReferralController(
   @GetMapping("/sent-referrals")
   fun getSentReferrals(
     authentication: JwtAuthenticationToken,
+    @Nullable @RequestParam(name = "concluded", required = false) concluded: Boolean?,
+    @Nullable @RequestParam(name = "cancelled", required = false) cancelled: Boolean?,
+    @Nullable @RequestParam(name = "unassigned", required = false) unassigned: Boolean?,
+    @Nullable @RequestParam(name = "assignedTo", required = false) assignedToUserId: String?,
   ): List<SentReferralSummaryDTO> {
     val user = userMapper.fromToken(authentication)
-    return referralService.getSentReferralsForUser(user).map { SentReferralSummaryDTO.from(it) }
+    return referralService.getSentReferralsForUser(user, concluded, cancelled, unassigned, assignedToUserId).map { SentReferralSummaryDTO.from(it) }
   }
 
   @Deprecated(message = "This is a temporary solution to by-pass the extremely long wait times in production that occurs with /sent-referrals")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
@@ -11,6 +11,7 @@ class ServiceProviderSentReferralSummaryDTO(
   val assignedToUserName: String?,
   val serviceUserFirstName: String?,
   val serviceUserLastName: String?,
+  val hasEndOfServiceReport: Boolean,
 ) {
   companion object {
     fun from(sentReferralSummary: ServiceProviderSentReferralSummary): ServiceProviderSentReferralSummaryDTO {
@@ -22,6 +23,7 @@ class ServiceProviderSentReferralSummaryDTO(
         assignedToUserName = sentReferralSummary.assignedToUserName,
         serviceUserFirstName = sentReferralSummary.serviceUserFirstName,
         serviceUserLastName = sentReferralSummary.serviceUserLastName,
+        hasEndOfServiceReport = sentReferralSummary.endOfServiceReportId != null
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
 import java.time.Instant
+import java.util.UUID
 
 interface ServiceProviderSentReferralSummary {
   val referralId: String
@@ -11,4 +12,5 @@ interface ServiceProviderSentReferralSummary {
   val assignedToUserName: String?
   val serviceUserFirstName: String?
   val serviceUserLastName: String?
+  val endOfServiceReportId: UUID?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -22,7 +22,8 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
       dynamicFrameworkContractId,
 			assignedToUserName,
 			serviceUserFirstName,
-			serviceUserLastName from (	
+			serviceUserLastName,
+      endOfServiceReportId from (	
 	select
 			cast(r.id as varchar) AS referralId,
 			cast(r.sent_at as TIMESTAMP WITH TIME ZONE) as sentAt,
@@ -32,6 +33,7 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
 			i.title as interventionTitle,
 			rsud.first_name as serviceUserFirstName,
 			rsud.last_name as serviceUserLastName,
+      cast(eosr.id as varchar) as endOfServiceReportId,
 			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq		
 	from referral r
 			 inner join intervention i on i.id = r.intervention_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -3,16 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
 import java.time.OffsetDateTime
 import java.util.UUID
 
-interface ReferralRepository : JpaRepository<Referral, UUID> {
+interface ReferralRepository : JpaRepository<Referral, UUID>, JpaSpecificationExecutor<Referral> {
   @Query(
     value = """select 
       referralId, 
@@ -54,15 +53,9 @@ interface ReferralRepository : JpaRepository<Referral, UUID> {
   )
   fun referralSummaryForServiceProviders(serviceProviders: List<String>): List<ServiceProviderSentReferralSummary>
 
-  // queries for service providers
-  fun findAllByInterventionDynamicFrameworkContractPrimeProviderInAndSentAtIsNotNull(providers: Iterable<ServiceProvider>): List<Referral>
-  fun findAllByInterventionDynamicFrameworkContractSubcontractorProvidersInAndSentAtIsNotNull(providers: Iterable<ServiceProvider>): List<Referral>
-
   // queries for sent referrals
   fun findByIdAndSentAtIsNotNull(id: UUID): Referral?
-  fun findByCreatedByAndSentAtIsNotNull(user: AuthUser): List<Referral>
   fun existsByReferenceNumber(reference: String): Boolean
-  fun findByServiceUserCRNAndSentAtIsNotNull(crn: String): List<Referral>
 
   // queries for draft referrals
   fun findByIdAndSentAtIsNull(id: UUID): Referral?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
+
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.criteria.JoinType
+
+class ReferralSpecifications {
+  companion object {
+
+    fun sent(): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        cb.isNotNull(root.get<OffsetDateTime>("sentAt"))
+      }
+    }
+
+    fun concluded(): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        cb.isNotNull(root.get<OffsetDateTime>("concludedAt"))
+      }
+    }
+
+    fun unassigned(): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        cb.isEmpty(root.get<List<ReferralAssignment>>("assignments"))
+      }
+    }
+
+    /**
+     * This cancellation logic is duplicated from Referral.kt. We have to duplicate it because the logic within the
+     * entity is not accessible via JPQL.
+     * The official definition of cancelled referral is where the referral is concluded and no session was attended;
+     * however, the logic below is a proxy for the same thing since only cancelled referrals have null EOSR from the
+     * ReferralConcluder.kt class.
+     */
+    fun cancelled(): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        cb.and(
+          cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
+          cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
+          root.join<Referral, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
+        )
+      }
+    }
+
+    fun withSPAccess(contracts: Set<DynamicFrameworkContract>): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        val interventionJoin = root.join<Referral, Intervention>("intervention", JoinType.INNER)
+        val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.LEFT)
+        dynamicContractJoin.`in`(contracts)
+      }
+    }
+
+    fun matchingPrimeProviderReferrals(serviceProviders: Set<ServiceProvider>): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        val interventionJoin = root.join<Referral, Intervention>("intervention", JoinType.INNER)
+        val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.LEFT)
+        query.distinct(true)
+        dynamicContractJoin.get<ServiceProvider>("primeProvider").`in`(serviceProviders)
+      }
+    }
+
+    fun matchingSubContractorReferrals(serviceProviders: Set<ServiceProvider>): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        val interventionJoin = root.join<Referral, Intervention>("intervention", JoinType.INNER)
+        val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.INNER)
+        val serviceProviderJoin = dynamicContractJoin.joinSet<DynamicFrameworkContract, ServiceProvider>("subcontractorProviders", JoinType.LEFT)
+        query.distinct(true)
+        serviceProviderJoin.get<AuthGroupID>("id").`in`(serviceProviders.map { it.id })
+      }
+    }
+
+    fun createdBy(authUser: AuthUser): Specification<Referral> {
+      return Specification<Referral> { root, query, cb -> cb.equal(root.get<String>("createdBy"), authUser) }
+    }
+
+    fun matchingServiceUserReferrals(serviceUserCRNs: List<String>): Specification<Referral> {
+      return Specification<Referral> { root, query, cb -> root.get<String>("serviceUserCRN").`in`(serviceUserCRNs) }
+    }
+
+    /**
+     * This is performing the equivalent of:
+     *
+     * SELECT r FROM referral r
+     * inner join referral_assignments ra
+     *    inner join auth_user au on ra.assigned_to_id = au.id
+     *  on ra.referral_id = r.id
+     * where ra.assigned_at = (SELECT MAX(assigned_at) FROM referral_assignments WHERE referral_id = ra.referral_id)
+     * and au.id = $USER_ID
+     */
+    fun currentlyAssignedTo(authUserId: String): Specification<Referral> {
+      return Specification<Referral> { root, query, cb ->
+        // INNER JOIN
+        val referralAssignmentJoin = root.join<Referral, ReferralAssignment>("assignments", JoinType.INNER)
+
+        // WHERE assigned_at = max(assigned_at)
+        val subquery = query.subquery(OffsetDateTime::class.java)
+        val subQueryReferral = subquery.from(Referral::class.java)
+        val subQueryReferralAssignmentJoin = subQueryReferral.join<Referral, ReferralAssignment>("assignments", JoinType.INNER)
+        val maxAssignedAt = cb.greatest(subQueryReferralAssignmentJoin.get<OffsetDateTime>("assignedAt"))
+        subquery.select(maxAssignedAt)
+        subquery.where(cb.equal(root.get<UUID>("id"), subQueryReferral.get<UUID>("id")))
+        val maxAssignedAtMatch = cb.equal(referralAssignmentJoin.get<OffsetDateTime>("assignedAt"), subquery)
+
+        // AND assigned_to = authUser
+        val authUserJoin = referralAssignmentJoin.join<ReferralAssignment, AuthUser>("assignedTo", JoinType.LEFT)
+        cb.and(maxAssignedAtMatch, cb.equal(authUserJoin.get<String>("id"), authUserId))
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProvid
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceUserFactory
 import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.UUID
 import javax.transaction.Transactional
 
 @Transactional
@@ -294,7 +295,8 @@ class ReferralRepositoryTest @Autowired constructor(
         it.dynamicFrameWorkContractId == summary.dynamicFrameWorkContractId &&
         it.assignedToUserName == summary.assignedToUserName &&
         it.serviceUserFirstName == summary.serviceUserFirstName &&
-        it.serviceUserLastName == summary.serviceUserLastName
+        it.serviceUserLastName == summary.serviceUserLastName &&
+        it.endOfServiceReportId == summary.endOfServiceReportId
     }
   }
 
@@ -307,7 +309,8 @@ class ReferralRepositoryTest @Autowired constructor(
       referral.intervention.dynamicFrameworkContract.id.toString(),
       referral.currentAssignee?.id,
       referral.serviceUserData!!.firstName,
-      referral.serviceUserData!!.lastName
+      referral.serviceUserData!!.lastName,
+      referral.endOfServiceReport?.id
     )
 
   @Test
@@ -334,5 +337,6 @@ data class Summary(
   override val dynamicFrameWorkContractId: String,
   override val assignedToUserName: String?,
   override val serviceUserFirstName: String?,
-  override val serviceUserLastName: String?
+  override val serviceUserLastName: String?,
+  override val endOfServiceReportId: UUID?,
 ) : ServiceProviderSentReferralSummary

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
@@ -1,0 +1,240 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DynamicFrameworkContractRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SupplierAssessmentRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProviderFactory
+import java.time.OffsetDateTime
+
+@RepositoryTest
+class ReferralSpecificationsTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val referralRepository: ReferralRepository,
+  val authUserRepository: AuthUserRepository,
+  val interventionRepository: InterventionRepository,
+  val endOfServiceReportRepository: EndOfServiceReportRepository,
+  val actionPlanRepository: ActionPlanRepository,
+  val appointmentRepository: AppointmentRepository,
+  val cancellationReasonRepository: CancellationReasonRepository,
+  val supplierAssessmentRepository: SupplierAssessmentRepository,
+  val dynamicFrameworkContractRepository: DynamicFrameworkContractRepository,
+) {
+
+  private val referralFactory = ReferralFactory(entityManager)
+  private val authUserFactory = AuthUserFactory(entityManager)
+  private val endOfServiceReportFactory = EndOfServiceReportFactory(entityManager)
+  private val interventionFactory = InterventionFactory(entityManager)
+  private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory(entityManager)
+  private val serviceProviderFactory = ServiceProviderFactory(entityManager)
+
+  @BeforeEach
+  fun setup() {
+    cancellationReasonRepository.deleteAll()
+    appointmentRepository.deleteAll()
+    actionPlanRepository.deleteAll()
+    endOfServiceReportRepository.deleteAll()
+    supplierAssessmentRepository.deleteAll()
+    entityManager.flush()
+
+    referralRepository.deleteAll()
+    interventionRepository.deleteAll()
+    dynamicFrameworkContractRepository.deleteAll()
+    authUserRepository.deleteAll()
+    entityManager.flush()
+  }
+
+  @Nested
+  inner class sent {
+    @Test
+    fun `only sent referrals are returned`() {
+      val sent = referralFactory.createSent()
+      val draft = referralFactory.createDraft()
+      val result = referralRepository.findAll(ReferralSpecifications.sent())
+      Assertions.assertThat(result).containsExactly(sent)
+      Assertions.assertThat(result).doesNotContain(draft)
+    }
+  }
+
+  @Nested
+  inner class concluded {
+    @Test
+    fun `only concluded referrals are returned`() {
+      val sent = referralFactory.createSent()
+      val cancelled = referralFactory.createEnded(endRequestedAt = OffsetDateTime.now(), concludedAt = OffsetDateTime.now(), endOfServiceReport = null)
+      val completed = referralFactory.createEnded(endRequestedAt = OffsetDateTime.now(), concludedAt = OffsetDateTime.now())
+      endOfServiceReportFactory.create(referral = completed)
+      val result = referralRepository.findAll(ReferralSpecifications.concluded())
+      Assertions.assertThat(result).containsExactlyInAnyOrder(completed, cancelled)
+      Assertions.assertThat(result).doesNotContain(sent)
+    }
+  }
+
+  @Nested
+  inner class cancelled {
+    @Test
+    fun `only cancelled referrals are returned`() {
+      val cancelled = referralFactory.createEnded(endRequestedAt = OffsetDateTime.now(), concludedAt = OffsetDateTime.now(), endOfServiceReport = null)
+      val completed = referralFactory.createEnded(endRequestedAt = OffsetDateTime.now(), concludedAt = OffsetDateTime.now())
+      endOfServiceReportFactory.create(referral = completed)
+      val result = referralRepository.findAll(ReferralSpecifications.cancelled())
+      Assertions.assertThat(result).containsExactly(cancelled)
+      Assertions.assertThat(result).doesNotContain(completed)
+    }
+  }
+
+  @Nested
+  inner class withSPAccess {
+    @Test
+    fun `sp with no contracts should never return a referral`() {
+      referralFactory.createSent()
+      referralFactory.createAssigned()
+
+      val result = referralRepository.findAll(ReferralSpecifications.withSPAccess(setOf()))
+      Assertions.assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `only referrals that are part of the contract set are returned`() {
+      val spContract = dynamicFrameworkContractFactory.create(contractReference = "spContractRef")
+      val spIntervention = interventionFactory.create(contract = spContract)
+      val referralWithSpContract = referralFactory.createSent(intervention = spIntervention)
+
+      val unrelatedSpContract = dynamicFrameworkContractFactory.create(contractReference = "unrelatedSpContractRef")
+
+      val someOtherContract = dynamicFrameworkContractFactory.create(contractReference = "someOtherContractRef")
+      val someOtherIntervention = interventionFactory.create(contract = someOtherContract)
+      val someOtherReferral = referralFactory.createSent(intervention = someOtherIntervention)
+
+      val result = referralRepository.findAll(ReferralSpecifications.withSPAccess(setOf(spContract, unrelatedSpContract)))
+      Assertions.assertThat(result).containsExactly(referralWithSpContract)
+      Assertions.assertThat(result).doesNotContain(someOtherReferral)
+    }
+  }
+
+  @Nested
+  inner class matchingPrimeProviderReferrals {
+    @Test
+    fun `only referrals with that are prime providers of the service providers are returned`() {
+      val userServiceProvider_1 = serviceProviderFactory.create("userServiceProvider_1")
+      val grantedReferral = referralFactory.createSent(
+        intervention = interventionFactory.create(contract = dynamicFrameworkContractFactory.create(primeProvider = userServiceProvider_1))
+      )
+      val userServiceProvider_2 = serviceProviderFactory.create("userServiceProvider_2 ${1 + 1}")
+      interventionFactory.create(contract = dynamicFrameworkContractFactory.create(primeProvider = userServiceProvider_2))
+
+      val someOtherServiceProvider = serviceProviderFactory.create("someOtherServiceProvider")
+      val restrictedReferral = referralFactory.createSent(
+        intervention = interventionFactory.create(contract = dynamicFrameworkContractFactory.create(primeProvider = someOtherServiceProvider))
+      )
+
+      val result = referralRepository.findAll(ReferralSpecifications.matchingPrimeProviderReferrals(setOf(userServiceProvider_1, userServiceProvider_2)))
+      Assertions.assertThat(result).containsExactly(grantedReferral)
+      Assertions.assertThat(result).doesNotContain(restrictedReferral)
+    }
+  }
+
+  @Nested
+  inner class matchingSubContractorReferrals {
+    @Test
+    fun `only referrals with that are sub contractors of the service providers are returned`() {
+      val userServiceProvider_1 = serviceProviderFactory.create("userServiceProvider_1")
+      val userServiceProvider_2 = serviceProviderFactory.create("userServiceProvider_2")
+      val someOtherServiceProvider = serviceProviderFactory.create("someOtherServiceProvider")
+
+      val grantedReferral = referralFactory.createSent(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            primeProvider = serviceProviderFactory.create("randomServiceProvider_1"),
+            subcontractorProviders = setOf(
+              userServiceProvider_1, someOtherServiceProvider
+            )
+          )
+        )
+      )
+
+      val restrictedReferral = referralFactory.createSent(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            primeProvider = serviceProviderFactory.create("randomServiceProvider_2"),
+            subcontractorProviders = setOf(
+              someOtherServiceProvider
+            )
+          )
+        )
+      )
+
+      val result = referralRepository.findAll(ReferralSpecifications.matchingSubContractorReferrals(setOf(userServiceProvider_1, userServiceProvider_2)))
+      Assertions.assertThat(result).containsExactly(grantedReferral)
+      Assertions.assertThat(result).doesNotContain(restrictedReferral)
+    }
+  }
+
+  @Nested
+  inner class assignedTo {
+    @Test
+    fun `returns referral if user is currently assigned`() {
+      val user = authUserFactory.create(id = "loggedInUser")
+      val someOtherUser = authUserFactory.create(id = "someOtherUser")
+
+      val assignments: List<ReferralAssignment> = listOf(
+        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = user),
+        ReferralAssignment(OffsetDateTime.now().minusDays(1), assignedBy = someOtherUser, assignedTo = someOtherUser),
+      )
+
+      val assignedReferral = referralFactory.createAssigned(assignments = assignments)
+
+      val result = referralRepository.findAll(ReferralSpecifications.currentlyAssignedTo(user.id))
+      Assertions.assertThat(result).containsExactly(assignedReferral)
+    }
+
+    @Test
+    fun `does not return referral if user is previously assigned`() {
+      val user = authUserFactory.create(id = "loggedInUser")
+      val someOtherUser = authUserFactory.create(id = "someOtherUser")
+
+      val assignments: List<ReferralAssignment> = listOf(
+        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = someOtherUser),
+        ReferralAssignment(OffsetDateTime.now().minusDays(1), assignedBy = someOtherUser, assignedTo = user),
+      )
+
+      referralFactory.createAssigned(assignments = assignments)
+      val result = referralRepository.findAll(ReferralSpecifications.currentlyAssignedTo(user.id))
+      Assertions.assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `does not return referral if user has never been assigned`() {
+      val user = authUserFactory.create(id = "loggedInUser")
+      val someOtherUser = authUserFactory.create(id = "someOtherUser")
+
+      val assignments: List<ReferralAssignment> = listOf(
+        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = someOtherUser)
+      )
+
+      referralFactory.createAssigned(assignments = assignments)
+      referralFactory.createAssigned(assignments = emptyList())
+
+      val result = referralRepository.findAll(ReferralSpecifications.currentlyAssignedTo(user.id))
+      Assertions.assertThat(result).isEmpty()
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Allows filtering options for GetSentReferrals.

This was accomplished using spring JPA Specification: https://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa/domain/Specification.html

There are a few defined JPA specifications for referrals which can be joined together using logical connections (and/or/not, etc).

This allows us to fetch the results pre-filtered from the DB rather than having to either:

1. Write a new query for each filter option and/or combination.
2. Perform the filtering in stages with code rather than SQL

A reason why filtering on a single query is preferable is because:

1. The query calls are more efficient as it doesn't retrieve any data we don't want.
2. It enables us to use spring sorting and pagination a lot more easily. We can just pass in a pageable request along with the JPA specification.
3. Any new filtering options added should be easier to incorporate.

One side effect of this change was effectively rewriting all the "SQL" connected with sent referrals into criteria builder; conceptually it is a bit harder to understand and write, so this is the disadvantage with it.

Another change was introducing the filtering of referral access to be part of the SQL query rather than filtering within the code after fetching. The main reason for this was in preparation for sorting and pagination.

Also note that the default GetSentReferrals call for SP now returns cancelled referrals if the option is not supplied; previously we filtered out cancelled referrals (but not for PPs).

I felt that this was acceptable because we currently don't use this end-point for SPs sent referrals. We created a temporary sent referrals summary for SPs due to inefficiencies with the call in production.

## What is the intent behind these changes?

Enable filtering of sent referrals to the UI client.