### PR TITLE
Ability to disable calling community-api with appointment outcomes when event listener is in production

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,6 +21,7 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
+  COMMUNITYAPI_APPOINTMENTS_OUTCOME_ENABLED: "true"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "dev"
   AWS_S3_STORAGE_ENABLED: "true"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
+  COMMUNITYAPI_APPOINTMENTS_OUTCOME_ENABLED: "true"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "preprod"
   AWS_S3_STORAGE_ENABLED: "true"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,6 +19,7 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://refer-monitor-intervention.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.probation.service.justice.gov.uk"
+  COMMUNITYAPI_APPOINTMENTS_OUTCOME_ENABLED: "true"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "prod"
   AWS_S3_STORAGE_ENABLED: "true"

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -19,6 +19,7 @@ env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-research.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
+  COMMUNITYAPI_APPOINTMENTS_OUTCOME_ENABLED: "true"
   ASSESSRISKSANDNEEDS_BASEURL: "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk"
   SENTRY_ENVIRONMENT: "research"
   AWS_S3_STORAGE_ENABLED: "true"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -190,6 +190,7 @@ class CommunityAPIActionPlanEventService(
 class CommunityAPIActionPlanAppointmentEventService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.probation-practitioner.session-feedback}") private val ppSessionFeedbackLocation: String,
+  @Value("\${community-api.appointments.outcome.enabled}") private val outcomeNotificationEnabled: Boolean,
   @Value("\${community-api.locations.appointment-outcome-request}") private val communityAPIAppointmentOutcomeLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   private val communityAPIClient: CommunityAPIClient,
@@ -199,6 +200,10 @@ class CommunityAPIActionPlanAppointmentEventService(
   override fun onApplicationEvent(event: ActionPlanAppointmentEvent) {
     when (event.type) {
       SESSION_FEEDBACK_RECORDED -> {
+        if (!outcomeNotificationEnabled) {
+          return
+        }
+
         val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
           .path(ppSessionFeedbackLocation)
           .buildAndExpand(event.deliverySession.referral.id, event.deliverySession.sessionNumber)
@@ -228,6 +233,7 @@ class CommunityAPIActionPlanAppointmentEventService(
 class CommunityAPIAppointmentEventService(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.probation-practitioner.supplier-assessment-feedback}") private val ppSessionFeedbackLocation: String,
+  @Value("\${community-api.appointments.outcome.enabled}") private val outcomeNotificationEnabled: Boolean,
   @Value("\${community-api.locations.appointment-outcome-request}") private val communityAPIAppointmentOutcomeLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
   private val communityAPIClient: CommunityAPIClient,
@@ -237,6 +243,10 @@ class CommunityAPIAppointmentEventService(
   override fun onApplicationEvent(event: AppointmentEvent) {
     when (event.type) {
       AppointmentEventType.SESSION_FEEDBACK_RECORDED -> {
+        if (!outcomeNotificationEnabled) {
+          return
+        }
+
         val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
           .path(ppSessionFeedbackLocation)
           .buildAndExpand(event.appointment.referral.id)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,6 +11,8 @@ community-api:
   appointments:
     bookings:
       enabled: false
+    outcome:
+      enabled: false
 
 assess-risks-and-needs:
   baseurl: http://localhost:8094

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,8 @@ community-api:
   appointments:
     bookings:
       enabled: true
+    outcome:
+      enabled: true
     office-location: CRSEXTL
     notes-field-qualifier: "{
       SERVICE_DELIVERY:'Service Delivery',

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIAppointmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIAppointmentEventServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
@@ -26,6 +27,7 @@ class CommunityAPIAppointmentEventServiceTest {
   private val communityAPIService = CommunityAPIAppointmentEventService(
     "http://baseUrl",
     "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback",
+    true,
     "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",
     "commissioned-rehabilitation-services",
     communityAPIClient
@@ -73,6 +75,26 @@ class CommunityAPIAppointmentEventServiceTest {
     communityAPIService.onApplicationEvent(appointmentEvent)
 
     verifyNotification(YES.name, true)
+  }
+
+  @Test
+  fun `does not notify when not enabled`() {
+
+    val communityAPIService = CommunityAPIAppointmentEventService(
+      "http://baseUrl",
+      "/probation-practitioner/referrals/{id}/supplier-assessment/post-session-feedback",
+      false,
+      "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",
+      "commissioned-rehabilitation-services",
+      communityAPIClient
+    )
+
+    appointmentEvent.appointment.attended = YES
+    appointmentEvent.appointment.notifyPPOfAttendanceBehaviour = true
+
+    communityAPIService.onApplicationEvent(appointmentEvent)
+
+    verifyZeroInteractions(communityAPIClient)
   }
 
   private fun verifyNotification(attended: String, notifyPP: Boolean) {


### PR DESCRIPTION
https://trello.com/c/xHVqOzpw/155-notify-appointment-outcome-via-event-listener

## What does this pull request do?
Ability to disable calling community-api with appointment outcomes when event listener takes over the responsibility for this.

## What is the intent behind these changes?
Facilitates the migration to the interventions to delius event listener notification route 