### PR TITLE
Ability for getSupplierAssessment() to be called by a client with ROLE_INTERVENTIONS_API_READ_ALL

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -249,10 +249,7 @@ class ReferralController(
     @PathVariable id: UUID,
     authentication: JwtAuthenticationToken,
   ): SupplierAssessmentDTO {
-    val user = userMapper.fromToken(authentication)
-
-    val sentReferral = referralService.getSentReferralForUser(id, user)
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$id]")
+    val sentReferral = getSentReferralAuthenticatedRequest(authentication, id)
 
     val supplierAssessment = getSupplierAssessment(sentReferral)
     return SupplierAssessmentDTO.from(supplierAssessment)


### PR DESCRIPTION
https://trello.com/c/xHVqOzpw/155-notify-appointment-outcome-via-event-listener

## What does this pull request do?
Ability for getSupplierAssessment() to be called by a client with ROLE_INTERVENTIONS_API_READ_ALL

## What is the intent behind these changes?
This is required by the interventions-event-listener to look up supplier assessment info so it can call community-api