### PR TITLE
rename old action plan session tables

### DIFF
--- a/src/main/resources/db/migration/V1_91__deprecate_action_plan_session_tables.sql
+++ b/src/main/resources/db/migration/V1_91__deprecate_action_plan_session_tables.sql
@@ -1,0 +1,13 @@
+ALTER TABLE action_plan_session
+RENAME TO deprecated_action_plan_session;
+
+ALTER TABLE action_plan_session_appointment
+RENAME TO deprecated_action_plan_session_appointment;
+
+update metadata
+set table_name = 'deprecated_action_plan_session'
+where table_name = 'action_plan_session';
+
+update metadata
+set table_name = 'deprecated_action_plan_session_appointment'
+where table_name = 'action_plan_session_appointment'


### PR DESCRIPTION
## What does this pull request do?

Rename's the old `action_plan_session` and `action_plan_session_appointment` tables

## What is the intent behind these changes?

Tidy up of the action plan to delivery session db changes
