### PR TITLE
Draft oasys risk info

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftOasysRiskInformationDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftOasysRiskInformationDTO.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftOasysRiskInformation
+
+data class DraftOasysRiskInformationDTO(
+  val riskSummaryWhoIsAtRisk: String?,
+  val riskSummaryNatureOfRisk: String?,
+  val riskSummaryRiskImminence: String?,
+  val riskToSelfSuicide: String?,
+  val riskToSelfSelfHarm: String?,
+  val riskToSelfHostelSetting: String?,
+  val riskToSelfVulnerability: String?,
+  val additionalInformation: String?,
+) {
+  companion object {
+    fun from(draftOasysRiskInformation: DraftOasysRiskInformation): DraftOasysRiskInformationDTO {
+      return DraftOasysRiskInformationDTO(
+        riskSummaryWhoIsAtRisk = draftOasysRiskInformation.riskSummaryWhoIsAtRisk,
+        riskSummaryNatureOfRisk = draftOasysRiskInformation.riskSummaryNatureOfRisk,
+        riskSummaryRiskImminence = draftOasysRiskInformation.riskSummaryRiskImminence,
+        riskToSelfSuicide = draftOasysRiskInformation.riskToSelfSuicide,
+        riskToSelfSelfHarm = draftOasysRiskInformation.riskToSelfSelfHarm,
+        riskToSelfHostelSetting = draftOasysRiskInformation.riskToSelfHostelSetting,
+        riskToSelfVulnerability = draftOasysRiskInformation.riskToSelfVulnerability,
+        additionalInformation = draftOasysRiskInformation.additionalInformation,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftOasysRiskInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftOasysRiskInformation.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import org.hibernate.annotations.Fetch
+import org.hibernate.annotations.FetchMode
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.ManyToOne
+import javax.validation.constraints.NotNull
+
+@Entity
+class DraftOasysRiskInformation(
+  @Id
+  val referralId: UUID,
+  @NotNull val updatedAt: OffsetDateTime,
+  @NotNull @ManyToOne @Fetch(FetchMode.JOIN)
+  val updatedBy: AuthUser,
+  var riskSummaryWhoIsAtRisk: String?,
+  var riskSummaryNatureOfRisk: String?,
+  var riskSummaryRiskImminence: String?,
+  var riskToSelfSuicide: String?,
+  var riskToSelfSelfHarm: String?,
+  var riskToSelfHostelSetting: String?,
+  var riskToSelfVulnerability: String?,
+  var additionalInformation: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DraftOasysRiskInformationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DraftOasysRiskInformationRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftOasysRiskInformation
+import java.util.UUID
+
+interface DraftOasysRiskInformationRepository : JpaRepository<DraftOasysRiskInformation, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftOasysRiskInformationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftOasysRiskInformationService.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftOasysRiskInformationDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftOasysRiskInformation
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftOasysRiskInformationRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.transaction.Transactional
+
+@Service
+@Transactional
+class DraftOasysRiskInformationService(
+  val draftOasysRiskInformationRepository: DraftOasysRiskInformationRepository,
+  val authUserRepository: AuthUserRepository,
+) {
+  fun updateDraftOasysRiskInformation(referral: Referral, draftOasysRiskInformationDTO: DraftOasysRiskInformationDTO, user: AuthUser): DraftOasysRiskInformation {
+    val draftOasysRiskInformation = DraftOasysRiskInformation(
+      referralId = referral.id,
+      updatedAt = OffsetDateTime.now(),
+      updatedBy = authUserRepository.save(user),
+      riskSummaryWhoIsAtRisk = draftOasysRiskInformationDTO.riskSummaryWhoIsAtRisk,
+      riskSummaryNatureOfRisk = draftOasysRiskInformationDTO.riskSummaryNatureOfRisk,
+      riskSummaryRiskImminence = draftOasysRiskInformationDTO.riskSummaryRiskImminence,
+      riskToSelfSuicide = draftOasysRiskInformationDTO.riskToSelfSuicide,
+      riskToSelfSelfHarm = draftOasysRiskInformationDTO.riskToSelfSelfHarm,
+      riskToSelfHostelSetting = draftOasysRiskInformationDTO.riskToSelfHostelSetting,
+      riskToSelfVulnerability = draftOasysRiskInformationDTO.riskToSelfVulnerability,
+      additionalInformation = draftOasysRiskInformationDTO.additionalInformation,
+    )
+    return draftOasysRiskInformationRepository.save(draftOasysRiskInformation)
+  }
+
+  fun getDraftOasysRiskInformation(id: UUID): DraftOasysRiskInformation? {
+    return draftOasysRiskInformationRepository.findByIdOrNull(id)
+  }
+}

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -127,3 +127,16 @@ COMMENT ON TABLE metadata IS 'defines metadata about the schema';
 COMMENT ON COLUMN metadata.table_name IS 'which table this record is describing';
 COMMENT ON COLUMN metadata.column_name IS 'which column this record is describing';
 COMMENT ON COLUMN metadata.sensitive IS '`true` means the contents should be obfuscated/anonymised in unsafe environments; `false` means it’s safe to see/copy';
+
+COMMENT ON TABLE draft_oasys_risk_information IS 'holds draft OASYS risk information only for a DraftReferral. Discarded after referral is sent.';
+COMMENT ON COLUMN draft_oasys_risk_information.referral_id IS 'the id of the draft referral connected to risk information';
+COMMENT ON COLUMN draft_oasys_risk_information.updated_at IS 'when the draft oasys risk information was last updated';
+COMMENT ON COLUMN draft_oasys_risk_information.updated_by_id IS 'who updated the draft oasys risk information';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_summary_who_is_at_risk IS 'OASYS Risk Summary - who is at risk?';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_summary_nature_of_risk IS 'OASYS Risk Summary - nature of risk';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_summary_risk_imminence IS 'OASYS Risk Summary - risk imminence';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_suicide IS 'OASYS Risk to Self - suicide';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_self_harm IS 'OASYS Risk to Self - self harm';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_hostel_setting IS 'OASYS Risk to Self - hostel setting';
+COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_vulnerability IS 'OASYS Risk to Self - vulnerability';
+COMMENT ON COLUMN draft_oasys_risk_information.additional_information IS 'OASYS Additional risk information';

--- a/src/main/resources/db/migration/V1_90__draft_oasys_risk_information.sql
+++ b/src/main/resources/db/migration/V1_90__draft_oasys_risk_information.sql
@@ -1,0 +1,28 @@
+create table draft_oasys_risk_information(
+    referral_id uuid not null,
+    updated_at timestamp with time zone not null,
+    updated_by_id text not null,
+    risk_summary_who_is_at_risk text,
+    risk_summary_nature_of_risk text,
+    risk_summary_risk_imminence text,
+    risk_to_self_suicide text,
+    risk_to_self_self_harm text,
+    risk_to_self_hostel_setting text,
+    risk_to_self_vulnerability text,
+    additional_information text,
+    primary key(referral_id),
+    constraint fk_draft_oasys_risk_information_referral_id foreign key (referral_id) references referral,
+    constraint fk_case_note_updated_by_id foreign key (updated_by_id) references auth_user
+);
+
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','referral_id',FALSE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','updated_at',FALSE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','updated_by_id',FALSE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_summary_who_is_at_risk',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_summary_nature_of_risk',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_summary_risk_imminence',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_to_self_suicide',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_to_self_self_harm',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_to_self_hostel_setting',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','risk_to_self_vulnerability',TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('draft_oasys_risk_information','additional_information',TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUse
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DraftOasysRiskInformationService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcluder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ServiceCategoryService
@@ -49,8 +50,9 @@ internal class ReferralControllerTest {
   private val clientApiAccessChecker = ClientApiAccessChecker()
   private val cancellationReasonMapper = mock<CancellationReasonMapper>()
   private val actionPlanService = mock<ActionPlanService>()
+  private val draftOasysRiskInformationService = mock<DraftOasysRiskInformationService>()
   private val referralController = ReferralController(
-    referralService, referralConcluder, serviceCategoryService, userMapper, clientApiAccessChecker, cancellationReasonMapper, actionPlanService
+    referralService, referralConcluder, serviceCategoryService, userMapper, clientApiAccessChecker, cancellationReasonMapper, actionPlanService, draftOasysRiskInformationService
   )
   private val tokenFactory = JwtTokenFactory()
   private val referralFactory = ReferralFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftOasysRiskInformationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftOasysRiskInformationServiceTest.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftOasysRiskInformationDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftOasysRiskInformation
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftOasysRiskInformationRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@RepositoryTest
+class DraftOasysRiskInformationServiceTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val draftOasysRiskInformationRepository: DraftOasysRiskInformationRepository,
+  val authUserRepository: AuthUserRepository
+) {
+
+  private val referralFactory = ReferralFactory(entityManager)
+  private val authUserFactory = AuthUserFactory(entityManager)
+  private val draftOasysRiskInformationService = DraftOasysRiskInformationService(
+    draftOasysRiskInformationRepository, authUserRepository
+  )
+
+  @Nested
+  inner class UpdateDraftOasysRiskInformation {
+    @Test
+    fun `can save oasys risk information`() {
+      val referral = referralFactory.createDraft()
+      val user = authUserFactory.createSP()
+      val oasysRiskInformationDTO = DraftOasysRiskInformationDTO(
+        riskSummaryWhoIsAtRisk = "riskSummaryWhoIsAtRisk",
+        riskSummaryNatureOfRisk = "riskSummaryNatureOfRisk",
+        riskSummaryRiskImminence = "riskSummaryRiskImminence",
+        riskToSelfSuicide = "riskToSelfSuicide",
+        riskToSelfSelfHarm = "riskToSelfSelfHarm",
+        riskToSelfHostelSetting = "riskToSelfHostelSetting",
+        riskToSelfVulnerability = "riskToSelfVulnerability",
+        additionalInformation = "additionalInformation",
+      )
+      val oasysRiskInformation = draftOasysRiskInformationService.updateDraftOasysRiskInformation(referral, oasysRiskInformationDTO, user)
+      Assertions.assertThat(oasysRiskInformation.referralId).isEqualTo(referral.id)
+      Assertions.assertThat(oasysRiskInformation.updatedAt).isBefore(OffsetDateTime.now())
+      Assertions.assertThat(oasysRiskInformation.updatedBy).isEqualTo(user)
+      Assertions.assertThat(oasysRiskInformation.additionalInformation).isEqualTo(oasysRiskInformationDTO.additionalInformation)
+      Assertions.assertThat(oasysRiskInformation.riskSummaryWhoIsAtRisk).isEqualTo(oasysRiskInformationDTO.riskSummaryWhoIsAtRisk)
+      Assertions.assertThat(oasysRiskInformation.riskSummaryNatureOfRisk).isEqualTo(oasysRiskInformationDTO.riskSummaryNatureOfRisk)
+      Assertions.assertThat(oasysRiskInformation.riskSummaryRiskImminence).isEqualTo(oasysRiskInformationDTO.riskSummaryRiskImminence)
+      Assertions.assertThat(oasysRiskInformation.riskToSelfSuicide).isEqualTo(oasysRiskInformationDTO.riskToSelfSuicide)
+      Assertions.assertThat(oasysRiskInformation.riskToSelfSelfHarm).isEqualTo(oasysRiskInformationDTO.riskToSelfSelfHarm)
+      Assertions.assertThat(oasysRiskInformation.riskToSelfHostelSetting).isEqualTo(oasysRiskInformationDTO.riskToSelfHostelSetting)
+      Assertions.assertThat(oasysRiskInformation.riskToSelfVulnerability).isEqualTo(oasysRiskInformationDTO.riskToSelfVulnerability)
+      Assertions.assertThat(oasysRiskInformation.additionalInformation).isEqualTo(oasysRiskInformationDTO.additionalInformation)
+    }
+
+    @Test
+    fun `can overwrite oasys risk information`() {
+      val referral = referralFactory.createDraft()
+      val spUser = authUserFactory.createSP()
+      val ppUser = authUserFactory.createPP()
+      val oasysRiskInformation = DraftOasysRiskInformation(
+        referralId = referral.id,
+        updatedAt = OffsetDateTime.now(),
+        updatedBy = spUser,
+        riskSummaryWhoIsAtRisk = "riskSummaryWhoIsAtRisk",
+        riskSummaryNatureOfRisk = "riskSummaryNatureOfRisk",
+        riskSummaryRiskImminence = "riskSummaryRiskImminence",
+        riskToSelfSuicide = "riskToSelfSuicide",
+        riskToSelfSelfHarm = "riskToSelfSelfHarm",
+        riskToSelfHostelSetting = "riskToSelfHostelSetting",
+        riskToSelfVulnerability = "riskToSelfVulnerability",
+        additionalInformation = "additionalInformation",
+      )
+      draftOasysRiskInformationRepository.save(oasysRiskInformation)
+      val oasysRiskInformationDTO = DraftOasysRiskInformationDTO(
+        riskSummaryWhoIsAtRisk = "riskSummaryWhoIsAtRiskModified",
+        riskSummaryNatureOfRisk = "riskSummaryNatureOfRiskModified",
+        riskSummaryRiskImminence = "riskSummaryRiskImminenceModified",
+        riskToSelfSuicide = "riskToSelfSuicideModified",
+        riskToSelfSelfHarm = "riskToSelfSelfHarmModified",
+        riskToSelfHostelSetting = "riskToSelfHostelSettingModified",
+        riskToSelfVulnerability = "riskToSelfVulnerabilityModified",
+        additionalInformation = "additionalInformationModified",
+      )
+      val entity = draftOasysRiskInformationService.updateDraftOasysRiskInformation(referral, oasysRiskInformationDTO, ppUser)
+      Assertions.assertThat(entity.referralId).isEqualTo(referral.id)
+      Assertions.assertThat(entity.updatedAt).isAfter(oasysRiskInformation.updatedAt)
+      Assertions.assertThat(entity.updatedBy).isEqualTo(ppUser)
+      Assertions.assertThat(entity.riskSummaryWhoIsAtRisk).isEqualTo(oasysRiskInformationDTO.riskSummaryWhoIsAtRisk)
+      Assertions.assertThat(entity.riskSummaryNatureOfRisk).isEqualTo(oasysRiskInformationDTO.riskSummaryNatureOfRisk)
+      Assertions.assertThat(entity.riskSummaryRiskImminence).isEqualTo(oasysRiskInformationDTO.riskSummaryRiskImminence)
+      Assertions.assertThat(entity.riskToSelfSuicide).isEqualTo(oasysRiskInformationDTO.riskToSelfSuicide)
+      Assertions.assertThat(entity.riskToSelfSelfHarm).isEqualTo(oasysRiskInformationDTO.riskToSelfSelfHarm)
+      Assertions.assertThat(entity.riskToSelfHostelSetting).isEqualTo(oasysRiskInformationDTO.riskToSelfHostelSetting)
+      Assertions.assertThat(entity.riskToSelfVulnerability).isEqualTo(oasysRiskInformationDTO.riskToSelfVulnerability)
+      Assertions.assertThat(entity.additionalInformation).isEqualTo(oasysRiskInformationDTO.additionalInformation)
+    }
+  }
+  @Nested
+  inner class GetDraftOasysRiskInformation {
+    @Test
+    fun `can get oasys risk information`() {
+      val referral = referralFactory.createDraft()
+      val user = authUserFactory.createSP()
+      val oasysRiskInformation = DraftOasysRiskInformation(
+        referralId = referral.id,
+        updatedAt = OffsetDateTime.now(),
+        updatedBy = user,
+        riskSummaryWhoIsAtRisk = "riskSummaryWhoIsAtRisk",
+        riskSummaryNatureOfRisk = "riskSummaryNatureOfRisk",
+        riskSummaryRiskImminence = "riskSummaryRiskImminence",
+        riskToSelfSuicide = "riskToSelfSuicide",
+        riskToSelfSelfHarm = "riskToSelfSelfHarm",
+        riskToSelfHostelSetting = "riskToSelfHostelSetting",
+        riskToSelfVulnerability = "riskToSelfVulnerability",
+        additionalInformation = "additionalInformationModified",
+      )
+      draftOasysRiskInformationRepository.save(oasysRiskInformation)
+      val entity = draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)
+      Assertions.assertThat(entity).isNotNull
+    }
+
+    @Test
+    fun `return null if no oasys risk information exists`() {
+      val entity = draftOasysRiskInformationService.getDraftOasysRiskInformation(UUID.randomUUID())
+      Assertions.assertThat(entity).isNull()
+    }
+  }
+}


### PR DESCRIPTION
Added draft OAsys risk information table. 
This holds the risk information entered by the user on "make a referral" journey for draft referrals.

It is used to hold the information as part of the journey until the user clicks submit referral; at this stage the risk information is posted to ARN. This data is not used as part of sent referral.

If/When we eventually make the draft referral a draft object hosted in redis then this table will not be required. For now, we need the risk information to have the same persistence retrieval time as the rest of the draft object.

