### PR TITLE
only add rows to delivery_session_appointment that have id's in delivery_session

### DIFF
--- a/src/main/resources/db/migration/V1_84__create_delivery_session_tables.sql
+++ b/src/main/resources/db/migration/V1_84__create_delivery_session_tables.sql
@@ -1,4 +1,3 @@
-BEGIN;
     alter view delivery_session rename to delivery_session_deprecated;
     alter view delivery_session_appointment rename to delivery_session_appointment_deprecated;
 
@@ -26,4 +25,3 @@ BEGIN;
 
     create index idx_delivery_session_appointment_delivery_session__id on delivery_session_appointment (delivery_session_id);
     create index idx_delivery_session_appointment_appointment__id on delivery_session_appointment (appointment_id);
-COMMIT;


### PR DESCRIPTION
## What does this pull request do?

Fixes the previous migration to ensure that only the `deliery_session_appointments` that are needed are migrated.

## What is the intent behind these changes?

To fix failing migration on creation of foreign key index.
