### PR TITLE
IC-1833 new action plan approval

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
@@ -11,4 +11,7 @@ interface DeliverySessionRepository : JpaRepository<DeliverySession, UUID> {
 
   @Query("select aps from DeliverySession aps left join ActionPlan ap on ap.referral = aps.referral where ap.id = :actionPlanId and aps.sessionNumber = :sessionNumber")
   fun findAllByActionPlanIdAndSessionNumber(actionPlanId: UUID, sessionNumber: Int): DeliverySession?
+
+  @Query("select ds from DeliverySession ds left join ActionPlan ap on ap.referral = ds.referral where ap.id = :actionPlanId")
+  fun findAllByActionPlanId(actionPlanId: UUID): List<DeliverySession>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -92,12 +92,7 @@ class ActionPlanService(
   fun approveActionPlan(id: UUID, user: AuthUser): ActionPlan {
     val actionPlan = getActionPlan(id)
 
-    actionPlan.referral.approvedActionPlan?. let {
-      val sessions = deliverySessionRepository.findAllByActionPlanId(id)
-      deliverySessionService.createUnscheduledSessionsForActionPlan(actionPlan, sessions.count())
-    } ?: run {
-      deliverySessionService.createUnscheduledSessionsForActionPlan(actionPlan)
-    }
+    deliverySessionService.createUnscheduledSessionsForActionPlan(actionPlan)
 
     actionPlan.approvedAt = OffsetDateTime.now()
     actionPlan.approvedBy = authUserRepository.save(user)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanService.kt
@@ -107,8 +107,8 @@ class ActionPlanService(
   private fun verifySafeForApproval(actionPlan: ActionPlan) {
     if (actionPlan.approvedAt != null) {
       throw ValidationException("Action plan has already been approved. [id=${actionPlan.id}]")
-    } else if (actionPlan.referral.actionPlans?.filter { it.approvedAt == null }?.maxByOrNull { it.createdAt }?.id != actionPlan.id) {
-      throw ValidationException("Action plan is not the latest created, so cannot be approved. [id=${actionPlan.id}]")
+    } else if (actionPlan.referral.actionPlans?.filter { it.approvedAt == null && it.submittedAt != null }?.maxByOrNull { it.submittedAt!! }?.id != actionPlan.id) {
+      throw ValidationException("Action plan is not the latest submitted, so cannot be approved. [id=${actionPlan.id}]")
     }
     actionPlan.referral.approvedActionPlan?. let {
       if (it.numberOfSessions!! > actionPlan.numberOfSessions!!) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -34,9 +34,9 @@ class DeliverySessionService(
   val appointmentService: AppointmentService,
   val appointmentRepository: AppointmentRepository,
 ) {
-  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan) {
+  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan, alreadyCreatedSessions: Int = 0) {
     val numberOfSessions = approvedActionPlan.numberOfSessions!!
-    for (i in 1..numberOfSessions) {
+    for (i in alreadyCreatedSessions + 1..numberOfSessions) {
       createSession(approvedActionPlan, i)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -34,9 +34,13 @@ class DeliverySessionService(
   val appointmentService: AppointmentService,
   val appointmentRepository: AppointmentRepository,
 ) {
-  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan, alreadyCreatedSessions: Int = 0) {
+  fun createUnscheduledSessionsForActionPlan(approvedActionPlan: ActionPlan) {
+    val previouslyApprovedSessions = approvedActionPlan.referral.approvedActionPlan?. let {
+      deliverySessionRepository.findAllByActionPlanId(it.id).count()
+    } ?: 0
+
     val numberOfSessions = approvedActionPlan.numberOfSessions!!
-    for (i in alreadyCreatedSessions + 1..numberOfSessions) {
+    for (i in previouslyApprovedSessions + 1..numberOfSessions) {
       createSession(approvedActionPlan, i)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -244,29 +244,7 @@ internal class ActionPlanServiceTest {
     assertThat(approvedActionPlan.approvedAt).isNotNull
     assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
     verify(actionPlanEventPublisher).actionPlanApprovedEvent(same(actionPlan))
-    verify(deliverySessionService).createUnscheduledSessionsForActionPlan(same(actionPlan), same(0))
-  }
-
-  @Test
-  fun `approve when there is a previously approved action plan passess previous sessions`() {
-    val newActionPlanId = UUID.randomUUID()
-    val referral = referralFactory.createSent()
-    val previouslyApprovedActionPlan = actionPlanFactory.createApproved(numberOfSessions = 2, referral = referral)
-    val newActionPlan = actionPlanFactory.createSubmitted(id = newActionPlanId, numberOfSessions = 2, referral = referral)
-    referral.actionPlans = mutableListOf(previouslyApprovedActionPlan, newActionPlan)
-
-    val authUser = AuthUser("CRN123", "auth", "user")
-    whenever(actionPlanRepository.findById(newActionPlanId)).thenReturn(of(newActionPlan))
-    whenever(authUserRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<AuthUser>())
-    whenever(actionPlanRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<ActionPlan>())
-    whenever(deliverySessionRepository.findAllByActionPlanId(any())).thenReturn(listOf(deliverySessionFactory.createAttended(), deliverySessionFactory.createAttended()))
-
-    val approvedActionPlan = actionPlanService.approveActionPlan(newActionPlanId, authUser)
-    assertThat(approvedActionPlan.approvedAt).isNotNull
-    assertThat(approvedActionPlan.approvedBy).isEqualTo(authUser)
-    verify(actionPlanEventPublisher).actionPlanApprovedEvent(same(newActionPlan))
-    verify(deliverySessionService).createUnscheduledSessionsForActionPlan(same(newActionPlan), same(2))
-    verify(deliverySessionRepository, times(1)).findAllByActionPlanId(any())
+    verify(deliverySessionService).createUnscheduledSessionsForActionPlan(same(actionPlan))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ActionPlanServiceTest.kt
@@ -250,7 +250,7 @@ internal class ActionPlanServiceTest {
   @Test
   fun `action plan approval fails if not the latest unapproved action plan`() {
     val referral = referralFactory.createSent()
-    val actionPlan = actionPlanFactory.createSubmitted(numberOfSessions = 2, referral = referral, createdAt = OffsetDateTime.now().minusDays(1))
+    val actionPlan = actionPlanFactory.createSubmitted(numberOfSessions = 2, referral = referral, submittedAt = OffsetDateTime.now().minusDays(1))
     val actionPlanOld = actionPlanFactory.createSubmitted(numberOfSessions = 2, referral = referral)
     referral.actionPlans = mutableListOf(actionPlan, actionPlanOld)
     val authUser = AuthUser("CRN123", "auth", "user")
@@ -260,7 +260,7 @@ internal class ActionPlanServiceTest {
     val exception = Assertions.assertThrows(ValidationException::class.java) {
       actionPlanService.approveActionPlan(actionPlan.id, authUser)
     }
-    assertThat(exception.message).isEqualTo("Action plan is not the latest created, so cannot be approved. [id=${actionPlan.id}]")
+    assertThat(exception.message).isEqualTo("Action plan is not the latest submitted, so cannot be approved. [id=${actionPlan.id}]")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -71,6 +71,17 @@ internal class DeliverySessionsServiceTest {
   }
 
   @Test
+  fun `create unscheduled sessions where some sessions are already created`() {
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 3)
+    whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(eq(actionPlan.id), any())).thenReturn(null)
+    whenever(authUserRepository.save(actionPlan.createdBy)).thenReturn(actionPlan.createdBy)
+    whenever(deliverySessionRepository.save(any())).thenAnswer { it.arguments[0] }
+
+    deliverySessionsService.createUnscheduledSessionsForActionPlan(actionPlan, 1)
+    verify(deliverySessionRepository, times(2)).save(any())
+  }
+
+  @Test
   fun `create unscheduled sessions throws exception if session already exists`() {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 1)
 


### PR DESCRIPTION
## What does this pull request do?

Allows new action-plans to be approved and then have any extra sessions created.

## What is the intent behind these changes?

To allow subsequent action plans to be approved for a given referral.

- [x] Not to be merged until all 4 steps of the action-plan-session -> delivery session pr's are live.