### PR TITLE
Cleanup: remove pinned dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,8 +59,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("com.nimbusds:oauth2-oidc-sdk:9.19")
-  // Issue with 4.1.67.Final from spring-boot-starter-webflux
-  implementation("io.netty:netty-codec:4.1.70.Final")
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION

## What does this pull request do?

Removes an explicitly pinned dependency -- we did that in 26c576a675d8a44e5fd6b93d518b06907de36cc2 to fix a security vulnerability; but since the cause has been fixed upstream

## What is the intent behind these changes?

The "inherited" netty-codec is now at `4.1.69.Final`, which is a downgrade, but we don't want to manage this dependency directly
