### PR TITLE
Show case note event details in exceptions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
@@ -15,7 +15,9 @@ class CreateCaseNoteEvent(
   val sentBy: AuthUser,
   val detailUrl: String,
   val referralId: UUID,
-) : ApplicationEvent(source)
+) : ApplicationEvent(source) {
+  override fun toString(): String = "CreateCaseNoteEvent(caseNoteId=$caseNoteId, referralId=$referralId)"
+}
 
 @Component
 class CaseNoteEventPublisher(


### PR DESCRIPTION


## What does this pull request do?

Show case note event details in exceptions

## What is the intent behind these changes?

We use these `toString`s to show details about the events in case of failure. The default toString doesn't include any IDs

This lead to unhelpful events: https://sentry.io/organizations/ministryofjustice/issues/2814711914/events/4820c55ecf314928a5639d2ef1ae68c2/?project=5807819#extra

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/1526295/143563271-889dd6b7-8bab-4946-b89c-2b33546d793e.png">


A custom `toString` solves this
