### PR TITLE
Async exception handler to not swallow exception so that top level exception handler reports full exception stack, e.g. below null pointer source is reported

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdvice.kt
@@ -20,6 +20,7 @@ class AsyncEventExceptionAdvice {
     } catch (exception: Throwable) {
       val event = (pjp as MethodInvocationProceedingJoinPoint).args.getOrNull(0)
       logger.error("Exception thrown for method annotated with @AsyncEventExceptionHandling {}", exception, kv("event", event))
+      throw exception
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdviceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdviceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.slf4j.LoggerFactory
 import org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
@@ -51,7 +52,9 @@ internal class AsyncEventExceptionAdviceTest {
     whenever(methodInvocationProceedingJoinPoint.proceed()).thenThrow(RuntimeException())
     whenever(methodInvocationProceedingJoinPoint.args).thenReturn(arrayOf(SampleData.sampleNPSRegion()))
 
-    asyncEventExceptionAdvice.handleException(methodInvocationProceedingJoinPoint)
+    assertThrows<RuntimeException> {
+      asyncEventExceptionAdvice.handleException(methodInvocationProceedingJoinPoint)
+    }
 
     Assertions.assertThat(memoryAppender.logEvents.size).isEqualTo(1)
     Assertions.assertThat(memoryAppender.logEvents[0].level.levelStr).isEqualTo("ERROR")


### PR DESCRIPTION
## What does this pull request do?
Async handler no longer swallows exception and is now caught by top level exception handler. Full stack trace is shown giving source of errors.

```
2021-11-18 08:48:21.280 ERROR 31069 --- [TaskExecutor-42] u.g.j.d.h.h.e.AsyncEventExceptionAdvice  : Exception thrown for method annotated with @AsyncEventExceptionHandling java.lang.NullPointerException
Exception in thread "SimpleAsyncTaskExecutor-42" java.lang.NullPointerException
	at uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SNSActionPlanService.onApplicationEvent(SNSService.kt:35)
	at uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SNSActionPlanService.onApplicationEvent(SNSService.kt:22)
	at uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SNSActionPlanService$$FastClassBySpringCGLIB$$5dfb72bb.invoke(<generated>)
```

## What is the intent behind these changes?
To be able to pinpoint the source of the exception which is not currently the case.