### PR TITLE
Add parallel dev deployment to the new cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,25 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
+      - hmpps/deploy_env:
+          name: deploy_dev_newcluster
+          env: "dev"
+          slack_notification: true
+          slack_channel_name: "interventions-dev-notifications"
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - validate
+            - validate_db
+            - publish_data
+            - build_and_publish_docker
+            - validate_helm
+            - vulnerability_scan_and_monitor
+          context:
+            - hmpps-common-vars
+            - hmpps-interventions-dev-deploy
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,7 @@ workflows:
           env: "dev"
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
+          helm_additional_args: "--set ingress.migration.colour=green"
           filters:
             branches:
               only:

--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-blue
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-{{ .Values.ingress.migration.colour }}
+    external-dns.alpha.kubernetes.io/aws-weight: "{{ pluck .Values.ingress.migration.colour .Values.ingress.migration.weights | first }}"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     {{- if .Values.env_details.contains_live_data }}
     kubernetes.io/ingress.class: "modsec01"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,12 @@ image:
 ingress:
   hosts:
     - host: hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+  migration:
+    colour: blue
+    weights:
+      # total weight must be 100; green is the new EKS cluster
+      blue: 100
+      green: 0
 
 env_details:
   contains_live_data: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,6 +13,12 @@ image:
 ingress:
   hosts:
     - host: hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+  migration:
+    colour: blue
+    weights:
+      # total weight must be 100; green is the new EKS cluster
+      blue: 100
+      green: 0
 
 env_details:
   contains_live_data: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,12 @@ image:
 ingress:
   hosts:
     - host: hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
+  migration:
+    colour: blue
+    weights:
+      # total weight must be 100; green is the new EKS cluster
+      blue: 100
+      green: 0
 
 env_details:
   contains_live_data: true

--- a/helm_deploy/values-research.yaml
+++ b/helm_deploy/values-research.yaml
@@ -10,6 +10,12 @@ image:
 ingress:
   hosts:
     - host: hmpps-interventions-service-research.apps.live-1.cloud-platform.service.justice.gov.uk
+  migration:
+    colour: blue
+    weights:
+      # total weight must be 100; green is the new EKS cluster
+      blue: 100
+      green: 0
 
 env_details:
   contains_live_data: false


### PR DESCRIPTION
## What does this pull request do?

Adds parallel dev environment deployment to the new cluster and a load balancer between them.

This is controlled by "blue" and "green" weights in the `values-{env}.yaml`

- 🔵 "blue": goes to the current cluster
- 🟢 "green": goes to the new cluster

## Next step

Dev will have 50-100% new cluster in the next PR and let's iron out any problems with that

## Background work

- Manually created a `hmpps-interventions-dev-deploy` CircleCI context to override the KUBE_* environment variables for the deployment.
- Manually copied all unprovisioned secrets over to the new cluster that blocked boot.

## What is the intent behind these changes?

We need to migrate over to the new cluster this year.