### PR TITLE
provide the option to use 'acl bucket owner full control' option with the S3Service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -21,6 +21,7 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.FileSystemResource
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
@@ -182,7 +183,7 @@ class NdmisPerformanceReportJobConfiguration(
   private val pushToS3Step = stepBuilderFactory["pushToS3Step"]
     .tasklet { _: StepContribution, _: ChunkContext ->
       listOf(referralReportPath, complexityReportPath, appointmentsReportPath).forEach { path ->
-        s3Service.publishFileToS3(ndmisS3Bucket, path, pathPrefix)
+        s3Service.publishFileToS3(ndmisS3Bucket, path, pathPrefix, acl = ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL)
         File(path.toString()).delete()
       }
       RepeatStatus.FINISHED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
@@ -28,7 +28,6 @@ class S3Service {
       .apply { acl?.let { acl(it) } }
       .build()
 
-
     bucket.client.putObject(objectRequest, RequestBody.fromFile(path))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/S3Service.kt
@@ -4,6 +4,7 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import java.nio.file.Path
@@ -12,7 +13,7 @@ import java.nio.file.Path
 class S3Service {
   companion object : KLogging()
 
-  fun publishFileToS3(bucket: S3Bucket, path: Path, keyPrefix: String = "") {
+  fun publishFileToS3(bucket: S3Bucket, path: Path, keyPrefix: String = "", acl: ObjectCannedACL? = null) {
     if (!bucket.enabled) {
       logger.info("not publishing to s3; s3 disabled")
       return
@@ -24,7 +25,9 @@ class S3Service {
     val objectRequest = PutObjectRequest.builder()
       .bucket(bucket.bucketName)
       .key(key)
+      .apply { acl?.let { acl(it) } }
       .build()
+
 
     bucket.client.putObject(objectRequest, RequestBody.fromFile(path))
   }


### PR DESCRIPTION


## What does this pull request do?

provide the option to use 'acl bucket owner full control' option with the S3Service

## What is the intent behind these changes?

allows us to write to the ndmis reporting bucket
