### PR TITLE
Make session type non nullable.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -31,7 +31,7 @@ data class UpdateAppointmentDTO(
   val appointmentTime: OffsetDateTime,
   @JsonProperty(required = true) val durationInMinutes: Int,
   val appointmentDeliveryType: AppointmentDeliveryType,
-  val sessionType: AppointmentSessionType? = null,
+  val sessionType: AppointmentSessionType,
   val appointmentDeliveryAddress: AddressDTO? = null,
   val npsOfficeCode: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AppointmentDelivery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AppointmentDelivery.kt
@@ -29,8 +29,7 @@ data class AppointmentDelivery(
   @NotNull var appointmentDeliveryType: AppointmentDeliveryType,
   @Type(type = "appointment_session_type")
   @Enumerated(EnumType.STRING)
-  // TODO: Transform to @NotNull this change is live
-  var appointmentSessionType: AppointmentSessionType? = null,
+  @NotNull var appointmentSessionType: AppointmentSessionType,
   var npsOfficeCode: String? = null,
   @OneToOne(cascade = [CascadeType.ALL])
   @PrimaryKeyJoinColumn

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -40,7 +40,7 @@ class AppointmentService(
     appointmentType: AppointmentType,
     createdByUser: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentSessionType: AppointmentSessionType?,
+    appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
   ): Appointment {
@@ -104,7 +104,7 @@ class AppointmentService(
   fun createOrUpdateAppointmentDeliveryDetails(
     appointment: Appointment,
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentSessionType: AppointmentSessionType?,
+    appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddressDTO: AddressDTO?,
     npsOfficeCode: String? = null
   ) {
@@ -230,7 +230,7 @@ class AppointmentService(
     deliusAppointmentId: Long?,
     createdByUser: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentSessionType: AppointmentSessionType?,
+    appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddress: AddressDTO? = null,
     referral: Referral,
     npsOfficeCode: String?,
@@ -255,7 +255,7 @@ class AppointmentService(
     appointmentTime: OffsetDateTime,
     deliusAppointmentId: Long?,
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentSessionType: AppointmentSessionType?,
+    appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String?,
   ): Appointment {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -64,7 +64,7 @@ class DeliverySessionService(
     durationInMinutes: Int,
     updatedBy: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentSessionType: AppointmentSessionType? = null,
+    appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
   ): DeliverySession {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -42,7 +42,7 @@ class SupplierAssessmentService(
     appointmentTime: OffsetDateTime,
     createdByUser: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
-    appointmentSessionType: AppointmentSessionType? = null,
+    appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
   ): Appointment {


### PR DESCRIPTION
Changed the AppointmentSessionType to be non-nullable when scheduling or rescheduling an appointment.

The value is defaulted to ONE_TO_ONE in the DB for historical appointments where this value was not specified.

This value is contained within the AppointmentDelivery Entity; this entity will only ever be created as part of an appointment when a schedule request has been made.

Making this value non-nullable will be safe because even though the UI defines it as a nullable field it will never be null when making a Schedule appointment request.