### PR TITLE
re-run migration to set sessions to true/false for specific referral ids

### DIFF
--- a/src/main/resources/db/migration/V1_83__prod_issue_fix_amend_multiple_true_sessions.sql
+++ b/src/main/resources/db/migration/V1_83__prod_issue_fix_amend_multiple_true_sessions.sql
@@ -1,19 +1,8 @@
-/*
-    Same as v1_80, but used to target specific referrals that were not correctly migrated.
-*/
-with action_plans_ranked_by_approved_at_desc as (
-    select id,
-           referral_id,
-           approved_at,
-           row_number() over (partition by referral_id order by approved_at desc) rank
-    from action_plan ap
-    where approved_at is not null
-    and referral_id in ('d7c7d7c1-df71-4501-9a0c-6649bcf31674', '4a95bf60-f5ab-4470-8988-addd705f0d5c')
-)
-update action_plan_session aps
-set latest_approved = case when apr.rank = 1 then true else false end
-from action_plans_ranked_by_approved_at_desc apr
-where aps.deprecated_action_plan_id = apr.id
-and aps.referral_id = apr.referral_id;
+-- To fix referral: d7c7d7c1-df71-4501-9a0c-6649bcf31674.
+-- Set action plan sessions to false for the old action plan: 98cdc3db-0493-45f5-9a4b-c19988c2cb9e
+update action_plan_session set latest_approved = false where deprecated_action_plan_id = '98cdc3db-0493-45f5-9a4b-c19988c2cb9e';
 
 
+-- To fix referral: 4a95bf60-f5ab-4470-8988-addd705f0d5c.
+-- Set action plan sessions to false for the old action plan: 2732a0f8-0ba1-4de4-83e1-f1624a4164d1
+update action_plan_session set latest_approved = false where deprecated_action_plan_id = '2732a0f8-0ba1-4de4-83e1-f1624a4164d1';


### PR DESCRIPTION
## What does this pull request do?

Fixes referrals that had multiple action plans' session set too true as a result of the step 3 change migration changes. This should only run against the referrals that did not migrate properly.

## What is the intent behind these changes?

There is currently an issue where there are multiple action plans action_plan_sessions set too true. Only the sessions for one action plan per referral should be set to true. This is to re-run the migration against a specific referral to fix this.


Identifying the action_action_plan id's that should not have been set to true.(the oldest ones)
```
             referral_id              |    				              id                  |    						    approved_at
--------------------------------------+--------------------------------------+-------------------------------
 d7c7d7c1-df71-4501-9a0c-6649bcf31674 	  | 98cdc3db-0493-45f5-9a4b-c19988c2cb9e 	| 2021-07-19 08:33:59.9356+00
 4a95bf60-f5ab-4470-8988-addd705f0d5c | 2732a0f8-0ba1-4de4-83e1-f1624a4164d1 	| 2021-07-21 08:21:16.288544+00
 4a95bf60-f5ab-4470-8988-addd705f0d5c | 19a7ac3b-f947-4cac-9af1-8726d2ab41b0 	| 2021-10-06 16:20:48.357179+00
 d7c7d7c1-df71-4501-9a0c-6649bcf31674 	  | 1f0996ef-9a43-4d67-8836-be0aedc19617 	| 2021-10-07 09:53:00.338462+00
```

Referral: d7c7d7c1-df71-4501-9a0c-6649bcf31674, 
latest action_plan_id = 1f0996ef-9a43-4d67-8836-be0aedc19617
Oldest action_plan_id(to set false) = 98cdc3db-0493-45f5-9a4b-c19988c2cb9e

action_plan_session id's to set to false for 98cdc3db-0493-45f5-9a4b-c19988c2cb9e: 
793c7ec3-b8a1-4736-ad83-831c42b0c1f2


Referral: 4a95bf60-f5ab-4470-8988-addd705f0d5c, 
latest action_plan_id = 19a7ac3b-f947-4cac-9af1-8726d2ab41b0 
Oldest action_plan_id(to set false) = 2732a0f8-0ba1-4de4-83e1-f1624a4164d1 

action_plan_session id's to set to false for 2732a0f8-0ba1-4de4-83e1-f1624a4164d1 :

adec799a-343c-44b7-a8d1-ed942c59ea9b
085c4195-52c0-4647-8e16-d4d79dce15b6
6fce9396-5fc8-4274-bf4c-287d97f35beb
912f04ec-e3b6-4f83-9fb4-6c01b2b29f1d
4e91383e-65f0-4418-a1a8-15de2cc8e097
9e6bc8fa-2aac-4374-8497-d0110e7acfa5
9beffd04-a9b7-48f5-a070-4b84d3ff887b
b10ad224-4a64-4c6b-889c-f5e80b874abf
2b8c1e7a-55a8-478c-92a9-44461fc054b0
4a0db364-a0d5-4b03-a194-b108a4e68455
b36e2945-9582-447c-9209-989ec310f57d
01f7f521-132c-4700-96f5-7023b4a508d2
d4aba846-c1c9-41f2-b9fc-465c8a29874b
d7aa709f-fd0b-4a39-8e0e-8ec4ff80bd7d
141213ae-983e-4952-a9e2-9d5c618f26df


