### PR TITLE
add unique constraint to referral id in end of service report table

### DIFF
--- a/src/main/resources/db/migration/V1_88__eosr_unique_constraint.sql
+++ b/src/main/resources/db/migration/V1_88__eosr_unique_constraint.sql
@@ -1,0 +1,2 @@
+alter table end_of_service_report
+    add unique (referral_id);


### PR DESCRIPTION
## What does this pull request do?

Adds a unique constraint to the referral id on the `end_of_service_report` table.

## What is the intent behind these changes?

To prevent multiple eosr's being created against a single referral.
