### PR TITLE
make the ndmis reporting job more easily runnable from the command line

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
@@ -32,11 +32,15 @@ class OnStartupJobLauncherFactory(
 
   fun makeBatchLauncher(job: Job): ApplicationRunner {
     val entryPoint = fun(args: ApplicationArguments): Int {
-      val params = jobParametersConverter.getJobParameters(
+      val rawParams = jobParametersConverter.getJobParameters(
         StringUtils.splitArrayElementsIntoProperties(args.nonOptionArgs.toTypedArray(), "=")
       )
 
-      val execution = jobLauncher.run(job, params)
+      val nextParams = job.jobParametersIncrementer?.let {
+        it.getNext(rawParams)
+      } ?: rawParams
+
+      val execution = jobLauncher.run(job, nextParams)
       return exitCodeMapper.intValue(execution.exitStatus.exitCode)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting
 
 import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
+import org.springframework.batch.core.JobParameters
+import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.core.JobParametersIncrementer
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.file.FlatFileHeaderCallback
@@ -14,6 +17,7 @@ import org.springframework.core.io.Resource
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.io.Writer
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -106,5 +110,19 @@ class LoggingWriter<T> : ItemWriter<T> {
 
   override fun write(items: MutableList<out T>) {
     logger.info(items.toString())
+  }
+}
+
+class TimestampIncrementer : JobParametersIncrementer {
+  override fun getNext(inputParams: JobParameters?): JobParameters {
+    val params = inputParams ?: JobParameters()
+
+    if (params.parameters["timestamp"] != null) {
+      return params
+    }
+
+    return JobParametersBuilder(params)
+      .addLong("timestamp", Instant.now().epochSecond)
+      .toJobParameters()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.BatchUtils
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
 import java.io.File
 import kotlin.io.path.createTempDirectory
@@ -110,6 +111,9 @@ class NdmisPerformanceReportJobConfiguration(
     )
 
     return jobBuilderFactory["ndmisPerformanceReportJob"]
+      // this incrementer adds a timestamp parameter meaning we can
+      // re-run the job with the same commandline params multiple times
+      .incrementer(TimestampIncrementer())
       .validator(validator)
       .start(ndmisWriteReferralToCsvStep)
       .next(ndmisWriteComplexityToCsvStep)


### PR DESCRIPTION


## What does this pull request do?

add spring batch 'JobParametersIncrementer' which allows the ndmis reporting job to run without the launcher specifying the timestamp

## What is the intent behind these changes?

means you don't need to specify the timestamp param by hand, which makes running this as a k8s cronjob simpler.
