### PR TITLE
Increase maximum JVM memory

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -12,6 +12,9 @@ env:
     value: "{{ $value }}"
   {{ end }}
 
+  - name: JAVA_OPTS
+    value: "-Xmx750m"
+
   - name: APPLICATIONINSIGHTS_CONNECTION_STRING
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,7 +18,6 @@ env_details:
   contains_live_data: false
 
 env:
-  JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,7 +18,6 @@ env_details:
   contains_live_data: true
 
 env:
-  JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,7 +16,6 @@ env_details:
   production_env: true
 
 env:
-  JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://refer-monitor-intervention.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.probation.service.justice.gov.uk"

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -16,7 +16,6 @@ env_details:
 
 env:
   SPRING_PROFILES_ACTIVE: research
-  JAVA_OPTS: "-Xmx512m"
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-research.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"


### PR DESCRIPTION

## What does this pull request do?

Increase JVM maximum heap memory size

## What is the intent behind these changes?

We are seeing some OutOfMemoryErrors in production on the `api-suspect`
pods, which handle `/sent-referrals/summary/service-provider`

The hard limit for our pods in our namespace is [1000MiB](https://github.com/ministryofjustice/cloud-platform-environments/blob/88ee810e1f48efa2af9eb7c78a0d7a1f3d37c619/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/02-limitrange.yaml#L10); the current
maximum JVM heap size is 512m

To make use of the already allocated memory without drawbacks, we can
increase the maximum heap size by about ~250m

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/1526295/140910044-e2b9dc4c-8ece-4861-b714-fda23a1bdfe3.png">
This is a graph of memory and CPU use -- when we run out of memory, the memory use still isn't anywhere near the hard limit (top red line)