### PR TITLE
remove unused 'cancelled' method in referral entity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -91,8 +91,6 @@ class Referral(
   @OneToOne(mappedBy = "referral") @Fetch(JOIN) var endOfServiceReport: EndOfServiceReport? = null,
   @OneToOne(mappedBy = "referral") @Fetch(JOIN) var supplierAssessment: SupplierAssessment? = null,
 ) {
-  fun cancelled(): Boolean = concludedAt != null && endRequestedAt != null && endOfServiceReport == null
-
   val approvedActionPlan: ActionPlan?
     get() = actionPlans?.filter { it.approvedAt != null }?.maxByOrNull { it.approvedAt!! }
 


### PR DESCRIPTION
## What does this pull request do?

removes a method called 'cancelled' in the referral entity. this was unused. the logic is duplicated in the 'endState' getter. so if future 'us' did want to use this method they could just check `referral.endState == 'cancelled'`.

## What is the intent behind these changes?

clean up
