### PR TITLE
Bug Fix: Don't include old referrals for myCases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
@@ -50,8 +50,7 @@ class ReferralSummaryRepositoryImpl : ReferralSummaryRepository {
 		  r.sent_at is not null
 		  and ( dfc.prime_provider_id in :serviceProviders or dfcsc.subcontractor_provider_id in :serviceProviders )
       and not (r.concluded_At is not null and r.end_Requested_At is not null and eosr.id is null)
-      $dashboardRestrictionCriteria
-) a where assigned_at_desc_seq = 1"""
+) a where assigned_at_desc_seq = 1 $dashboardRestrictionCriteria"""
   }
 
   override fun getSentReferralSummaries(authUser: AuthUser, serviceProviders: List<String>, dashboardType: DashboardType?): List<ServiceProviderSentReferralSummary> {
@@ -80,10 +79,10 @@ class ReferralSummaryRepositoryImpl : ReferralSummaryRepository {
 
   private fun constructCustomCriteria(dashboardType: DashboardType?): String? {
     return when (dashboardType) {
-      DashboardType.myCases -> "and au.user_name = :username and eosr.submitted_at is null "
-      DashboardType.openCases -> "and eosr.submitted_at is null "
-      DashboardType.unassignedCases -> "and au.user_name is null and eosr.submitted_at is null "
-      DashboardType.completedCases -> "and eosr.submitted_at is not null "
+      DashboardType.myCases -> "and assignedToUserName = :username and endOfServiceReportSubmittedAt is null "
+      DashboardType.openCases -> "and endOfServiceReportSubmittedAt is null "
+      DashboardType.unassignedCases -> "and assignedToUserName is null and endOfServiceReportSubmittedAt is null "
+      DashboardType.completedCases -> "and endOfServiceReportSubmittedAt is not null "
       null -> null
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -224,6 +224,18 @@ class ReferralRepositoryTest @Autowired constructor(
 
   @Nested
   inner class DashboardTypeSelection {
+
+    @Test
+    fun `myCases dashboard will not return self assigned if they're not latest`() {
+
+      val assignedReferral = createReferral(true, 2)
+      val oldAssignee = assignedReferral.assignments.get(0).assignedTo
+      val serviceProviderSearchId = assignedReferral.intervention.dynamicFrameworkContract.primeProvider.id
+      val summaries = referralRepository.getSentReferralSummaries(oldAssignee, listOf(serviceProviderSearchId), DashboardType.myCases)
+
+      assertThat(summaries.size).isEqualTo(0)
+    }
+
     @Test
     fun `myCases dashboard type should only return logged in user referrals`() {
       val assignedReferral = createReferral(true, 1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -226,7 +226,7 @@ class ReferralRepositoryTest @Autowired constructor(
   inner class DashboardTypeSelection {
 
     @Test
-    fun `myCases dashboard will not return self assigned if they're not latest`() {
+    fun `does not show referrals where the user has been historically assigned but no longer the active assignee`() {
 
       val assignedReferral = createReferral(true, 2)
       val oldAssignee = assignedReferral.assignments.get(0).assignedTo


### PR DESCRIPTION
Some users were reporting that they were seeing that they were being assigned to the wrong referral on my cases dashboard.
    
After some investigation it appears that for MyCases dashboard we are returning a referral if the user has ***ever*** been assigned to it and not just if they're the latest assigned user.
    
This bug fix moves the custom SQL checks to be after filtering for the latest assigned referral has been done.

