### PR TITLE
enable writing to csv for reporting job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
@@ -7,6 +7,9 @@ import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.file.FlatFileHeaderCallback
 import org.springframework.batch.item.file.FlatFileItemWriter
 import org.springframework.batch.item.file.builder.FlatFileItemWriterBuilder
+import org.springframework.batch.item.file.transform.BeanWrapperFieldExtractor
+import org.springframework.batch.item.file.transform.DelimitedLineAggregator
+import org.springframework.batch.item.file.transform.RecursiveCollectionLineAggregator
 import org.springframework.core.io.Resource
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
@@ -31,34 +34,58 @@ class BatchUtils {
     return date.toInstant().atOffset(zoneOffset)
   }
 
+  private fun <T> csvFileWriterBase(
+    name: String,
+    resource: Resource,
+    headers: List<String>,
+  ): FlatFileItemWriterBuilder<T> {
+    return FlatFileItemWriterBuilder<T>()
+      .name(name)
+      .resource(resource)
+      .headerCallback(HeaderWriter(headers.joinToString(",")))
+  }
+
+  private fun <T> csvLineAggregator(fields: List<String>): DelimitedLineAggregator<T> {
+    return DelimitedLineAggregator<T>().apply {
+      setDelimiter(",")
+      setFieldExtractor(
+        BeanWrapperFieldExtractor<T>().apply {
+          setNames(fields.toTypedArray())
+          afterPropertiesSet()
+        }
+      )
+    }
+  }
+
   fun <T> csvFileWriter(
     name: String,
     resource: Resource,
     headers: List<String>,
     fields: List<String>,
   ): FlatFileItemWriter<T> {
-    return FlatFileItemWriterBuilder<T>()
-      .name(name)
-      .resource(resource)
-      .headerCallback(HeaderWriter(headers.joinToString(",")))
-      .delimited()
-      .delimiter(",")
-      .names(*fields.toTypedArray())
+    return csvFileWriterBase<T>(name, resource, headers)
+      .lineAggregator(csvLineAggregator(fields))
       .build()
+  }
+
+  fun <T> recursiveCollectionCsvFileWriter(
+    name: String,
+    resource: Resource,
+    headers: List<String>,
+    fields: List<String>,
+  ): FlatFileItemWriter<Collection<T>> {
+    return csvFileWriterBase<Collection<T>>(name, resource, headers)
+      .lineAggregator(
+        RecursiveCollectionLineAggregator<T>().apply {
+          setDelegate(csvLineAggregator(fields))
+        }
+      ).build()
   }
 }
 
 class HeaderWriter(private val header: String) : FlatFileHeaderCallback {
   override fun writeHeader(writer: Writer) {
     writer.write(header)
-  }
-}
-
-class LoggingWriter<T> : ItemWriter<T> {
-  companion object : KLogging()
-
-  override fun write(items: MutableList<out T>) {
-    logger.info(items.toString())
   }
 }
 
@@ -71,5 +98,13 @@ interface SentReferralProcessor<T> : ItemProcessor<Referral, T> {
     logger.debug("processing referral {}", StructuredArguments.kv("referralId", referral.id))
     if (referral.sentAt == null) throw RuntimeException("invalid referral passed to sent referral processor; referral has not been sent")
     return processSentReferral(referral)
+  }
+}
+
+class LoggingWriter<T> : ItemWriter<T> {
+  companion object : KLogging()
+
+  override fun write(items: MutableList<out T>) {
+    logger.info(items.toString())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -3,19 +3,28 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.p
 import org.hibernate.SessionFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
+import org.springframework.batch.core.StepContribution
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
 import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.core.job.DefaultJobParametersValidator
+import org.springframework.batch.core.scope.context.ChunkContext
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
+import org.springframework.batch.item.file.FlatFileItemWriter
+import org.springframework.batch.repeat.RepeatStatus
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.FileSystemResource
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.BatchUtils
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.LoggingWriter
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
+import java.io.File
+import kotlin.io.path.createTempDirectory
 
 @Configuration
 @EnableBatchProcessing
@@ -23,9 +32,16 @@ class NdmisPerformanceReportJobConfiguration(
   private val jobBuilderFactory: JobBuilderFactory,
   private val stepBuilderFactory: StepBuilderFactory,
   private val batchUtils: BatchUtils,
+  private val s3Service: S3Service,
+  private val ndmisS3Bucket: S3Bucket,
   @Value("\${spring.batch.jobs.ndmis.performance-report.page-size}") private val pageSize: Int,
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
+  private val tmpDir = createTempDirectory()
+  private val referralReportPath = tmpDir.resolve("crs_performance_report-v2-referrals.csv")
+  private val complexityReportPath = tmpDir.resolve("crs_performance_report-v2-complexity.csv")
+  private val appointmentsReportPath = tmpDir.resolve("crs_performance_report-v2-appointments.csv")
+
   @Bean
   @JobScope
   fun ndmisReader(
@@ -37,6 +53,39 @@ class NdmisPerformanceReportJobConfiguration(
       .sessionFactory(sessionFactory)
       .queryString("select r from Referral r where sent_at is not null")
       .build()
+  }
+
+  @Bean
+  @StepScope
+  fun ndmisReferralsWriter(): FlatFileItemWriter<ReferralsData> {
+    return batchUtils.csvFileWriter(
+      "ndmisReferralsPerformanceReportWriter",
+      FileSystemResource(referralReportPath),
+      ReferralsData.headers,
+      ReferralsData.fields
+    )
+  }
+
+  @Bean
+  @StepScope
+  fun ndmisComplexityWriter(): FlatFileItemWriter<Collection<ComplexityData>> {
+    return batchUtils.recursiveCollectionCsvFileWriter(
+      "ndmisComplexityPerformanceReportWriter",
+      FileSystemResource(complexityReportPath),
+      ComplexityData.headers,
+      ComplexityData.fields
+    )
+  }
+
+  @Bean
+  @StepScope
+  fun ndmisAppointmentWriter(): FlatFileItemWriter<Collection<AppointmentData>> {
+    return batchUtils.recursiveCollectionCsvFileWriter(
+      "ndmisAppointmentPerformanceReportWriter",
+      FileSystemResource(appointmentsReportPath),
+      AppointmentData.headers,
+      AppointmentData.fields
+    )
   }
 
   @Bean
@@ -57,6 +106,7 @@ class NdmisPerformanceReportJobConfiguration(
       .start(ndmisWriteReferralToCsvStep)
       .next(ndmisWriteComplexityToCsvStep)
       .next(ndmisWriteAppointmentToCsvStep)
+      .next(pushToS3Step)
       .build()
   }
 
@@ -64,12 +114,13 @@ class NdmisPerformanceReportJobConfiguration(
   fun ndmisWriteReferralToCsvStep(
     ndmisReader: HibernateCursorItemReader<Referral>,
     processor: ReferralsProcessor,
+    writer: FlatFileItemWriter<ReferralsData>,
   ): Step {
     return stepBuilderFactory.get("ndmisWriteReferralToCsvStep")
       .chunk<Referral, ReferralsData>(chunkSize)
       .reader(ndmisReader)
       .processor(processor)
-      .writer(LoggingWriter<ReferralsData>())
+      .writer(writer)
       .build()
   }
 
@@ -77,12 +128,13 @@ class NdmisPerformanceReportJobConfiguration(
   fun ndmisWriteComplexityToCsvStep(
     ndmisReader: HibernateCursorItemReader<Referral>,
     processor: ComplexityProcessor,
+    writer: FlatFileItemWriter<Collection<ComplexityData>>,
   ): Step {
     return stepBuilderFactory.get("ndmisWriteComplexityToCsvStep")
       .chunk<Referral, List<ComplexityData>>(chunkSize)
       .reader(ndmisReader)
       .processor(processor)
-      .writer(LoggingWriter<List<ComplexityData>>())
+      .writer(writer)
       .build()
   }
 
@@ -90,12 +142,23 @@ class NdmisPerformanceReportJobConfiguration(
   fun ndmisWriteAppointmentToCsvStep(
     ndmisReader: HibernateCursorItemReader<Referral>,
     processor: AppointmentProcessor,
+    writer: FlatFileItemWriter<Collection<AppointmentData>>,
   ): Step {
     return stepBuilderFactory.get("ndmisWriteAppointmentToCsvStep")
       .chunk<Referral, List<AppointmentData>>(chunkSize)
       .reader(ndmisReader)
       .processor(processor)
-      .writer(LoggingWriter<List<AppointmentData>>())
+      .writer(writer)
       .build()
   }
+
+  private val pushToS3Step = stepBuilderFactory["pushToS3Step"]
+    .tasklet { _: StepContribution, _: ChunkContext ->
+      listOf(referralReportPath, complexityReportPath, appointmentsReportPath).forEach { path ->
+        s3Service.publishFileToS3(ndmisS3Bucket, path, "export/csv/reports/")
+        File(path.toString()).delete()
+      }
+      RepeatStatus.FINISHED
+    }
+    .build()
 }


### PR DESCRIPTION
## What does this pull request do?

Performs the write to csv part of the ndmis performance report. Then publishes the csv to s3.

## What is the intent behind these changes?

To create 3 seperate performance report csv's for referrals, appointments and complexity