### PR TITLE
remove explicit s3 'provider' config and just override the endpoint uri if it's specified

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,7 +19,6 @@ aws:
   s3:
     storage:
       enabled: false
-      provider: localstack
       access-key-id: test
       secret-access-key: test
       endpoint.uri: http://localhost:4566

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -167,7 +167,6 @@ aws:
   s3:
     storage:
       enabled: false
-      provider: aws
       region: eu-west-2
   sns:
     enabled: true


### PR DESCRIPTION
## What does this pull request do?

remove explicit s3 'provider' config and just override the endpoint uri if it's specified

## What is the intent behind these changes?

unblock the broken deploy - simplify the s3 configuration
