### PR TITLE
Prod issue fix add missing sessions to action plan

### DIFF
--- a/src/main/resources/db/migration/V1_82_prod_issue_fix_add_missing_sessions_to_action_plan.sql
+++ b/src/main/resources/db/migration/V1_82_prod_issue_fix_add_missing_sessions_to_action_plan.sql
@@ -1,0 +1,3 @@
+insert into action_plan_session (id, session_number, deprecated_action_plan_id, referral_id, latest_approved) values (gen_random_uuid(), 6, 'b9cd89d0-6e6a-4856-8220-69fdb62732ea', 'c88ba538-aa56-442b-8aca-65582150a869', true);
+insert into action_plan_session (id, session_number, deprecated_action_plan_id, referral_id, latest_approved) values (gen_random_uuid(), 7, 'b9cd89d0-6e6a-4856-8220-69fdb62732ea', 'c88ba538-aa56-442b-8aca-65582150a869', true);
+insert into action_plan_session (id, session_number, deprecated_action_plan_id, referral_id, latest_approved) values (gen_random_uuid(), 8, 'b9cd89d0-6e6a-4856-8220-69fdb62732ea', 'c88ba538-aa56-442b-8aca-65582150a869', true);


### PR DESCRIPTION
## overview

User notes that they have missing sessions on their approved action plan.

The action plan was approved with 8 sessions but they can only book 5 sessions.

This is because there are two action plans tied to the referral, one with 5 and one with 8.

This was caused by a bug that was introduced into production where we deployed action plan versioning too early such that action plans can turn into an invalid state.

To fix the issue we simply just need to add the missing sessions on the action_plan_session table.

# Discovery

Looking at preprod data, I see that there are two action plans for the referral in question:


```
select id, referral_id, number_of_sessions, submitted_at, approved_at from action_plan where referral_id in (select id from referral where service_usercrn = 'D842686');
                  id                  |             referral_id              | number_of_sessions |         submitted_at          |          approved_at          
--------------------------------------+--------------------------------------+--------------------+-------------------------------+-------------------------------
 eba092e3-2b40-456c-922f-f95761f143c7 | c88ba538-aa56-442b-8aca-65582150a869 |                  5 | 2021-08-06 14:00:02.529424+00 | 
 b9cd89d0-6e6a-4856-8220-69fdb62732ea | c88ba538-aa56-442b-8aca-65582150a869 |                  8 | 2021-08-06 14:02:27.477286+00 | 2021-08-06 14:01:56.286808+00
(2 rows)

```

There is only one approved action plan with 8 sessions.
However looking at the action_plan_sessions table we see that there are only 5 tied to that specific action_plan (from the old deprecated_action_plan_id):

```
select * from action_plan_session where referral_id = 'c88ba538-aa56-442b-8aca-65582150a869';
                  id                  | session_number |      deprecated_action_plan_id       |             referral_id              | latest_approved 
--------------------------------------+----------------+--------------------------------------+--------------------------------------+-----------------
 770f3462-e140-4885-bb12-ec6a2dfc1d29 |              5 | b9cd89d0-6e6a-4856-8220-69fdb62732ea | c88ba538-aa56-442b-8aca-65582150a869 | t
 b8fa6f6a-8095-4cd3-9e13-fd31a155e7cf |              4 | b9cd89d0-6e6a-4856-8220-69fdb62732ea | c88ba538-aa56-442b-8aca-65582150a869 | t
 940e8df6-430d-468f-a98c-e5149ce90e69 |              3 | b9cd89d0-6e6a-4856-8220-69fdb62732ea | c88ba538-aa56-442b-8aca-65582150a869 | t
 8cab3c52-6687-41d7-b172-e018cf812798 |              2 | b9cd89d0-6e6a-4856-8220-69fdb62732ea | c88ba538-aa56-442b-8aca-65582150a869 | t
 8314e071-d1fd-45a0-9b6f-1fa48c595ee4 |              1 | b9cd89d0-6e6a-4856-8220-69fdb62732ea | c88ba538-aa56-442b-8aca-65582150a869 | t
(5 rows)

```
