### PR TITLE
Switch to EKS cluster on the dev environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,25 +287,6 @@ workflows:
             - vulnerability_scan_and_monitor
           context:
             - hmpps-common-vars
-      - hmpps/deploy_env:
-          name: deploy_dev_newcluster
-          env: "dev"
-          slack_notification: true
-          slack_channel_name: "interventions-dev-notifications"
-          helm_additional_args: "--set ingress.migration.colour=green"
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - validate
-            - validate_db
-            - publish_data
-            - build_and_publish_docker
-            - validate_helm
-            - vulnerability_scan_and_monitor
-          context:
-            - hmpps-common-vars
             - hmpps-interventions-dev-deploy
       - tag_pact_version:
           name: "tag_pact_version_dev"

--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-{{ .Values.ingress.migration.colour }}
-    external-dns.alpha.kubernetes.io/aws-weight: "{{ pluck .Values.ingress.migration.colour .Values.ingress.migration.weights | first }}"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     {{- if .Values.env_details.contains_live_data }}
     kubernetes.io/ingress.class: "modsec01"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,10 +15,6 @@ ingress:
     - host: hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   migration:
     colour: blue
-    weights:
-      # total weight must be 100; green is the new EKS cluster
-      blue: 100
-      green: 0
 
 env_details:
   contains_live_data: false

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,7 @@ ingress:
   hosts:
     - host: hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
   migration:
-    colour: blue
+    colour: green
 
 env_details:
   contains_live_data: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,10 +15,6 @@ ingress:
     - host: hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
   migration:
     colour: blue
-    weights:
-      # total weight must be 100; green is the new EKS cluster
-      blue: 100
-      green: 0
 
 env_details:
   contains_live_data: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,10 +12,6 @@ ingress:
     - host: hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk
   migration:
     colour: blue
-    weights:
-      # total weight must be 100; green is the new EKS cluster
-      blue: 100
-      green: 0
 
 env_details:
   contains_live_data: true


### PR DESCRIPTION
## What does this pull request do?

- Switch dev env to 100% new cluster
- Remove weights to support 100% switchover instead

## What is the intent behind these changes?

We will switch to the new cluster in one go. This is because the
hmpps-delius-interventions-listener and hmpps-interventions-ui both only
support complete switchovers; so let's do it the same way