### PR TITLE
Document how to run the data refresh job

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,48 +6,11 @@ Business/domain API to **find, arrange and monitor an intervention** for service
 
 ## Quickstart
 
-### Requirements
+Please see the [quickstart document](doc/quickstart.md).
 
-- Docker
-- Java
-
-Build and test:
-```
-./gradlew build
-```
-
-Run:
-
-First, add the following line to your `/etc/hosts` file to allow hmpps-auth interoperability with other docker services:
-
-```127.0.0.1 hmpps-auth```
-
-Then run:
-
-```
-docker-compose pull
-docker-compose up -d
-SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
-```
-
-### Running with AWS LocalStack for SNS (Simple Notification Service) or S3
-
-- Install the AWS CLI with Homebrew: `brew install awscli`
-- Configure the CLI for localstack: `aws configure --profile localstack` and set `AWS Access Key ID = test`, `AWS Secret Access Key = test`, `Default region name = eu-west-2`, `Default output format = json`
-- Run localstack with docker-compose: `docker-compose -f docker-compose-localstack.yml up`
-  
-#### SNS 
-
-- Create an SNS topic: `aws --profile localstack --endpoint-url=http://localhost:4566 sns create-topic --name intervention-events-local`
-- Validate the topic ARN matches: `arn:aws:sns:eu-west-2:000000000000:intervention-events-local`, if not modify the ARN in `application-local.yml`
-- Subscribe to topic: `aws --profile localstack --endpoint-url=http://localhost:4566 sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:intervention-events-local --protocol http --notification-endpoint http://host.docker.internal:5000`
-- Output notifications: `npx http-echo-server 5000`
-- Run the application with the following environment var `AWS_SNS_ENABLED=true`
-
-#### S3
-
-- Create new buckets on startup: Edit 'script/localstack/buckets.sh' e.g. `awslocal s3 mb s3://new-bucket-name`
-- List the contents of a bucket: `aws --profile localstack --endpoint-url=http://localhost:4566 s3 ls s3://new-bucket-name --recursive`
+Common tasks:
+- [Refreshing data from production](doc/tasks-data-refresh.md)
+- [Working with CronJobs](doc/tasks-cronjob.md)
 
 ## Architecture
 
@@ -62,35 +25,8 @@ To see where this service fits in the broader interventions (and probation) arch
 
 Run `./gradlew ktlintFormat` to fix formatting errors in your code before commit.
 
-### OpenAPI
+## Resource documentation
 
-OpenAPI documentation is auto-generated. To view it start the application and visit /swagger-ui.html in your browser.
-
-### Intervention Database
-If you want to connect to your local interventions service database, first exec onto the postgres container with:
-```
-docker exec -it ${containerId} /bin/sh
-```
-and then run:
-```
-psql -h localhost -d interventions -U postgres
-```
-
-If you want to populate your local database with seeded values from [local data setup](/src/main/resources/db/local) then run:
-```
-SPRING_PROFILES_ACTIVE=local,seed ./gradlew bootRun
-```
-
-### Testing cronjobs
-
-Run the CronJob as a one-off job with:
-
-```
-kubectl create job --from=cronjob/{name} "{any name for the one-off job}" --namespace=hmpps-interventions-{yournamespace}
-```
-
-For example:
-
-```
-kubectl create job --from=cronjob.batch/data-extractor-reporting data-extractor-reporting-once --namespace=hmpps-interventions-preprod
-```
+- **API**: OpenAPI documentation is auto-generated. To view it start the application and visit `/swagger-ui.html` in your browser.
+- **Data**: Data documentation is auto-generated. To view it, visit [https://{dev}/meta/schema](https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/meta/schema/).
+  It also generates an ERD at [here](https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/meta/schema/relationships.html).

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart
+
+## Requirements
+
+- Docker
+- Java
+
+Build and test:
+```
+./gradlew build
+```
+
+Run:
+
+First, add the following line to your `/etc/hosts` file to allow hmpps-auth interoperability with other docker services:
+
+```127.0.0.1 hmpps-auth```
+
+Then run:
+
+```
+docker-compose pull
+docker-compose up -d
+SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
+```
+
+## Running with AWS LocalStack for SNS (Simple Notification Service) or S3
+
+- Install the AWS CLI with Homebrew: `brew install awscli`
+- Configure the CLI for localstack: `aws configure --profile localstack` and set `AWS Access Key ID = test`, `AWS Secret Access Key = test`, `Default region name = eu-west-2`, `Default output format = json`
+- Run localstack with docker-compose: `docker-compose -f docker-compose-localstack.yml up`
+
+### SNS
+
+- Create an SNS topic: `aws --profile localstack --endpoint-url=http://localhost:4566 sns create-topic --name intervention-events-local`
+- Validate the topic ARN matches: `arn:aws:sns:eu-west-2:000000000000:intervention-events-local`, if not modify the ARN in `application-local.yml`
+- Subscribe to topic: `aws --profile localstack --endpoint-url=http://localhost:4566 sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:intervention-events-local --protocol http --notification-endpoint http://host.docker.internal:5000`
+- Output notifications: `npx http-echo-server 5000`
+- Run the application with the following environment var `AWS_SNS_ENABLED=true`
+
+### S3
+
+- Create new buckets on startup: Edit 'script/localstack/buckets.sh' e.g. `awslocal s3 mb s3://new-bucket-name`
+- List the contents of a bucket: `aws --profile localstack --endpoint-url=http://localhost:4566 s3 ls s3://new-bucket-name --recursive`
+
+## Connecting to local database
+
+If you want to connect to your local interventions service database, first exec onto the postgres container with:
+```
+docker exec -it ${containerId} /bin/sh
+```
+and then run:
+```
+psql -h localhost -d interventions -U postgres
+```
+
+## Seeding the local database
+
+If you want to populate your local database with seeded values from [local data setup](/src/main/resources/db/local) then run:
+```
+SPRING_PROFILES_ACTIVE=local,seed ./gradlew bootRun
+```

--- a/doc/tasks-cronjob.md
+++ b/doc/tasks-cronjob.md
@@ -1,0 +1,17 @@
+# Working with CronJobs
+
+## Running a job ad-hoc
+
+Run the CronJob as a one-off job with:
+
+```
+kubectl create job --from=cronjob/{name} "{any name for the one-off job}" --namespace=hmpps-interventions-{yournamespace}
+```
+
+For example:
+
+```
+kubectl create job --from=cronjob.batch/data-extractor-reporting data-extractor-reporting-once --namespace=hmpps-interventions-preprod
+```
+
+📋 This command may need `kubectl` 1.19 to work (as the server is only 1.18 at the moment)

--- a/doc/tasks-data-refresh.md
+++ b/doc/tasks-data-refresh.md
@@ -1,0 +1,11 @@
+# Refreshing our data
+
+## Refreshing pre-production from production
+
+Execute the scheduled load job
+```
+kubectl --namespace=hmpps-interventions-prod \
+  create job --from=cronjob.batch/db-refresh-job refresh-job
+```
+
+📋 This command may need `kubectl` 1.19 to work (as the server is only 1.18 at the moment)


### PR DESCRIPTION
## What does this pull request do?

Document how to run the data refresh job

## What is the intent behind these changes?

To make this step better known

To be immediately visible, the "quickstart" section has been moved into its own document:

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1526295/137149161-27ea1ad5-63fb-48fb-8bab-183a56339e82.png">

