### PR TITLE
Trello-129 Added missing SNS Events for referral end (canx, end, completion) and end of service report submit

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSEndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSEndOfServiceReportServiceTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import java.time.OffsetDateTime
+import java.util.UUID
+
+internal class SNSEndOfServiceReportServiceTest {
+  private val publisher = mock<SNSPublisher>()
+  private val snsEndOfServiceReportService = SNSEndOfServiceReportService(publisher)
+
+  private val endOfServiceReportFactory = EndOfServiceReportFactory()
+  private val authUserFactory = AuthUserFactory()
+  private val referral = ReferralFactory().createSent(id = UUID.fromString("56b40f96-0657-4e01-925c-da208a6fbcfd"))
+  private val now = OffsetDateTime.now()
+  private val user = authUserFactory.create()
+
+  private val endOfServiceReportEvent = EndOfServiceReportEvent(
+    "source",
+    EndOfServiceReportEventType.SUBMITTED,
+    endOfServiceReportFactory.create(
+      referral = referral,
+      submittedAt = now,
+      submittedBy = user,
+    ),
+    "http://localhost/sent-referral/123/supplier-assessment"
+  )
+
+  @Test
+  fun `publishes message on end of service report submit`() {
+    snsEndOfServiceReportService.onApplicationEvent(endOfServiceReportEvent)
+
+    val referralId = UUID.fromString("56b40f96-0657-4e01-925c-da208a6fbcfd")
+    val eventDTO = EventDTO(
+      eventType = "intervention.end-of-service-report.submitted",
+      description = "An end of service report has been submitted",
+      detailUrl = "http://localhost/sent-referral/123/supplier-assessment",
+      occurredAt = now,
+      additionalInformation = mapOf(
+        "endOfServiceReportId" to endOfServiceReportEvent.endOfServiceReport.id,
+        "submittedBy" to endOfServiceReportEvent.endOfServiceReport.submittedBy!!.userName,
+      ),
+    )
+
+    verify(publisher).publish(referralId, user, eventDTO)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSReferralServiceTest.kt
@@ -7,6 +7,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPubli
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.CANCELLED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.COMPLETED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.PREMATURELY_ENDED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
@@ -48,6 +51,25 @@ internal class SNSReferralServiceTest {
     "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
   )
 
+  private fun referralConcludedEvent(eventType: ReferralEventType) = ReferralEvent(
+    "source",
+    eventType,
+    referralFactory.createEnded(
+      id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
+      referenceNumber = "HAS71263",
+      concludedAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+      endRequestedBy = AuthUser("ecd7b8d690", "irrelevant", "irrelevant"),
+      assignments = listOf(
+        ReferralAssignment(
+          OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+          authUserFactory.createSP("irrelevant"),
+          authUserFactory.createSP("abc123")
+        )
+      )
+    ),
+    "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"
+  )
+
   @Test
   fun `referral sent event publishes message`() {
     snsReferralService().onApplicationEvent(referralSentEvent)
@@ -76,6 +98,48 @@ internal class SNSReferralServiceTest {
       referralAssignedEvent.referral.currentAssignment!!.assignedBy,
       snsEvent
     )
+  }
+
+  @Test
+  fun `publishes referral cancelled event message`() {
+    val referralConcludedEvent = referralConcludedEvent(CANCELLED)
+    snsReferralService().onApplicationEvent(referralConcludedEvent)
+    val snsEvent = EventDTO(
+      "intervention.referral.cancelled",
+      "A referral has been cancelled",
+      "http://localhost:8080" + "/sent-referral/${referralConcludedEvent.referral.id}",
+      referralConcludedEvent.referral.concludedAt!!,
+      mapOf("referralId" to UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"))
+    )
+    verify(snsPublisher).publish(referralConcludedEvent.referral.id, referralConcludedEvent.referral.endRequestedBy!!, snsEvent)
+  }
+
+  @Test
+  fun `publishes referral prematurely ended event message`() {
+    val referralConcludedEvent = referralConcludedEvent(PREMATURELY_ENDED)
+    snsReferralService().onApplicationEvent(referralConcludedEvent)
+    val snsEvent = EventDTO(
+      "intervention.referral.prematurely-ended",
+      "A referral has been ended prematurely",
+      "http://localhost:8080" + "/sent-referral/${referralConcludedEvent.referral.id}",
+      referralConcludedEvent.referral.concludedAt!!,
+      mapOf("referralId" to UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"))
+    )
+    verify(snsPublisher).publish(referralConcludedEvent.referral.id, referralConcludedEvent.referral.endRequestedBy!!, snsEvent)
+  }
+
+  @Test
+  fun `publishes referral completed event message`() {
+    val referralConcludedEvent = referralConcludedEvent(COMPLETED)
+    snsReferralService().onApplicationEvent(referralConcludedEvent)
+    val snsEvent = EventDTO(
+      "intervention.referral.completed",
+      "A referral has been completed",
+      "http://localhost:8080" + "/sent-referral/${referralConcludedEvent.referral.id}",
+      referralConcludedEvent.referral.concludedAt!!,
+      mapOf("referralId" to UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"))
+    )
+    verify(snsPublisher).publish(referralConcludedEvent.referral.id, referralConcludedEvent.referral.currentAssignee!!, snsEvent)
   }
 
   private fun snsReferralService(): SNSReferralService {


### PR DESCRIPTION
https://trello.com/c/JFRLDjoJ/129-missing-sns-events-for-referral-end-canx-end-completion-and-end-of-service-report-submit

## What does this pull request do?
Added missing SNS Events for referral end (canx, end, completion) and end of service report submit

## What is the intent behind these changes?
These are omissions from day one and are necessary for the interventions-event-listener to consume and notify nDelius
