### PR TITLE
Refactor the custom retrying token response client into it's own component class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RetryingClientCredentialsTokenResponseClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RetryingClientCredentialsTokenResponseClient.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
+
+import mu.KLogging
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.boot.web.client.RestTemplateCustomizer
+import org.springframework.http.converter.FormHttpMessageConverter
+import org.springframework.retry.RetryCallback
+import org.springframework.retry.RetryContext
+import org.springframework.retry.backoff.FixedBackOffPolicy
+import org.springframework.retry.listener.RetryListenerSupport
+import org.springframework.retry.policy.SimpleRetryPolicy
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.security.oauth2.client.endpoint.DefaultClientCredentialsTokenResponseClient
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient
+import org.springframework.security.oauth2.client.endpoint.OAuth2ClientCredentialsGrantRequest
+import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.provider.hmppsauth.token-request")
+data class TokenRequestConfig(
+  val connectTimeoutMs: Long,
+  val readTimeoutMs: Long,
+  val retries: Int,
+  val retryDelayMs: Long,
+)
+
+@Component
+@EnableConfigurationProperties(TokenRequestConfig::class)
+class RetryingClientCredentialsTokenResponseClient(
+  private val config: TokenRequestConfig,
+  private val restTemplateBuilder: RestTemplateBuilder,
+) : OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> {
+  companion object : KLogging()
+
+  override fun getTokenResponse(authorizationGrantRequest: OAuth2ClientCredentialsGrantRequest?): OAuth2AccessTokenResponse =
+    customizedClient.getTokenResponse(authorizationGrantRequest)
+
+  private val errorHandler = OAuth2ErrorResponseErrorHandler()
+
+  private val retryLogger = object : RetryListenerSupport() {
+    override fun <T : Any?, E : Throwable?> onError(context: RetryContext?, callback: RetryCallback<T, E>?, throwable: Throwable?) {
+      logger.info("token request failed; retrying", throwable)
+    }
+  }
+
+  private val retryTemplate = RetryTemplate().apply {
+    setBackOffPolicy(
+      FixedBackOffPolicy().apply {
+        backOffPeriod = config.retryDelayMs
+      }
+    )
+    setRetryPolicy(SimpleRetryPolicy(config.retries))
+    setListeners(arrayOf(retryLogger))
+  }
+
+  private val retryCustomizer = RestTemplateCustomizer { restTemplate ->
+    restTemplate.interceptors.add { request, body, execution ->
+      retryTemplate.execute(
+        RetryCallback {
+          execution.execute(request, body).also { response ->
+            // i hate that this basically duplicates `RestTemplate.handleResponse`,
+            // but it's the only way i could figure out to get this to work.
+            if (errorHandler.hasError(response)) {
+              errorHandler.handleError(response)
+            }
+          }
+        }
+      )
+    }
+  }
+
+  private val customizedClient = DefaultClientCredentialsTokenResponseClient().apply {
+    // see https://docs.spring.io/spring-security/site/docs/current/reference/html5/#customizing-the-access-token-response-3
+    // for information on how to configure the defaults in this RestTemplate.
+    setRestOperations(
+      restTemplateBuilder
+        .setConnectTimeout(Duration.ofMillis(config.connectTimeoutMs))
+        .setReadTimeout(Duration.ofMillis(config.readTimeoutMs))
+        .customizers(retryCustomizer)
+        .messageConverters(
+          FormHttpMessageConverter(),
+          OAuth2AccessTokenResponseHttpMessageConverter(),
+        )
+        .errorHandler(errorHandler)
+        .build()
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -2,48 +2,23 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
 import io.netty.handler.timeout.ReadTimeoutHandler
 import io.netty.handler.timeout.WriteTimeoutHandler
-import mu.KLogging
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
-import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.boot.web.client.RestTemplateBuilder
-import org.springframework.boot.web.client.RestTemplateCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
-import org.springframework.http.converter.FormHttpMessageConverter
-import org.springframework.retry.RetryCallback
-import org.springframework.retry.RetryContext
-import org.springframework.retry.backoff.FixedBackOffPolicy
-import org.springframework.retry.listener.RetryListenerSupport
-import org.springframework.retry.policy.SimpleRetryPolicy
-import org.springframework.retry.support.RetryTemplate
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
-import org.springframework.security.oauth2.client.endpoint.DefaultClientCredentialsTokenResponseClient
-import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
-import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RetryingClientCredentialsTokenResponseClient
 import java.time.Duration
 
-@ConstructorBinding
-@ConfigurationProperties(prefix = "spring.security.oauth2.client.provider.hmppsauth.token-request")
-data class TokenRequestConfig(
-  val connectTimeoutMs: Long,
-  val readTimeoutMs: Long,
-  val retries: Int,
-  val retryDelayMs: Long,
-)
-
 @Configuration
-@EnableConfigurationProperties(TokenRequestConfig::class)
 class WebClientConfiguration(
   @Value("\${webclient.connect-timeout-seconds}") private val defaultConnectTimeoutSeconds: Long,
   @Value("\${webclient.read-timeout-seconds}") private val defaultReadTimeoutSeconds: Int,
@@ -53,9 +28,8 @@ class WebClientConfiguration(
   @Value("\${community-api.baseurl}") private val communityApiBaseUrl: String,
   @Value("\${hmppsauth.baseurl}") private val hmppsAuthBaseUrl: String,
   @Value("\${assess-risks-and-needs.baseurl}") private val assessRisksAndNeedsBaseUrl: String,
-  private val tokenRequestConfig: TokenRequestConfig,
   private val webClientBuilder: WebClient.Builder,
-  private val restTemplateBuilder: RestTemplateBuilder,
+  private val retryingClientCredentialsTokenResponseClient: RetryingClientCredentialsTokenResponseClient,
 ) {
   private val interventionsClientRegistrationId = "interventions-client"
 
@@ -90,7 +64,7 @@ class WebClientConfiguration(
   ): OAuth2AuthorizedClientManager? {
     val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
       .clientCredentials {
-        it.accessTokenResponseClient(createRetryingTokenResponseClient())
+        it.accessTokenResponseClient(retryingClientCredentialsTokenResponseClient)
       }
       .build()
 
@@ -101,49 +75,6 @@ class WebClientConfiguration(
     authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
 
     return authorizedClientManager
-  }
-
-  private fun createRetryingTokenResponseClient(): DefaultClientCredentialsTokenResponseClient {
-    val clientCredentialsTokenResponseClient = DefaultClientCredentialsTokenResponseClient()
-    val errorHandler = OAuth2ErrorResponseErrorHandler()
-
-    val retryCustomizer = RestTemplateCustomizer { restTemplate ->
-      restTemplate.interceptors.add { request, body, execution ->
-
-        val retryTemplate = RetryTemplate()
-        val fixedBackOffPolicy = FixedBackOffPolicy()
-        fixedBackOffPolicy.backOffPeriod = tokenRequestConfig.retryDelayMs
-        retryTemplate.setBackOffPolicy(fixedBackOffPolicy)
-        retryTemplate.setRetryPolicy(SimpleRetryPolicy(tokenRequestConfig.retries))
-        retryTemplate.setListeners(arrayOf(RetryLogger("token request failed; retrying")))
-
-        retryTemplate.execute(
-          RetryCallback {
-            execution.execute(request, body).also {
-              // i hate that this basically duplicates `RestTemplate.handleResponse`,
-              // but it's the only way i could figure out to get this to work.
-              if (errorHandler.hasError(it)) {
-                errorHandler.handleError(it)
-              }
-            }
-          }
-        )
-      }
-    }
-
-    val restTemplate = restTemplateBuilder
-      .setConnectTimeout(Duration.ofMillis(tokenRequestConfig.connectTimeoutMs))
-      .setReadTimeout(Duration.ofMillis(tokenRequestConfig.readTimeoutMs))
-      .customizers(retryCustomizer)
-      .messageConverters(
-        FormHttpMessageConverter(),
-        OAuth2AccessTokenResponseHttpMessageConverter(),
-      )
-      .errorHandler(errorHandler)
-      .build()
-
-    clientCredentialsTokenResponseClient.setRestOperations(restTemplate)
-    return clientCredentialsTokenResponseClient
   }
 
   private fun createAuthorizedWebClient(
@@ -167,13 +98,5 @@ class WebClientConfiguration(
       .baseUrl(baseUrl)
       .apply(oauth2Client.oauth2Configuration())
       .build()
-  }
-}
-
-class RetryLogger(private val msg: String) : RetryListenerSupport() {
-  companion object : KLogging()
-
-  override fun <T : Any?, E : Throwable?> onError(context: RetryContext?, callback: RetryCallback<T, E>?, throwable: Throwable?) {
-    logger.info(msg, throwable)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RetryingClientCredentialsTokenResponseClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RetryingClientCredentialsTokenResponseClientTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
+
+import ch.qos.logback.classic.Level
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.security.oauth2.client.endpoint.OAuth2ClientCredentialsGrantRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingSpyTest
+import java.util.concurrent.TimeUnit
+
+class RetryingClientCredentialsTokenResponseClientTest : LoggingSpyTest(RetryingClientCredentialsTokenResponseClient::class, Level.INFO) {
+  private val mockWebServer = MockWebServer()
+  private val grantRequest = OAuth2ClientCredentialsGrantRequest(
+    ClientRegistration.withRegistrationId("test-registration")
+      .clientId("test-client")
+      .tokenUri(mockWebServer.url("/oauth/token").toString())
+      .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+      .build()
+  )
+
+  @Test
+  fun `client retries the correct number of times on different types of timeout`() {
+    // error responses
+    mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+    // read timeouts
+    mockWebServer.enqueue(MockResponse().setHeadersDelay(100, TimeUnit.MILLISECONDS))
+
+    // success
+    mockWebServer.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/json")
+        .setBody(
+          """
+        {
+          "token_type": "Bearer",
+          "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        }
+       """
+        )
+    )
+
+    val tokenConfig = TokenRequestConfig(
+      connectTimeoutMs = 50,
+      readTimeoutMs = 50,
+      retries = 3,
+      retryDelayMs = 0,
+    )
+
+    val client = RetryingClientCredentialsTokenResponseClient(
+      tokenConfig,
+      RestTemplateBuilder(),
+    )
+
+    client.getTokenResponse(grantRequest)
+
+    assertThat(logEvents.size).isEqualTo(2)
+
+    assertThat(logEvents[0].message).isEqualTo("token request failed; retrying")
+    assertThat(logEvents[0].throwableProxy.message).contains("500 Server Error")
+
+    assertThat(logEvents[1].message).isEqualTo("token request failed; retrying")
+    assertThat(logEvents[1].throwableProxy.message).contains("Read timed out")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceRetryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceRetryTest.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
-import ch.qos.logback.classic.Level.DEBUG
-import ch.qos.logback.classic.Logger
-import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.Level
 import io.netty.channel.ConnectTimeoutException
 import io.netty.handler.timeout.ReadTimeoutException
 import io.netty.handler.timeout.ReadTimeoutHandler
@@ -13,13 +11,9 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import okhttp3.mockwebserver.SocketPolicy.NO_RESPONSE
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
@@ -31,12 +25,12 @@ import reactor.util.context.ContextView
 import reactor.util.retry.Retry.RetrySignal
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingMemoryAppender
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingSpyTest
 import java.net.URI
 import java.time.Duration
 import java.util.concurrent.TimeUnit.SECONDS
 
-class HMPPSAuthServiceRetryTest {
+class HMPPSAuthServiceRetryTest : LoggingSpyTest(HMPPSAuthService::class, Level.DEBUG) {
 
   private val userDetailBody = """
         { "email": "tom@tom.tom", "verified": true, "firstName": "tom", "lastName": "tom" }
@@ -66,26 +60,6 @@ class HMPPSAuthServiceRetryTest {
     .build()
   private lateinit var hmppsAuthService: HMPPSAuthService
 
-  companion object {
-    private val logger = LoggerFactory.getLogger(HMPPSAuthService::class.java) as Logger
-    private var memoryAppender = LoggingMemoryAppender()
-
-    @BeforeAll
-    @JvmStatic
-    fun setupAll() {
-      memoryAppender.context = LoggerFactory.getILoggerFactory() as LoggerContext
-      logger.level = DEBUG
-      logger.addAppender(memoryAppender)
-      memoryAppender.start()
-    }
-
-    @AfterAll
-    @JvmStatic
-    fun teardownAll() {
-      logger.detachAppender(memoryAppender)
-    }
-  }
-
   @BeforeEach
   fun setUp() {
     hmppsAuthService = HMPPSAuthService(
@@ -96,11 +70,6 @@ class HMPPSAuthServiceRetryTest {
       2L,
       RestClient(webClient, "client-registration-id")
     )
-  }
-
-  @AfterEach
-  fun teardown() {
-    memoryAppender.reset()
   }
 
   @Test
@@ -224,12 +193,12 @@ class HMPPSAuthServiceRetryTest {
 
     hmppsAuthService.logRetrySignal(retrySignal)
 
-    assertThat(memoryAppender.logEvents.size).isEqualTo(1)
-    assertThat(memoryAppender.logEvents[0].level.levelStr).isEqualTo("DEBUG")
-    assertThat(memoryAppender.logEvents[0].message).isEqualTo("Retrying due to [io.netty.handler.timeout.ReadTimeoutException]")
-    assertThat(memoryAppender.logEvents[0].argumentArray[0].toString()).isEqualTo("io.netty.handler.timeout.ReadTimeoutException")
-    assertThat(memoryAppender.logEvents[0].argumentArray[1].toString()).isEqualTo("res.causeMessage=io.netty.handler.timeout.ReadTimeoutException")
-    assertThat(memoryAppender.logEvents[0].argumentArray[2].toString()).isEqualTo("totalRetries=1")
+    assertThat(logEvents.size).isEqualTo(1)
+    assertThat(logEvents[0].level.levelStr).isEqualTo("DEBUG")
+    assertThat(logEvents[0].message).isEqualTo("Retrying due to [io.netty.handler.timeout.ReadTimeoutException]")
+    assertThat(logEvents[0].argumentArray[0].toString()).isEqualTo("io.netty.handler.timeout.ReadTimeoutException")
+    assertThat(logEvents[0].argumentArray[1].toString()).isEqualTo("res.causeMessage=io.netty.handler.timeout.ReadTimeoutException")
+    assertThat(logEvents[0].argumentArray[2].toString()).isEqualTo("totalRetries=1")
   }
 
   @Test
@@ -238,12 +207,12 @@ class HMPPSAuthServiceRetryTest {
 
     hmppsAuthService.logRetrySignal(retrySignal)
 
-    assertThat(memoryAppender.logEvents.size).isEqualTo(1)
-    assertThat(memoryAppender.logEvents[0].level.levelStr).isEqualTo("DEBUG")
-    assertThat(memoryAppender.logEvents[0].message).isEqualTo("Retrying due to [io.netty.handler.timeout.ReadTimeoutException]")
-    assertThat(memoryAppender.logEvents[0].argumentArray[0].toString()).isEqualTo("io.netty.handler.timeout.ReadTimeoutException")
-    assertThat(memoryAppender.logEvents[0].argumentArray[1].toString()).isEqualTo("res.causeMessage=io.netty.handler.timeout.ReadTimeoutException")
-    assertThat(memoryAppender.logEvents[0].argumentArray[2].toString()).isEqualTo("totalRetries=1")
+    assertThat(logEvents.size).isEqualTo(1)
+    assertThat(logEvents[0].level.levelStr).isEqualTo("DEBUG")
+    assertThat(logEvents[0].message).isEqualTo("Retrying due to [io.netty.handler.timeout.ReadTimeoutException]")
+    assertThat(logEvents[0].argumentArray[0].toString()).isEqualTo("io.netty.handler.timeout.ReadTimeoutException")
+    assertThat(logEvents[0].argumentArray[1].toString()).isEqualTo("res.causeMessage=io.netty.handler.timeout.ReadTimeoutException")
+    assertThat(logEvents[0].argumentArray[2].toString()).isEqualTo("totalRetries=1")
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/LoggingSpyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/LoggingSpyTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.LoggerContext
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.slf4j.LoggerFactory
+import kotlin.reflect.KClass
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class LoggingSpyTest(
+  loggerClass: KClass<out Any>,
+  private val level: Level,
+) {
+  private val logger = LoggerFactory.getLogger(loggerClass.java) as Logger
+  private val memoryAppender = LoggingMemoryAppender()
+  protected val logEvents get() = memoryAppender.logEvents
+
+  @BeforeAll
+  fun setupLoggerSpy() {
+    memoryAppender.context = LoggerFactory.getILoggerFactory() as LoggerContext
+    logger.level = level
+    logger.addAppender(memoryAppender)
+    memoryAppender.start()
+  }
+
+  @AfterAll
+  fun teardownLoggerSpy() {
+    logger.detachAppender(memoryAppender)
+  }
+
+  @AfterEach
+  fun resetLoggerSpy() {
+    memoryAppender.reset()
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Refactor the custom retrying token response client into it's own component class

## What is the intent behind these changes?

encapsulate all the logic for the retying client in it's own class, which will make it easier for others to reuse.
