### PR TITLE
BugFix: Include EOSR submitted at for SP dashboard filtering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
@@ -12,6 +12,7 @@ class ServiceProviderSentReferralSummaryDTO(
   val serviceUserFirstName: String?,
   val serviceUserLastName: String?,
   val hasEndOfServiceReport: Boolean,
+  val endOfServiceReportSubmitted: Boolean,
 ) {
   companion object {
     fun from(sentReferralSummary: ServiceProviderSentReferralSummary): ServiceProviderSentReferralSummaryDTO {
@@ -23,7 +24,8 @@ class ServiceProviderSentReferralSummaryDTO(
         assignedToUserName = sentReferralSummary.assignedToUserName,
         serviceUserFirstName = sentReferralSummary.serviceUserFirstName,
         serviceUserLastName = sentReferralSummary.serviceUserLastName,
-        hasEndOfServiceReport = sentReferralSummary.endOfServiceReportId != null
+        hasEndOfServiceReport = sentReferralSummary.endOfServiceReportId != null,
+        endOfServiceReportSubmitted = sentReferralSummary.endOfServiceReportSubmittedAt != null
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
@@ -13,4 +13,5 @@ interface ServiceProviderSentReferralSummary {
   val serviceUserFirstName: String?
   val serviceUserLastName: String?
   val endOfServiceReportId: UUID?
+  val endOfServiceReportSubmittedAt: Instant?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -22,7 +22,8 @@ interface ReferralRepository : JpaRepository<Referral, UUID>, JpaSpecificationEx
 			assignedToUserName,
 			serviceUserFirstName,
 			serviceUserLastName,
-      endOfServiceReportId from (	
+      endOfServiceReportId,
+      endOfServiceReportSubmittedAt from (	
 	select
 			cast(r.id as varchar) AS referralId,
 			cast(r.sent_at as TIMESTAMP WITH TIME ZONE) as sentAt,
@@ -33,6 +34,7 @@ interface ReferralRepository : JpaRepository<Referral, UUID>, JpaSpecificationEx
 			rsud.first_name as serviceUserFirstName,
 			rsud.last_name as serviceUserLastName,
       cast(eosr.id as varchar) as endOfServiceReportId,
+      cast(eosr.submitted_at as TIMESTAMP WITH TIME ZONE) as endOfServiceReportSubmittedAt,
 			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq		
 	from referral r
 			 inner join intervention i on i.id = r.intervention_id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -296,7 +296,8 @@ class ReferralRepositoryTest @Autowired constructor(
         it.assignedToUserName == summary.assignedToUserName &&
         it.serviceUserFirstName == summary.serviceUserFirstName &&
         it.serviceUserLastName == summary.serviceUserLastName &&
-        it.endOfServiceReportId == summary.endOfServiceReportId
+        it.endOfServiceReportId == summary.endOfServiceReportId &&
+        it.endOfServiceReportSubmittedAt == summary.endOfServiceReportSubmittedAt
     }
   }
 
@@ -310,7 +311,8 @@ class ReferralRepositoryTest @Autowired constructor(
       referral.currentAssignee?.id,
       referral.serviceUserData!!.firstName,
       referral.serviceUserData!!.lastName,
-      referral.endOfServiceReport?.id
+      referral.endOfServiceReport?.id,
+      referral.endOfServiceReport?.submittedAt?.toInstant()
     )
 
   @Test
@@ -339,4 +341,5 @@ data class Summary(
   override val serviceUserFirstName: String?,
   override val serviceUserLastName: String?,
   override val endOfServiceReportId: UUID?,
+  override val endOfServiceReportSubmittedAt: Instant?,
 ) : ServiceProviderSentReferralSummary


### PR DESCRIPTION
For sent referrals summary we should be sending the submitted_at date for the end of service report.

This will solve a bug in prod whereby we include referrals that have an EOSR created but not submitted in the "Completed cases" column for SP.

(Note: Completed Cases is not the same as our definition of completed referral. The SPs want to see all referrals that have been ended/delivered, so this includes prematurely ended, delivery completed and completed but not cancelled))

