### PR TITLE
Deploy to pre-prod after successful dev deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,18 +312,13 @@ workflows:
           tag: "deployed:dev"
           requires: [deploy_dev]
           context: [hmpps-common-vars]
-      - approve_postdev:
-          type: approval
-          requires:
-            - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
           show_changelog: true
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
-          requires:
-            - approve_postdev
+          requires: [deploy_dev]
           context:
             - hmpps-common-vars
             - hmpps-interventions-service-preprod


### PR DESCRIPTION


## What does this pull request do?

In other words, remove the manual approval to pre-prod.

## What is the intent behind these changes?



As the majority of our changes (99%+) are correct and safe, there is no
reason to hold back. My hypothesis is that if we get the changes to a
live-like environment sooner, we will be aware of data
problems/migration problems sooner.
