### PR TITLE
add cronjob to run the ndmis performance report job every morning

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
@@ -1,0 +1,19 @@
+{{- if not .Values.env_details.production_env -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: generate-ndmis-performance-report
+spec:
+  schedule: "30 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: "Never"
+          containers:
+            - name: hmpps-interventions-service
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: Always
+              args: ["--jobName=ndmisPerformanceReportJob"]
+  {{- include "deployment.envs" . | nindent 14 }}
+{{- end -}}


### PR DESCRIPTION
## What does this pull request do?

add cronjob to run the ndmis performance report job every morning

## What is the intent behind these changes?

run the report using automated cronjob
