### PR TITLE
Make 1.88 migration concurrency-safe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
       - checkout
       - gradle/with_cache:
           cache_checksum_file: "build.gradle.kts"
+          cache_key: v2
           steps:
             - run: ./gradlew check
       - store_test_results:
@@ -133,6 +134,7 @@ jobs:
       - checkout
       - gradle/with_cache:
           cache_checksum_file: "build.gradle.kts"
+          cache_key: v2
           steps:
             - run:
                 command: |
@@ -192,6 +194,7 @@ jobs:
       - checkout
       - gradle/with_cache:
           cache_checksum_file: "build.gradle.kts"
+          cache_key: v2
           steps:
             - run: ./gradlew assemble
       - persist_to_workspace:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 repositories {
-  jcenter()
   mavenCentral()
 }
 

--- a/src/main/resources/db/migration/V1_88__eosr_unique_constraint.sql
+++ b/src/main/resources/db/migration/V1_88__eosr_unique_constraint.sql
@@ -1,2 +1,2 @@
-alter table end_of_service_report
-    add unique (referral_id);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_unique_eosr_referral
+    ON end_of_service_report (referral_id);


### PR DESCRIPTION
## What does this pull request do?

Make 1.88 migration concurrency-safe

Following advice in https://medium.com/paypal-tech/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680#62d6

🙋 `ci/circleci: validate_db` failing is expected and ✅ OK and can be overriden; it rightly warns on a mutated migration
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/1526295/140930327-5a781584-4927-4a7c-8223-e88d9893ff55.png">

## JCenter

Also gets rid of the jcenter repository as their certificate expired and blocks the build -- we don't need them anyway
```
   > Could not resolve org.jetbrains.kotlin:kotlin-reflect:1.4.31.
     Required by:
         project :
      > Could not resolve org.jetbrains.kotlin:kotlin-reflect:1.4.31.
         > Could not get resource 'https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.4.31/kotlin-reflect-1.4.31.pom'.
            > Could not GET 'https://jcenter.bintray.com/org/jetbrains/kotlin/kotlin-reflect/1.4.31/kotlin-reflect-1.4.31.pom'.
               > PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
```

## What is the intent behind these changes?

Previously, when we applied this migration on production it locked down
everything due to the ACCESS EXCLUSIVE lock it created (which prohibits
reading)

As 1.88 and 1.89 both applied to environments before `production` we
rolled them back to 1.87 before applying this PR.

The query used to rollback (as flyway undo is paid):
```
ALTER TABLE end_of_service_report DROP CONSTRAINT IF EXISTS end_of_service_report_referral_id_key;
ALTER TABLE auth_user DROP COLUMN IF EXISTS deleted;
DELETE FROM metadata where table_name = 'auth_user' and column_name = 'deleted';
DELETE FROM flyway_schema_history WHERE version IN ('1.88', '1.89');
```

