### PR TITLE
add migration to remove duplicate eosr from prod

### DIFF
--- a/src/main/resources/db/migration/V1_87__prod_issue_remove_duplicate_eosr.sql
+++ b/src/main/resources/db/migration/V1_87__prod_issue_remove_duplicate_eosr.sql
@@ -1,0 +1,3 @@
+-- This is to remove a duplicate end of service report in prod.
+delete from end_of_service_report
+where id = '22f417f8-7faf-498a-bd3b-6d0e0cedb71f';


### PR DESCRIPTION
## What does this pull request do?

Removes a duplicate end of service report in prod.
There are two rows for the referral: `0900496a-d6f1-4c78-9c15-8f0eeacfb53f`

eosr ids: `6c678352-e3e0-4358-a06b-ffe738303b51` , `22f417f8-7faf-498a-bd3b-6d0e0cedb71f`

`6c678352-e3e0-4358-a06b-ffe738303b51` has a row in the `end_of_service_report_outcome` table, therefore the change is to remove the other eosr that was created which does not.

## What is the intent behind these changes?

There are currently two end of service reports for a referral in prod. This will cause issues as there should only ever be one. Initially brought to attention upon an error running the sp performance report.
