### PR TITLE
add migration to remove incorrectly added columns to delivery_session appointment table

### DIFF
--- a/src/main/resources/db/migration/V1_86__remove_surplus_columns_from_delivery_session_appointment.sql
+++ b/src/main/resources/db/migration/V1_86__remove_surplus_columns_from_delivery_session_appointment.sql
@@ -1,0 +1,9 @@
+-- This is to remove accidently added columns in the v1_84.
+alter table delivery_session_appointment
+    drop column id;
+
+alter table delivery_session_appointment
+    drop column session_number;
+
+alter table delivery_session_appointment
+    drop column referral_id;


### PR DESCRIPTION
## What does this pull request do?

Removes unneeded columns from the delivery_session_appointment table.


## What is the intent behind these changes?


An error in the 1.84 migration resulted in columns from the delivery session table being added to the new delivery_session_appointment table in dev. As these are all nullable, they can safely be deleted.
