### PR TITLE
Enforce data documentation on tables

### DIFF
--- a/script/validate-metadata.sh
+++ b/script/validate-metadata.sh
@@ -1,23 +1,57 @@
-#!/bin/bash -e
-missing_columns="SELECT i.table_name, i.column_name
+#!/bin/bash
+missing_columns="SELECT m.*
 FROM information_schema.columns i
          LEFT JOIN metadata m ON i.table_name = m.table_name AND i.column_name = m.column_name
 WHERE i.table_schema = 'public'
-  AND m.sensitive IS NULL;"
+  AND (m.sensitive IS NULL OR m.domain_data IS NULL);"
 
-validation="$(psql -v"ON_ERROR_STOP=1" -U"postgres" "postgresql://localhost:5432/${POSTGRES_DB:-interventions}" \
+missing_table_comment="SELECT c.table_name, pg_catalog.obj_description(c.table_name::regclass::oid) AS table_comment
+FROM information_schema.columns AS c
+         JOIN metadata AS m ON (c.table_name = m.table_name AND c.column_name = m.column_name)
+WHERE c.table_schema = 'public'
+  AND m.domain_data = TRUE
+  AND pg_catalog.obj_description(c.table_name::regclass::oid) IS NULL
+GROUP BY c.table_name
+ORDER BY c.table_name;"
+
+found_missing_doc=""
+
+column_validation="$(psql -v"ON_ERROR_STOP=1" -U"postgres" "postgresql://localhost:5432/${POSTGRES_DB:-interventions}" \
   --command "$missing_columns")"
 
-echo "Undocumented columns:"
-echo "$validation"
+echo
+echo "Unclassified columns:"
+echo "$column_validation"
 echo
 
-if [[ "$validation" =~ \(0\ rows\) ]]; then
-  echo "✅ All columns are documented in the metadata table"
+if [[ "$column_validation" =~ \(0\ rows\) ]]; then
+  echo "✅ All columns are classified in the metadata table"
 else
-  echo "😰 Undocumented columns found"
+  found_missing_doc="x"
+  echo "😰 Unclassified columns found"
   echo
   echo "Fix by adding this into your new migration:"
   echo "INSERT INTO metadata (table_name, column_name, ...) VALUES (..., ..., ...);"
+fi
+
+table_comment_validation="$(psql -v"ON_ERROR_STOP=1" -U"postgres" "postgresql://localhost:5432/${POSTGRES_DB:-interventions}" \
+  --command "$missing_table_comment")"
+
+echo
+echo "Undocumented domain tables:"
+echo "$table_comment_validation"
+echo
+
+if [[ "$table_comment_validation" =~ \(0\ rows\) ]]; then
+  echo "✅ All domain tables are documented in the R__data_dictionary.sql migration"
+else
+  found_missing_doc="x"
+  echo "😰 Undocumented domain tables found"
+  echo
+  echo "Fix by adding this into R__data_dictionary.sql:"
+  echo "COMMENT ON TABLE table_name IS '...useful information for data users...';"
+fi
+
+if [[ "x" == "$found_missing_doc" ]]; then
   exit 1
 fi

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -102,6 +102,8 @@ COMMENT ON COLUMN action_plan_activity.action_plan_id IS 'service user''s action
 COMMENT ON COLUMN action_plan_activity.description IS 'description of the activity';
 COMMENT ON COLUMN action_plan_activity.created_at IS 'when the service user''s action plan was created';
 
+COMMENT ON TABLE appointment IS 'person-on-probation appointment details (all kinds, assessments and delivery)';
+
 COMMENT ON TABLE appointment_delivery IS 'appointment delivery details';
 COMMENT ON COLUMN appointment_delivery.appointment_id IS 'appointment''s unique identifier';
 COMMENT ON COLUMN appointment_delivery.appointment_delivery_type IS 'type to denote how the appointment is delivered';
@@ -114,7 +116,6 @@ COMMENT ON COLUMN appointment_delivery_address.second_address_line IS 'second ad
 COMMENT ON COLUMN appointment_delivery_address.town_city IS 'town or city of appointment delivery address location';
 COMMENT ON COLUMN appointment_delivery_address.county IS 'county of appointment delivery address location';
 COMMENT ON COLUMN appointment_delivery_address.post_code IS 'postcode of appointment delivery address location';
-
 
 COMMENT ON TABLE case_note IS 'case note provided by officer for a referral';
 COMMENT ON COLUMN case_note.referral_id IS 'referral connected to this case note';
@@ -141,3 +142,27 @@ COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_self_harm IS 'OASYS 
 COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_hostel_setting IS 'OASYS Risk to Self - hostel setting';
 COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_vulnerability IS 'OASYS Risk to Self - vulnerability';
 COMMENT ON COLUMN draft_oasys_risk_information.additional_information IS 'OASYS Additional risk information';
+
+COMMENT ON TABLE deprecated_action_plan_appointment IS '**deprecated**; use `appointment`';
+COMMENT ON TABLE deprecated_action_plan_session IS '**deprecated**; use `delivery_session`';
+COMMENT ON TABLE deprecated_action_plan_session_appointment IS '**deprecated**; use `delivery_session_appointment`';
+COMMENT ON VIEW delivery_session_deprecated IS '**deprecated** view in favour of new table `delivery_session`';
+COMMENT ON VIEW delivery_session_appointment_deprecated IS '**deprecated** view in favour of new table `delivery_session_appointment`';
+
+COMMENT ON TABLE action_plan_session_appointment_pre_v1_78 IS '**backup** no longer in use; for up-to-date session appointment links, see `delivery_session_appointment`';
+COMMENT ON TABLE delivery_session IS 'session details for a referral';
+COMMENT ON TABLE delivery_session_appointment IS 'links between sessions and appointments for a referral';
+COMMENT ON TABLE supplier_assessment IS 'supplier assessment details for a referral';
+COMMENT ON TABLE supplier_assessment_appointment IS 'links between supplier assessments and their appointments for a referral';
+
+COMMENT ON TABLE cancellation_reason IS '**reference data** early end/cancellation reasons';
+COMMENT ON TABLE contract_type IS 'contract (service) types available for commissioned rehabilitative services';
+COMMENT ON TABLE contract_type_service_category IS 'configuration of selectable service categories for each contract type';
+COMMENT ON TABLE dynamic_framework_contract_sub_contractor IS 'sub-contractors for each commissioned rehabilitative services contract';
+
+COMMENT ON TABLE end_of_service_report IS 'end of service reports';
+COMMENT ON TABLE end_of_service_report_outcome IS 'outcome progress recorded in end of service reports';
+COMMENT ON TABLE referral_complexity_level_ids IS 'selected complexity levels for each referral';
+COMMENT ON TABLE referral_selected_service_category IS 'selected service categories for each referral';
+
+-- some definitions are in V1_34__document_contract_table.sql; needs lifting

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -127,6 +127,7 @@ COMMENT ON TABLE metadata IS 'defines metadata about the schema';
 COMMENT ON COLUMN metadata.table_name IS 'which table this record is describing';
 COMMENT ON COLUMN metadata.column_name IS 'which column this record is describing';
 COMMENT ON COLUMN metadata.sensitive IS '`true` means the contents should be obfuscated/anonymised in unsafe environments; `false` means it’s safe to see/copy';
+COMMENT ON COLUMN metadata.domain_data IS '`true` means the field hold operational/domain data; `false` means it is an internal structure that holds no operational data';
 
 COMMENT ON TABLE draft_oasys_risk_information IS 'holds draft OASYS risk information only for a DraftReferral. Discarded after referral is sent.';
 COMMENT ON COLUMN draft_oasys_risk_information.referral_id IS 'the id of the draft referral connected to risk information';

--- a/src/main/resources/db/migration/V1_92__describe_domain_data.sql
+++ b/src/main/resources/db/migration/V1_92__describe_domain_data.sql
@@ -1,0 +1,17 @@
+ALTER TABLE metadata
+    ADD COLUMN domain_data boolean;
+
+UPDATE metadata
+SET domain_data = FALSE
+WHERE table_name = 'flyway_schema_history'
+   OR table_name LIKE 'batch_%';
+
+UPDATE metadata
+SET domain_data = TRUE
+WHERE domain_data IS NULL;
+
+ALTER TABLE metadata
+    ALTER COLUMN domain_data SET NOT NULL;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data)
+VALUES ('metadata', 'domain_data', FALSE, TRUE);


### PR DESCRIPTION
## What does this pull request do?

Enables CI check on whether tables have data documentation. (This PR does not enforce column definitions.)

To make sure we don't needlessly document "internal" tables, a new `domain_data` flag is added to the `metadata` table.

## What is the intent behind these changes?

The current data dictionary tables are a bit patchy:
![image](https://user-images.githubusercontent.com/1526295/143151412-88501480-9834-4606-9c27-f6f1a143beaf.png)

The aim is to make sure the _relevant_ bits are filled out.

## After these changes

The main page will look like this:
![image](https://user-images.githubusercontent.com/1526295/143152952-1a187f74-fbee-4c6f-9ef4-792bc1cc1b97.png)
