### PR TITLE
Increase WAF anomaly threshold

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
       SecRuleEngine On
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
     {{- else }}
     kubernetes.io/ingress.class: "nginx"
     {{- end }}


### PR DESCRIPTION


## What does this pull request do?

Increase (service) WAF anomaly threshold

## What is the intent behind these changes?

We are using the service ingress to split between paths, which forced us in the UI to use the ingress URLs again

- https://github.com/ministryofjustice/hmpps-interventions-service/pull/628
- https://github.com/ministryofjustice/hmpps-interventions-ui/pull/937

This means the UI requests _will_ be blocked by the WAF

Rather than disabling the WAF completely, we can increase its anomaly
threshold and monitor the blocks so we can come up with reasonable rules

Source: https://www.netnea.com/cms/apache-tutorial-8_handling-false-positives-modsecurity-core-rule-set/
