### PR TITLE
stop report from breaking on null pointer exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ComplexityProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ComplexityProcessor.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
 
 import mu.KLogging
-import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentReferralProcessor
@@ -10,26 +9,18 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentRefe
 class ComplexityProcessor() : SentReferralProcessor<List<ComplexityData>> {
   companion object : KLogging()
 
-  override fun processSentReferral(referral: Referral): List<ComplexityData>? {
-    try {
-      return referral.selectedServiceCategories!!.map {
-        ComplexityData(
-          referralReference = referral.referenceNumber!!,
-          referralId = referral.id,
-          interventionTitle = referral.intervention.title,
-          serviceCategoryId = it.id,
-          serviceCategoryName = it.name,
-          complexityLevelTitle = it.complexityLevels.find { complexityLevel ->
-            complexityLevel.id == referral.complexityLevelIds!![it.id]
-          }!!.title
-        )
-      }
-    } catch (e: NullPointerException) {
-      logger.warn(
-        "Null pointer found when processing complexity report {}",
-        StructuredArguments.kv("referral", referral.id),
+  override fun processSentReferral(referral: Referral): List<ComplexityData> {
+    return referral.selectedServiceCategories!!.map {
+      ComplexityData(
+        referralReference = referral.referenceNumber!!,
+        referralId = referral.id,
+        interventionTitle = referral.intervention.title,
+        serviceCategoryId = it.id,
+        serviceCategoryName = it.name,
+        complexityLevelTitle = it.complexityLevels.find { complexityLevel ->
+          complexityLevel.id == referral.complexityLevelIds!![it.id]
+        }!!.title
       )
-      return null
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ComplexityProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ComplexityProcessor.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
 
 import mu.KLogging
+import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentReferralProcessor
@@ -9,19 +10,26 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentRefe
 class ComplexityProcessor() : SentReferralProcessor<List<ComplexityData>> {
   companion object : KLogging()
 
-  override fun processSentReferral(referral: Referral): List<ComplexityData> {
-    return referral.selectedServiceCategories!!.map {
-      ComplexityData(
-        referralReference = referral.referenceNumber!!,
-        referralId = referral.id,
-        interventionTitle = referral.intervention.title,
-        serviceCategoryId = it.id,
-        serviceCategoryName = it.name,
-        complexityLevelTitle = it.complexityLevels.find {
-          complexityLevel ->
-          complexityLevel.id == referral.complexityLevelIds!![it.id]
-        }!!.title
+  override fun processSentReferral(referral: Referral): List<ComplexityData>? {
+    try {
+      return referral.selectedServiceCategories!!.map {
+        ComplexityData(
+          referralReference = referral.referenceNumber!!,
+          referralId = referral.id,
+          interventionTitle = referral.intervention.title,
+          serviceCategoryId = it.id,
+          serviceCategoryName = it.name,
+          complexityLevelTitle = it.complexityLevels.find { complexityLevel ->
+            complexityLevel.id == referral.complexityLevelIds!![it.id]
+          }!!.title
+        )
+      }
+    } catch (e: NullPointerException) {
+      logger.warn(
+        "Null pointer found when processing complexity report {}",
+        StructuredArguments.kv("referral", referral.id),
       )
+      return null
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
 
+import mu.KLogging
 import org.hibernate.SessionFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.BatchUtils
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.NPESkipPolicy
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
 import java.io.File
@@ -41,6 +43,8 @@ class NdmisPerformanceReportJobConfiguration(
   @Value("\${spring.batch.jobs.ndmis.performance-report.page-size}") private val pageSize: Int,
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
+  companion object : KLogging()
+  private val skipPolicy = NPESkipPolicy()
   private val tmpDir = createTempDirectory()
   private val referralReportPath = tmpDir.resolve("crs_performance_report-v2-referrals.csv")
   private val complexityReportPath = tmpDir.resolve("crs_performance_report-v2-complexity.csv")
@@ -133,6 +137,8 @@ class NdmisPerformanceReportJobConfiguration(
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
+      .faultTolerant()
+      .skipPolicy(skipPolicy)
       .build()
   }
 
@@ -147,6 +153,8 @@ class NdmisPerformanceReportJobConfiguration(
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
+      .faultTolerant()
+      .skipPolicy(skipPolicy)
       .build()
   }
 
@@ -161,6 +169,8 @@ class NdmisPerformanceReportJobConfiguration(
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
+      .faultTolerant()
+      .skipPolicy(skipPolicy)
       .build()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
 
 import mu.KLogging
+import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentReferralProcessor
@@ -12,29 +13,37 @@ class ReferralsProcessor(
 ) : SentReferralProcessor<ReferralsData> {
   companion object : KLogging()
 
-  override fun processSentReferral(referral: Referral): ReferralsData {
-    return ReferralsData(
-      referralReference = referral.referenceNumber!!,
-      referralId = referral.id,
-      contractReference = referral.intervention.dynamicFrameworkContract.contractReference,
-      contractType = referral.intervention.dynamicFrameworkContract.contractType.name,
-      primeProvider = referral.intervention.dynamicFrameworkContract.primeProvider.name,
-      referringOfficerId = referral.createdBy.userName,
-      relevantSentanceId = referral.relevantSentenceId!!,
-      serviceUserCRN = referral.serviceUserCRN,
-      dateReferralReceived = referral.sentAt!!,
-      firstActionPlanSubmittedAt = referral.actionPlans?.mapNotNull { it.submittedAt }?.minOrNull(),
-      firstActionPlanApprovedAt = referral.actionPlans?.mapNotNull { it.approvedAt }?.minOrNull(),
-      numberOfOutcomes = referral.selectedDesiredOutcomes?.size,
-      achievementScore = referral.endOfServiceReport?.achievementScore,
-      numberOfSessions = referral.approvedActionPlan?.numberOfSessions,
-      numberOfSessionsAttended = referral.approvedActionPlan?.let { actionPlanService.getAllAttendedAppointments(it).size },
-      endRequestedAt = referral.endRequestedAt,
-      endRequestedReason = referral.endRequestedReason?.description,
-      eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
-      endReasonCode = referral.endRequestedReason?.code,
-      endReasonDescription = referral.endRequestedComments,
-      concludedAt = referral.concludedAt
-    )
+  override fun processSentReferral(referral: Referral): ReferralsData? {
+    try {
+      return ReferralsData(
+        referralReference = referral.referenceNumber!!,
+        referralId = referral.id,
+        contractReference = referral.intervention.dynamicFrameworkContract.contractReference,
+        contractType = referral.intervention.dynamicFrameworkContract.contractType.name,
+        primeProvider = referral.intervention.dynamicFrameworkContract.primeProvider.name,
+        referringOfficerId = referral.createdBy.userName,
+        relevantSentanceId = referral.relevantSentenceId!!,
+        serviceUserCRN = referral.serviceUserCRN,
+        dateReferralReceived = referral.sentAt!!,
+        firstActionPlanSubmittedAt = referral.actionPlans?.mapNotNull { it.submittedAt }?.minOrNull(),
+        firstActionPlanApprovedAt = referral.actionPlans?.mapNotNull { it.approvedAt }?.minOrNull(),
+        numberOfOutcomes = referral.selectedDesiredOutcomes?.size,
+        achievementScore = referral.endOfServiceReport?.achievementScore,
+        numberOfSessions = referral.approvedActionPlan?.numberOfSessions,
+        numberOfSessionsAttended = referral.approvedActionPlan?.let { actionPlanService.getAllAttendedAppointments(it).size },
+        endRequestedAt = referral.endRequestedAt,
+        endRequestedReason = referral.endRequestedReason?.description,
+        eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
+        endReasonCode = referral.endRequestedReason?.code,
+        endReasonDescription = referral.endRequestedComments,
+        concludedAt = referral.concludedAt
+      )
+    } catch (e: NullPointerException) {
+      logger.warn(
+        "Null pointer found when processing referral report {}",
+        StructuredArguments.kv("referral", referral.id),
+      )
+      return null
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
 
 import mu.KLogging
-import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentReferralProcessor
@@ -13,37 +12,29 @@ class ReferralsProcessor(
 ) : SentReferralProcessor<ReferralsData> {
   companion object : KLogging()
 
-  override fun processSentReferral(referral: Referral): ReferralsData? {
-    try {
-      return ReferralsData(
-        referralReference = referral.referenceNumber!!,
-        referralId = referral.id,
-        contractReference = referral.intervention.dynamicFrameworkContract.contractReference,
-        contractType = referral.intervention.dynamicFrameworkContract.contractType.name,
-        primeProvider = referral.intervention.dynamicFrameworkContract.primeProvider.name,
-        referringOfficerId = referral.createdBy.userName,
-        relevantSentanceId = referral.relevantSentenceId!!,
-        serviceUserCRN = referral.serviceUserCRN,
-        dateReferralReceived = referral.sentAt!!,
-        firstActionPlanSubmittedAt = referral.actionPlans?.mapNotNull { it.submittedAt }?.minOrNull(),
-        firstActionPlanApprovedAt = referral.actionPlans?.mapNotNull { it.approvedAt }?.minOrNull(),
-        numberOfOutcomes = referral.selectedDesiredOutcomes?.size,
-        achievementScore = referral.endOfServiceReport?.achievementScore,
-        numberOfSessions = referral.approvedActionPlan?.numberOfSessions,
-        numberOfSessionsAttended = referral.approvedActionPlan?.let { actionPlanService.getAllAttendedAppointments(it).size },
-        endRequestedAt = referral.endRequestedAt,
-        endRequestedReason = referral.endRequestedReason?.description,
-        eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
-        endReasonCode = referral.endRequestedReason?.code,
-        endReasonDescription = referral.endRequestedComments,
-        concludedAt = referral.concludedAt
-      )
-    } catch (e: NullPointerException) {
-      logger.warn(
-        "Null pointer found when processing referral report {}",
-        StructuredArguments.kv("referral", referral.id),
-      )
-      return null
-    }
+  override fun processSentReferral(referral: Referral): ReferralsData {
+    return ReferralsData(
+      referralReference = referral.referenceNumber!!,
+      referralId = referral.id,
+      contractReference = referral.intervention.dynamicFrameworkContract.contractReference,
+      contractType = referral.intervention.dynamicFrameworkContract.contractType.name,
+      primeProvider = referral.intervention.dynamicFrameworkContract.primeProvider.name,
+      referringOfficerId = referral.createdBy.userName,
+      relevantSentanceId = referral.relevantSentenceId!!,
+      serviceUserCRN = referral.serviceUserCRN,
+      dateReferralReceived = referral.sentAt!!,
+      firstActionPlanSubmittedAt = referral.actionPlans?.mapNotNull { it.submittedAt }?.minOrNull(),
+      firstActionPlanApprovedAt = referral.actionPlans?.mapNotNull { it.approvedAt }?.minOrNull(),
+      numberOfOutcomes = referral.selectedDesiredOutcomes?.size,
+      achievementScore = referral.endOfServiceReport?.achievementScore,
+      numberOfSessions = referral.approvedActionPlan?.numberOfSessions,
+      numberOfSessionsAttended = referral.approvedActionPlan?.let { actionPlanService.getAllAttendedAppointments(it).size },
+      endRequestedAt = referral.endRequestedAt,
+      endRequestedReason = referral.endRequestedReason?.description,
+      eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
+      endReasonCode = referral.endRequestedReason?.code,
+      endReasonDescription = referral.endRequestedComments,
+      concludedAt = referral.concludedAt
+    )
   }
 }


### PR DESCRIPTION
## What does this pull request do?

keeps the report processing if a null pointer is thrown

## What is the intent behind these changes?

To make the report more resilient to data issues.
