### PR TITLE
Include some cancelled referrals for sentReferralsSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceProviderSentReferralSummaryDTO.kt
@@ -13,6 +13,7 @@ class ServiceProviderSentReferralSummaryDTO(
   val serviceUserLastName: String?,
   val hasEndOfServiceReport: Boolean,
   val endOfServiceReportSubmitted: Boolean,
+  val concluded: Boolean,
 ) {
   companion object {
     fun from(sentReferralSummary: ServiceProviderSentReferralSummary): ServiceProviderSentReferralSummaryDTO {
@@ -25,7 +26,8 @@ class ServiceProviderSentReferralSummaryDTO(
         serviceUserFirstName = sentReferralSummary.serviceUserFirstName,
         serviceUserLastName = sentReferralSummary.serviceUserLastName,
         hasEndOfServiceReport = sentReferralSummary.endOfServiceReportId != null,
-        endOfServiceReportSubmitted = sentReferralSummary.endOfServiceReportSubmittedAt != null
+        endOfServiceReportSubmitted = sentReferralSummary.endOfServiceReportSubmittedAt != null,
+        concluded = sentReferralSummary.concludedAt != null
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ServiceProviderSentReferralSummary.kt
@@ -14,4 +14,5 @@ interface ServiceProviderSentReferralSummary {
   val serviceUserLastName: String?
   val endOfServiceReportId: UUID?
   val endOfServiceReportSubmittedAt: Instant?
+  val concludedAt: Instant?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -23,7 +23,8 @@ interface ReferralRepository : JpaRepository<Referral, UUID>, JpaSpecificationEx
 			serviceUserFirstName,
 			serviceUserLastName,
       endOfServiceReportId,
-      endOfServiceReportSubmittedAt from (	
+      endOfServiceReportSubmittedAt,
+      concludedAt from (	
 	select
 			cast(r.id as varchar) AS referralId,
 			cast(r.sent_at as TIMESTAMP WITH TIME ZONE) as sentAt,
@@ -35,7 +36,8 @@ interface ReferralRepository : JpaRepository<Referral, UUID>, JpaSpecificationEx
 			rsud.last_name as serviceUserLastName,
       cast(eosr.id as varchar) as endOfServiceReportId,
       cast(eosr.submitted_at as TIMESTAMP WITH TIME ZONE) as endOfServiceReportSubmittedAt,
-			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq		
+      cast(r.concluded_at as TIMESTAMP WITH TIME ZONE) as concludedAt,
+			row_number() over(partition by r.id order by ra.assigned_at desc) as assigned_at_desc_seq
 	from referral r
 			 inner join intervention i on i.id = r.intervention_id
 			 left join referral_service_user_data rsud on rsud.referral_id = r.id
@@ -44,11 +46,17 @@ interface ReferralRepository : JpaRepository<Referral, UUID>, JpaSpecificationEx
 			 left join referral_assignments ra on ra.referral_id = r.id
 			 left join auth_user au on au.id = ra.assigned_to_id
 			 left join end_of_service_report eosr on eosr.referral_id = r.id
+			 left outer join action_plan ap on ap.referral_id = r.id
+	 	 	 left outer join appointment app
+       	 left join supplier_assessment_appointment saa on saa.appointment_id = app.id
+       	 on app.referral_id = r.id
 	where
 		  r.sent_at is not null
-		  and not (r.concluded_At is not null
-			and r.end_Requested_At is not null
-			and eosr.id is null)
+		  and not (
+		  	    (r.concluded_At is not null and r.end_Requested_At is not null and eosr.id is null) -- cancelled
+	 	        and app.attendance_submitted_at is null -- supplier assessment feedback not submitted
+            and ap.submitted_at is null -- action plan has not been submitted
+        ) -- filter out referrals that are cancelled with SAA feedback not completed yet or cancelled with no action plan submitted
 		and ( dfc.prime_provider_id in :serviceProviders or dfcsc.subcontractor_provider_id in :serviceProviders )
 ) a where assigned_at_desc_seq = 1""",
     nativeQuery = true


### PR DESCRIPTION
The `Completed cases` dashboard for SP should now include referrals which:

1. have their End of Service Report submitted
2. or were cancelled with at least feedback submitted for their supplier assessment
3. or were cancelled with at least an action plan submitted

The /sent-referrals/summary/service-provider endpoint will now return a new field called "concluded".

The UI can use this field to move all referrals where concluded is true to the `Completed cases` dashboard. This will include the unfiltered cancelled referrals.

## Notes
This is based on a conversation with Leigh where he provided the following table:

![image](https://user-images.githubusercontent.com/83066216/139670576-4229eaa9-1adf-4576-87be-2cfb823a5ff2.png)

This shows that we should be filtering out cancelled referrals but only until their SAA feedback has been submitted or action plan has been submitted.

We don't need to consider the other scenarios in the table since they all occur after the SAA feedback submitted or Action Plan submitted.