### PR TITLE
Referral Dashboard SQL efficiency improvement

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
@@ -50,7 +50,7 @@ class ReferralSummaryRepositoryImpl : ReferralSummaryRepository {
 			 left join end_of_service_report eosr on eosr.referral_id = r.id
 			 left outer join action_plan ap on ap.referral_id = r.id
 	 	 	 left outer join appointment app
-       	 left outer join supplier_assessment_appointment saa on saa.appointment_id = app.id
+       	 left join supplier_assessment_appointment saa on saa.appointment_id = app.id
        	 on app.referral_id = r.id
 	where
 		  r.sent_at is not null


### PR DESCRIPTION
Change "left outer join" from appointment to supplier assessment to "left join" to improve SQL efficiency.

The final output of the SQL will be identical however this will reduce the number of rows to work over when partioning by referral id and getting the lastest assignment.
