### PR TITLE
153-issue-pps-terminating-nsis-on-delius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
@@ -45,7 +45,7 @@ class CommunityApiCallError(val httpStatus: HttpStatus, causeMessage: String, va
           "The Service User Sentence must not contain more than one active rehabilitation activity requirement. Please correct in Delius and try again"
         }
         category.contains("Cannot find NSI for CRN: _ Sentence: _ and ContractType".toRegex()) -> {
-          "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support"
+          "This update has not been possible. This is because there's been a change to the referral in non-structured interventions in nDelius. Ask the probation practitioner if anything has changed with the referral or the person on probation"
         }
         category.contains("Multiple existing matching NSIs found".toRegex()) -> {
           "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
@@ -46,7 +46,7 @@ internal class CommunityApiCallErrorTest {
         "{}",
         RuntimeException()
       ).userMessage
-    ).isEqualTo("There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support")
+    ).isEqualTo("This update has not been possible. This is because there's been a change to the referral in non-structured interventions in nDelius. Ask the probation practitioner if anything has changed with the referral or the person on probation")
 
     assertThat(
       CommunityApiCallError(


### PR DESCRIPTION
https://trello.com/c/1JTAM8ki/153-issue-pps-terminating-nsis-on-delius

## What does this pull request do?
When updating an appointment, the SP can be told "Cannot find NSI". This is because it has been terminated in Delius by the PP. The purpose of this change is to make the message more informative

## What is the intent behind these changes?
This change makes the message more directive and encourages the SP to talk to the PP about changing circumstances and to avoid business related support queries
