### PR TITLE
Add auth user validity flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AuthUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AuthUser.kt
@@ -9,6 +9,7 @@ data class AuthUser(
   @Id @NotNull val id: String,
   @NotNull val authSource: String,
   @NotNull val userName: String,
+  var deleted: Boolean? = null,
 ) {
   override fun hashCode(): Int {
     return id.hashCode()

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -2,6 +2,7 @@ COMMENT ON TABLE auth_user IS 'details about the user from hmpps-auth';
 COMMENT ON COLUMN auth_user.id IS 'the user ID';
 COMMENT ON COLUMN auth_user.auth_source IS 'where the user has come from';
 COMMENT ON COLUMN auth_user.user_name IS 'the username';
+COMMENT ON COLUMN auth_user.deleted IS 'soft deleted flag';
 
 COMMENT ON TABLE service_category IS '**reference data** intervention service categories, which relate to service user needs';
 COMMENT ON COLUMN service_category.id IS 'service-owned unique identifier';

--- a/src/main/resources/db/migration/V1_89__auth_user_validity_flag.sql
+++ b/src/main/resources/db/migration/V1_89__auth_user_validity_flag.sql
@@ -1,0 +1,3 @@
+alter table auth_user add column deleted boolean;
+
+INSERT INTO metadata (table_name, column_name, sensitive) values ('auth_user', 'deleted', FALSE);


### PR DESCRIPTION
Alter `auth_user` table to include new column `valid_hmpps_user` which acts as a boolean flag.

The flag communicates whether the user is a HMPPS auth user and also if the id is a valid HMPPS auth user id.

The flag defaults to null which means "We don't know yet" or "Not applicable because they're not a HMPPS auth user".

This flag was created because there was a bug with HMPPS auth where the existing auth user ids for all users were being returned as a different value. This had the consequence of having duplicate auth users in the table for the same email address. We therefore need this flag to state which of the duplicate records are valid users or not.

We will be setting this flag to true or false (where applicable) in a future script.
