### PR TITLE
Add code to enable jobs to be run at application start up

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff
+
+import mu.KLogging
+import net.logstash.logback.argument.StructuredArguments
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.converter.DefaultJobParametersConverter
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.batch.core.launch.support.SimpleJvmExitCodeMapper
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import org.springframework.util.StringUtils
+import kotlin.system.exitProcess
+
+@Component
+class OnStartupJobLauncherFactory(
+  private val jobLauncher: JobLauncher,
+) {
+  companion object : KLogging()
+
+  private val exitCodeMapper = SimpleJvmExitCodeMapper()
+  private val jobParametersConverter = DefaultJobParametersConverter()
+
+  fun makeLauncher(jobName: String, entryPoint: (args: ApplicationArguments) -> Int): ApplicationRunner {
+    return ApplicationRunner { args ->
+      if (args.getOptionValues("jobName")?.contains(jobName) == true) {
+        logger.info("running one off job {}", StructuredArguments.kv("jobName", jobName))
+        exitProcess(entryPoint(args))
+      }
+    }
+  }
+
+  fun makeBatchLauncher(job: Job): ApplicationRunner {
+    val entryPoint = fun(args: ApplicationArguments): Int {
+      val params = jobParametersConverter.getJobParameters(
+        StringUtils.splitArrayElementsIntoProperties(args.nonOptionArgs.toTypedArray(), "=")
+      )
+
+      val execution = jobLauncher.run(job, params)
+      return exitCodeMapper.intValue(execution.exitStatus.exitCode)
+    }
+
+    return makeLauncher(job.name, entryPoint)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -16,10 +16,12 @@ import org.springframework.batch.item.database.builder.HibernateCursorItemReader
 import org.springframework.batch.item.file.FlatFileItemWriter
 import org.springframework.batch.repeat.RepeatStatus
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.FileSystemResource
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.BatchUtils
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
@@ -34,6 +36,7 @@ class NdmisPerformanceReportJobConfiguration(
   private val batchUtils: BatchUtils,
   private val s3Service: S3Service,
   private val ndmisS3Bucket: S3Bucket,
+  private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
   @Value("\${spring.batch.jobs.ndmis.performance-report.page-size}") private val pageSize: Int,
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
@@ -41,6 +44,11 @@ class NdmisPerformanceReportJobConfiguration(
   private val referralReportPath = tmpDir.resolve("crs_performance_report-v2-referrals.csv")
   private val complexityReportPath = tmpDir.resolve("crs_performance_report-v2-complexity.csv")
   private val appointmentsReportPath = tmpDir.resolve("crs_performance_report-v2-appointments.csv")
+
+  @Bean
+  fun ndmisPerformanceReportJobLauncher(ndmisPerformanceReportJob: Job): ApplicationRunner {
+    return onStartupJobLauncherFactory.makeBatchLauncher(ndmisPerformanceReportJob)
+  }
 
   @Bean
   @JobScope


### PR DESCRIPTION
## What does this pull request do?

    Add a factory class which allows jobs to register themselves for execution at application startup.

    the implementation makes use of Spring's 'ApplicationRunner' interface, which allows arbitrary
    code to be run on startup. jobs can use the factory methods to register ApplicationRunner beans
    for either simple functions or spring batch jobs.

    to launch a registered job, run the application with the '--jobName=<name>' commandline argument.

## What is the intent behind these changes?

allow containers to be spun up to run arbitrary one-off jobs
