### PR TITLE
Dump heap on OutOfMemory to a volume

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -13,7 +13,7 @@ env:
   {{ end }}
 
   - name: JAVA_OPTS
-    value: "-Xmx750m"
+    value: "-Xmx750m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps"
 
   - name: APPLICATIONINSIGHTS_CONNECTION_STRING
     valueFrom:
@@ -104,5 +104,4 @@ env:
       secretKeyRef:
         name: storage-s3-bucket
         key: bucket_name
-
 {{- end -}}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
@@ -39,6 +39,9 @@ spec:
           ports:
             - containerPort: {{ .Values.image.ports.app }}
               protocol: TCP
+          volumeMounts:
+          - name: heap-dumps
+            mountPath: /dumps
           livenessProbe:
             httpGet:
               path: /health/liveness
@@ -53,4 +56,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{ include "deployment.envs" . | nindent 10 }}
+  {{- include "deployment.envs" . | nindent 10 }}
+      volumes:
+        - name: heap-dumps
+          emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           ports:
             - containerPort: {{ .Values.image.ports.app }}
               protocol: TCP
+          volumeMounts:
+          - name: heap-dumps
+            mountPath: /dumps
           livenessProbe:
             httpGet:
               path: /health/liveness
@@ -53,4 +56,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{ include "deployment.envs" . | nindent 10 }}
+  {{- include "deployment.envs" . | nindent 10 }}
+      volumes:
+        - name: heap-dumps
+          emptyDir: {}


### PR DESCRIPTION

## What does this pull request do?

Dump heap on OutOfMemory to a volume so we can analyse it later

## What is the intent behind these changes?

Objective: get a heap dump when we run out of memory, so we can analyse the heap

This heap dump would need to persist between container restarts; to achieve this, we put it in a volume

We can then `kubectl cp` the files afterwards