### PR TITLE
Consistently refer to IDs in event toStrings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
@@ -15,7 +15,7 @@ enum class ActionPlanAppointmentEventType {
 
 class ActionPlanAppointmentEvent(source: Any, val type: ActionPlanAppointmentEventType, val deliverySession: DeliverySession, val detailUrl: String, val notifyPP: Boolean) : ApplicationEvent(source) {
   override fun toString(): String {
-    return "ActionPlanAppointmentEvent(type=$type, appointment=${deliverySession.id}, detailUrl='$detailUrl', source=$source)"
+    return "ActionPlanAppointmentEvent(type=$type, deliverySessionId=${deliverySession.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -25,7 +25,7 @@ class AppointmentEvent(
   val appointmentType: AppointmentType
 ) : ApplicationEvent(source) {
   override fun toString(): String {
-    return "AppointmentEvent(type=$type, appointment=${appointment.id}, detailUrl='$detailUrl', source=$source)"
+    return "AppointmentEvent(type=$type, appointmentId=${appointment.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/EndOfServiceReportEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/EndOfServiceReportEventPublisher.kt
@@ -19,7 +19,7 @@ class EndOfServiceReportEvent(
 ) :
   ApplicationEvent(source) {
   override fun toString(): String {
-    return "EndOfServiceReportEvent(type=$type, referral=${endOfServiceReport.id}, detailUrl='$detailUrl', source=$source)"
+    return "EndOfServiceReportEvent(type=$type, referralId=${endOfServiceReport.referral.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -14,7 +14,7 @@ enum class ReferralEventType {
 
 class ReferralEvent(source: Any, val type: ReferralEventType, val referral: Referral, val detailUrl: String) : ApplicationEvent(source) {
   override fun toString(): String {
-    return "ReferralEvent(type=$type, referral=${referral.id}, detailUrl='$detailUrl', source=$source)"
+    return "ReferralEvent(type=$type, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 


### PR DESCRIPTION


## What does this pull request do?

Consistently refer to IDs in event toStrings as `somethingId={something_id}`

## What is the intent behind these changes?

There were some inconsistencies in names and values
