### PR TITLE
Detect migration clashes against mainline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,14 @@ jobs:
             sudo apt update
             sudo apt install postgresql-client
       - run:
+          name: Run main migrations then branch migrations to detect clashes
+          command: |
+            flyway clean -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password"
+            git reset --hard origin/main
+            flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration"
+            git reset --hard "$CIRCLE_SHA1"
+            flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration"
+      - run:
           name: Run migrations and local seeds
           command: |
             flyway clean -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password"


### PR DESCRIPTION
## What does this pull request do?

Extends the `ci/circleci: validate_db` job with applying migrations from `main` **before** migrating from the active branch. 

## What is the intent behind these changes?

The aim is to detect clashes of version numbers, which are typical after rebases.

This still won't detect clashes if branches are old or not rebased, so it's recommended to keep branch lifetime short