### PR TITLE
uJB67WFy: split s3 bucket configuration to allow multiple buckets to be configured

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,4 +77,5 @@ dependencies {
   testImplementation("au.com.dius.pact.provider:junit5spring:4.2.14")
   testImplementation("com.squareup.okhttp3:okhttp:4.9.2")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
+  testImplementation("org.mockito:mockito-inline:4.0.0")
 }

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -84,22 +84,40 @@ env:
         name: sentry
         key: service_dsn
 
-  - name: AWS_S3_ACCESSKEYID
+  - name: AWS_S3_STORAGE_ACCESSKEYID
     valueFrom:
       secretKeyRef:
         name: storage-s3-bucket
         key: access_key_id
 
-  - name: AWS_S3_SECRETACCESSKEY
+  - name: AWS_S3_STORAGE_SECRETACCESSKEY
     valueFrom:
       secretKeyRef:
         name: storage-s3-bucket
         key: secret_access_key
 
-  - name: AWS_S3_BUCKET_NAME
+  - name: AWS_S3_STORAGE_BUCKET_NAME
     valueFrom:
       secretKeyRef:
         name: storage-s3-bucket
+        key: bucket_name
+
+  - name: AWS_S3_NDMIS_ACCESSKEYID
+    valueFrom:
+      secretKeyRef:
+        name: reporting-s3-bucket
+        key: access_key_id
+
+  - name: AWS_S3_NDMIS_SECRETACCESSKEY
+    valueFrom:
+      secretKeyRef:
+        name: reporting-s3-bucket
+        key: secret_access_key
+
+  - name: AWS_S3_NDMIS_BUCKET_NAME
+    valueFrom:
+      secretKeyRef:
+        name: reporting-s3-bucket
         key: bucket_name
 
 {{- end -}}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,4 +24,4 @@ env:
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "dev"
-  AWS_S3_ENABLED: "true"
+  AWS_S3_STORAGE_ENABLED: "true"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,4 +24,4 @@ env:
   COMMUNITYAPI_BASEURL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "preprod"
-  AWS_S3_ENABLED: "true"
+  AWS_S3_STORAGE_ENABLED: "true"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,4 +22,4 @@ env:
   COMMUNITYAPI_BASEURL: "https://community-api-secure.probation.service.justice.gov.uk"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "prod"
-  AWS_S3_ENABLED: "true"
+  AWS_S3_STORAGE_ENABLED: "true"

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -22,4 +22,4 @@ env:
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "research"
-  AWS_S3_ENABLED: "true"
+  AWS_S3_STORAGE_ENABLED: "true"

--- a/script/localstack/buckets.sh
+++ b/script/localstack/buckets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -x
 awslocal s3 mb s3://interventions-bucket-local
+awslocal s3 mb s3://ndmis-bucket-local
 set +x

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobListener.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSender
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
 import java.io.File
 import kotlin.io.path.Path
@@ -17,6 +18,7 @@ import kotlin.io.path.createTempDirectory
 @Component
 class PerformanceReportJobListener(
   private val s3Service: S3Service,
+  private val storageS3Bucket: S3Bucket,
   private val emailSender: EmailSender,
   @Value("\${notify.templates.service-provider-performance-report-ready}") private val successNotifyTemplateId: String,
   @Value("\${notify.templates.service-provider-performance-report-failed}") private val failureNotifyTemplateId: String,
@@ -40,7 +42,7 @@ class PerformanceReportJobListener(
 
     when (jobExecution.status) {
       BatchStatus.COMPLETED -> {
-        s3Service.publishFileToS3(path, "reports/service-provider/performance/")
+        s3Service.publishFileToS3(storageS3Bucket, path, "reports/service-provider/performance/")
 
         emailSender.sendEmail(
           successNotifyTemplateId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
@@ -2,23 +2,18 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.core.sync.RequestBody
-import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import java.nio.file.Path
 
 @Service
-class S3Service(
-  private val s3Client: S3Client,
-  @Value("\${aws.s3.enabled}") private val s3Enabled: Boolean,
-  @Value("\${aws.s3.bucket.name}") private val s3BucketName: String,
-) {
+class S3Service {
   companion object : KLogging()
 
-  fun publishFileToS3(path: Path, keyPrefix: String = "") {
-    if (!s3Enabled) {
+  fun publishFileToS3(bucket: S3Bucket, path: Path, keyPrefix: String = "") {
+    if (!bucket.enabled) {
       logger.info("not publishing to s3; s3 disabled")
       return
     }
@@ -27,10 +22,10 @@ class S3Service(
     logger.info("publishing file to s3 {}", StructuredArguments.kv("key", key))
 
     val objectRequest = PutObjectRequest.builder()
-      .bucket(s3BucketName)
+      .bucket(bucket.bucketName)
       .key(key)
       .build()
 
-    s3Client.putObject(objectRequest, RequestBody.fromFile(path))
+    bucket.client.putObject(objectRequest, RequestBody.fromFile(path))
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,12 +17,20 @@ assess-risks-and-needs:
 
 aws:
   s3:
-    enabled: false
-    provider: localstack
-    access-key-id: test
-    secret-access-key: test
-    endpoint.uri: http://localhost:4566
-    bucket.name: interventions-bucket-local
+    storage:
+      enabled: false
+      provider: localstack
+      access-key-id: test
+      secret-access-key: test
+      endpoint.uri: http://localhost:4566
+      bucket.name: interventions-bucket-local
+    ndmis:
+      enabled: false
+      provider: localstack
+      access-key-id: test
+      secret-access-key: test
+      endpoint.uri: http://localhost:4566
+      bucket.name: ndmis-bucket-local
   sns:
     enabled: false
     provider: localstack

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,9 +165,14 @@ assess-risks-and-needs:
 
 aws:
   s3:
-    enabled: false
-    provider: aws
-    region: eu-west-2
+    storage:
+      enabled: false
+      provider: aws
+      region: eu-west-2
+    ndmis:
+      enabled: false
+      provider: aws
+      region: eu-west-2
   sns:
     enabled: true
     provider: aws

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportJobListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportJobListenerTest.kt
@@ -9,14 +9,17 @@ import org.springframework.batch.core.JobInstance
 import org.springframework.batch.core.JobParametersBuilder
 import org.springframework.batch.item.ExecutionContext
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSender
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider.performance.PerformanceReportJobListener
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
 
 internal class PerformanceReportJobListenerTest {
   private val s3Service = mock<S3Service>()
+  private val s3Bucket = mock<S3Bucket>()
   private val emailSender = mock<EmailSender>()
   private val listener = PerformanceReportJobListener(
     s3Service,
+    s3Bucket,
     emailSender,
     "success-email-template",
     "failure-email-template",


### PR DESCRIPTION
## What does this pull request do?

* adds configuration for the ndmis 'reporting' s3 bucket
* using spring configuration properties mapping to re-use the bucket config in the s3 config bean
* updates the s3 service to operate on a specific bucket instead of a generic s3 client.

## What is the intent behind these changes?

allow the application to interact with multiple s3 buckets
