### PR TITLE
add basic job configuration for soft deleting invalid auth user ids

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
+import org.springframework.batch.core.configuration.JobRegistry
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing
+import org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
@@ -9,9 +12,11 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
 @Configuration
+@EnableBatchProcessing
 class BatchConfiguration(
   @Value("\${spring.batch.concurrency.pool-size}") private val poolSize: Int,
   @Value("\${spring.batch.concurrency.queue-size}") private val queueSize: Int,
+  private val jobRegistry: JobRegistry,
 ) {
   @Bean
   fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
@@ -25,5 +30,12 @@ class BatchConfiguration(
     launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher
+  }
+
+  @Bean
+  fun jobRegistryBeanPostProcessor(): JobRegistryBeanPostProcessor? {
+    val postProcessor = JobRegistryBeanPostProcessor()
+    postProcessor.setJobRegistry(jobRegistry)
+    return postProcessor
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/JobsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/JobsController.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.springframework.batch.core.ExitStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.JobLauncherService
+
+data class JobConfiguration(
+  val jobName: String,
+)
+
+@RestController
+class JobsController(
+  private val jobLauncherService: JobLauncherService,
+) {
+  @PostMapping("/jobs/one-off")
+  @PreAuthorize("hasRole('ROLE_INTERVENTIONS_BATCH_USER')")
+  fun runOneOffJob(
+    @RequestBody jobConfiguration: JobConfiguration,
+  ): ResponseEntity<Any> {
+    val execution = jobLauncherService.launchJobByName(jobConfiguration.jobName)
+    return when (execution.exitStatus) {
+      ExitStatus.COMPLETED -> {
+        ResponseEntity.ok().build()
+      }
+      else -> {
+        ResponseEntity.internalServerError().body(execution.exitStatus)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/SoftDeleteInvalidUsers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/SoftDeleteInvalidUsers.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff
+
+import mu.KLogging
+import net.logstash.logback.argument.StructuredArguments
+import org.hibernate.SessionFactory
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
+
+@Configuration
+class SoftDeleteInvalidUsers(
+  private val sessionFactory: SessionFactory,
+  private val jobBuilderFactory: JobBuilderFactory,
+  private val stepBuilderFactory: StepBuilderFactory,
+  private val hmppsAuthService: HMPPSAuthService,
+) {
+  companion object : KLogging() {
+    private const val chunkSize = 100
+  }
+
+  private val reader = HibernateCursorItemReaderBuilder<AuthUser>()
+    .name("softDeleteInvalidUsersReader")
+    .sessionFactory(sessionFactory)
+    .queryString("select u from AuthUser u")
+    .build()
+
+  private val step = stepBuilderFactory.get("softDeleteInvalidUsersStep")
+    .chunk<AuthUser, Unit>(chunkSize)
+    .reader(reader)
+    .processor(
+      ItemProcessor { user ->
+        if (user.deleted == null) {
+          val idIsInvalid = user.authSource == "auth" && !hmppsAuthService.checkAuthUserExists(user.id)
+
+          if (idIsInvalid) {
+            logger.info("soft deleting invalid auth user record", StructuredArguments.kv("user_id", user.id))
+          }
+
+          user.deleted = idIsInvalid
+        }
+      }
+    )
+    .writer { }
+    .build()
+
+  @Bean
+  fun softDeleteInvalidUsersJob(): Job {
+    return jobBuilderFactory["softDeleteInvalidUsersJob"]
+      .start(step)
+      .build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/JobLauncherService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/JobLauncherService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.springframework.batch.core.JobExecution
+import org.springframework.batch.core.JobParameters
+import org.springframework.batch.core.configuration.JobRegistry
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.stereotype.Service
+
+@Service
+class JobLauncherService(
+  private val jobLauncher: JobLauncher,
+  private val jobRegistry: JobRegistry,
+) {
+  fun launchJobByName(jobName: String, jobParameters: JobParameters? = JobParameters()): JobExecution =
+    jobLauncher.run(jobRegistry.getJob(jobName), jobParameters)
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,6 +165,7 @@ hmppsauth:
     locations:
       auth-user-groups: "/api/authuser/{username}/groups"
       auth-user-detail: "/api/authuser/{username}"
+      auth-user-detail-by-id: "/api/authuser/id/{userId}"
       user-email: "/api/user/{username}/email"
       user-detail: "/api/user/{username}"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceRetryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthServiceRetryTest.kt
@@ -91,6 +91,7 @@ class HMPPSAuthServiceRetryTest {
     hmppsAuthService = HMPPSAuthService(
       "/authuser/groups",
       "/authuser/detail",
+      "/authuser/detail/id",
       "/user/email",
       "/user/detail",
       2L,


### PR DESCRIPTION
## What does this pull request do?

adds a one-off job configuration which soft-deletes invalid auth user records from the internal database

## What is the intent behind these changes?

tidy up the database after a recent mix up in hmpps auth which caused us to create invalid duplicate user records.
