### PR TITLE
Remove duplicated issues in Sentry which arise from async listeners

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdvice.kt
@@ -1,25 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception
 
-import mu.KLogging
-import net.logstash.logback.argument.StructuredArguments.kv
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
-import org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint
 import org.springframework.stereotype.Component
 
 @Aspect
 @Component
 class AsyncEventExceptionAdvice {
-  companion object : KLogging()
-
   @Around(value = "@annotation(AsyncEventExceptionHandling)")
   fun handleException(pjp: ProceedingJoinPoint) {
     try {
       pjp.proceed()
     } catch (exception: Throwable) {
-      val event = (pjp as MethodInvocationProceedingJoinPoint).args.getOrNull(0)
-      logger.error("Exception thrown for method annotated with @AsyncEventExceptionHandling {}", exception, kv("event", event))
       throw exception
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/AsyncEventExceptionAdvice.kt
@@ -1,9 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception
 
+import io.sentry.Sentry
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
+import org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint
+import org.springframework.context.ApplicationEvent
 import org.springframework.stereotype.Component
+
+class EventException(val event: ApplicationEvent, cause: Throwable) : RuntimeException(cause) {
+  override val message: String
+    get() = "${cause?.javaClass?.simpleName}: ${cause?.message}; while processing ${eventName()}"
+
+  private fun eventName(): String = event.javaClass.simpleName
+}
 
 @Aspect
 @Component
@@ -13,7 +23,9 @@ class AsyncEventExceptionAdvice {
     try {
       pjp.proceed()
     } catch (exception: Throwable) {
-      throw exception
+      val event = (pjp as MethodInvocationProceedingJoinPoint).args.getOrNull(0) as ApplicationEvent
+      Sentry.setExtra("async-event", event.toString())
+      throw EventException(event, exception)
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Remove duplicated issues in Sentry which arise from async listeners

This is the same thing:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1526295/143046922-88c8d967-8583-4d5b-b869-684b1a5237f4.png">

[Exception thrown for method annotated with @AsyncEventExceptionHandling](https://sentry.io/organizations/ministryofjustice/issues/2797313334/events/c3bab534c24b494d939155e9cea2f8df/?project=5807819) has `java.lang.NullPointerException` **and** the context (`event=ReferralEvent(type=COMPLETED, referral=fd7e9b73-eb9f-4fce-82bd-092f8cb3adf1, ...`)

[NullPointerException](https://sentry.io/organizations/ministryofjustice/issues/2808067315/events/27da8978341a48198cd24597ef4f88e1/?project=5807819) has the full stacktrace and allows us to group the issues

The goal is to [keep only one](https://media.giphy.com/media/8L0yOaWLNmHnm9T4yy/giphy.gif).

## What will be after this?

We'll see 1 issue with `EventException` and message as `causeClass: causeMessage; while processing EventClassName` and full context of the event in the details

## What is the intent behind these changes?

Outcomes sought:
1. Separate issues in Sentry per event listener
2. Context (event details) available in code
3. Context (event details) available to Sentry

Point 1 is satisfied due to fingerprinting in Sentry will separate issues based on stack trace (this is why we have different `NotificationClientException`s per listener)

Point 2 is satisfied by enveloping the event in a custom exception

Point 3 is satisfied by adding `setExtra` details for Sentry
