### PR TITLE
Username used in equals method to determine if two AuthUser entities represent the same hmpps-auth user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AuthUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AuthUser.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
+import java.util.Objects
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.validation.constraints.NotNull
@@ -11,15 +12,16 @@ data class AuthUser(
   @NotNull val userName: String,
   var deleted: Boolean? = null,
 ) {
-  override fun hashCode(): Int {
-    return id.hashCode()
-  }
+  // Normally a user with a hmpps-auth Id represents a unique user. However, hmpps-auth has returned the same
+  // user with two different ids. To deal with this temporary issue, username is now being used for equality
+  // checking, e.g. don't email user if they are both the sender and assignee of a referral, as determined by user name.
+  override fun hashCode() = Objects.hash(userName, authSource)
 
   override fun equals(other: Any?): Boolean {
     if (other == null || other !is AuthUser) {
       return false
     }
 
-    return id == other.id
+    return userName == other.userName && authSource == other.authSource
   }
 }


### PR DESCRIPTION
Context: https://mojdt.slack.com/archives/CR5ESQ8T1/p1634807215003000

## What does this pull request do?
As a workaround for the functionality in R&M, the determination of whether two Hmpps-Auth user entities represent the same actual user is now based on username and not hmpps-auth Id. 

## What is the intent behind these changes?
This purpose of this change is to ensure R&M continues to function correctly given the consequences of the issue in hmpps-auth