### PR TITLE
Trello-129 Added missing session feedback domain events for both initial assessments and service delivery appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -143,6 +143,27 @@ class SNSActionPlanAppointmentService(
 
         snsPublisher.publish(referral.id, appointment.appointmentFeedbackSubmittedBy!!, snsEvent)
       }
+      ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED -> {
+        val referral = event.deliverySession.referral
+        val appointment = event.deliverySession.currentAppointment
+          ?: throw RuntimeException("event triggered for session with no appointments")
+
+        val eventType = "intervention.session-appointment.session-feedback-submitted"
+
+        val snsEvent = EventDTO(
+          eventType,
+          "Session feedback submitted for a session appointment",
+          event.detailUrl,
+          appointment.appointmentFeedbackSubmittedAt!!,
+          mapOf(
+            "serviceUserCRN" to referral.serviceUserCRN,
+            "referralId" to referral.id,
+            "deliusAppointmentId" to appointment.deliusAppointmentId.toString()
+          )
+        )
+
+        snsPublisher.publish(referral.id, appointment.appointmentFeedbackSubmittedBy!!, snsEvent)
+      }
     }
   }
 }
@@ -171,6 +192,26 @@ class SNSAppointmentService(
           event.detailUrl,
           appointment.attendanceSubmittedAt!!,
           mapOf("serviceUserCRN" to referral.serviceUserCRN, "referralId" to referral.id)
+        )
+
+        snsPublisher.publish(referral.id, appointment.appointmentFeedbackSubmittedBy!!, snsEvent)
+      }
+      AppointmentEventType.SESSION_FEEDBACK_RECORDED -> {
+        val referral = event.appointment.referral
+        val appointment = event.appointment
+
+        val eventType = "intervention.initial-assessment-appointment.session-feedback-submitted"
+
+        val snsEvent = EventDTO(
+          eventType,
+          "Session feedback submitted for an initial assessment appointment",
+          event.detailUrl,
+          appointment.appointmentFeedbackSubmittedAt!!,
+          mapOf(
+            "serviceUserCRN" to referral.serviceUserCRN,
+            "referralId" to referral.id,
+            "deliusAppointmentId" to appointment.deliusAppointmentId.toString()
+          )
         )
 
         snsPublisher.publish(referral.id, appointment.appointmentFeedbackSubmittedBy!!, snsEvent)


### PR DESCRIPTION
## What does this pull request do?
Added missing session feedback domain events for both initial assessments and service delivery appointments. These have been missing from day one.

## What is the intent behind these changes?
These events required by the interventions-event-listener for it to update nDelius (via community-api)
