### PR TITLE
Additional logging for NullPointerException when getting CurrentAssignee 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
 
+import mu.KLogging
 import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -22,6 +23,7 @@ class ReferralEventPublisher(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val locationMapper: LocationMapper
 ) {
+  companion object : KLogging()
 
   fun referralSentEvent(referral: Referral) {
     applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.SENT, referral, getSentReferralURL(referral)))
@@ -32,6 +34,7 @@ class ReferralEventPublisher(
   }
 
   fun referralConcludedEvent(referral: Referral, eventType: ReferralEventType) {
+    referral.currentAssignee ?: logger.warn("Concluding referral has no current assignment ${referral.id} for event type $eventType")
     applicationEventPublisher.publishEvent(ReferralEvent(this, eventType, referral, getSentReferralURL(referral)))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AuthUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/AuthUser.kt
@@ -24,4 +24,8 @@ data class AuthUser(
 
     return userName == other.userName && authSource == other.authSource
   }
+  companion object {
+    // System user to represent the actor for events that are automatically generated
+    val interventionsServiceUser = AuthUser("00000000-0000-0000-0000-000000000000", "fake", "hmpps-interventions-service")
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 
 interface SNSService
 
@@ -108,7 +109,8 @@ class SNSReferralService(
           event.referral.concludedAt!!,
           mapOf("referralId" to event.referral.id)
         )
-        snsPublisher.publish(event.referral.id, event.referral.currentAssignee!!, snsEvent)
+        // This is a system generated event at present and as such the actor will represent this
+        snsPublisher.publish(event.referral.id, AuthUser.interventionsServiceUser, snsEvent)
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSReferralServiceTest.kt
@@ -129,7 +129,7 @@ internal class SNSReferralServiceTest {
   }
 
   @Test
-  fun `publishes referral completed event message`() {
+  fun `publishes referral completed event message with actor as Interventions service user`() {
     val referralConcludedEvent = referralConcludedEvent(COMPLETED)
     snsReferralService().onApplicationEvent(referralConcludedEvent)
     val snsEvent = EventDTO(
@@ -139,7 +139,11 @@ internal class SNSReferralServiceTest {
       referralConcludedEvent.referral.concludedAt!!,
       mapOf("referralId" to UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"))
     )
-    verify(snsPublisher).publish(referralConcludedEvent.referral.id, referralConcludedEvent.referral.currentAssignee!!, snsEvent)
+    verify(snsPublisher).publish(
+      referralConcludedEvent.referral.id,
+      AuthUser("00000000-0000-0000-0000-000000000000", "fake", "hmpps-interventions-service"),
+      snsEvent
+    )
   }
 
   private fun snsReferralService(): SNSReferralService {


### PR DESCRIPTION
https://trello.com/c/RkihX2uQ/159-prod-issue-nullpointerexception-in-getcurrentassignment

## What does this pull request do?
Add a null check on the current assignment, with logging, to the app event publisher method as a fact finding change for two reasons:
1. To confirm whether the current assignment exists when in the main transactional thread
2. By doing this, it will lazy load the current assignee and can confirm there is a lazy loading issue (as the problem will go away)
If this proves to be correct then we can formulate a more elegant solution.

```
Crashed in non-app: org.hibernate.collection.internal.AbstractPersistentCollection in withTemporarySessionIfNeeded
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral in getCurrentAssignment at line 152
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral in getCurrentAssignee at line 106
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SNSReferralService in onApplicationEvent at line 111
uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SNSReferralService in onApplicationEvent at line 54
```

## What is the intent behind these changes?
Provides additional insight into the cause of the problem.
