### PR TITLE
Schedule past appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.Appointmen
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DeliverySessionService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.validator.AppointmentValidator
+import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.EntityNotFoundException
 
@@ -49,6 +50,7 @@ class DeliverySessionController(
   ): DeliverySessionDTO {
     val user = userMapper.fromToken(authentication)
     appointmentValidator.validateUpdateAppointment(updateAppointmentDTO)
+    val pastAppointment = updateAppointmentDTO.appointmentTime.isBefore(OffsetDateTime.now())
     val deliverySession = deliverySessionService.updateSessionAppointment(
       actionPlanId,
       sessionNumber,
@@ -59,6 +61,11 @@ class DeliverySessionController(
       updateAppointmentDTO.sessionType,
       updateAppointmentDTO.appointmentDeliveryAddress,
       updateAppointmentDTO.npsOfficeCode,
+      updateAppointmentDTO.appointmentAttendance?.attended,
+      updateAppointmentDTO.appointmentAttendance?.additionalAttendanceInformation,
+      updateAppointmentDTO.appointmentBehaviour?.notifyProbationPractitioner,
+      updateAppointmentDTO.appointmentBehaviour?.behaviourDescription,
+      pastAppointment
     )
     return DeliverySessionDTO.from(deliverySession)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.Appointmen
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DeliverySessionService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.validator.AppointmentValidator
-import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.EntityNotFoundException
 
@@ -50,7 +49,6 @@ class DeliverySessionController(
   ): DeliverySessionDTO {
     val user = userMapper.fromToken(authentication)
     appointmentValidator.validateUpdateAppointment(updateAppointmentDTO)
-    val pastAppointment = updateAppointmentDTO.appointmentTime.isBefore(OffsetDateTime.now())
     val deliverySession = deliverySessionService.updateSessionAppointment(
       actionPlanId,
       sessionNumber,
@@ -65,7 +63,6 @@ class DeliverySessionController(
       updateAppointmentDTO.appointmentAttendance?.additionalAttendanceInformation,
       updateAppointmentDTO.appointmentBehaviour?.notifyProbationPractitioner,
       updateAppointmentDTO.appointmentBehaviour?.behaviourDescription,
-      pastAppointment
     )
     return DeliverySessionDTO.from(deliverySession)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.Appointmen
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SupplierAssessmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.validator.AppointmentValidator
-import java.time.OffsetDateTime
 import java.util.UUID
 
 @RestController
@@ -42,7 +41,6 @@ class SupplierAssessmentController(
     val user = userMapper.fromToken(authentication)
     val supplierAssessment = supplierAssessmentService.getSupplierAssessmentById(id)
     appointmentValidator.validateUpdateAppointment(updateAppointmentDTO)
-    val pastAppointment = updateAppointmentDTO.appointmentTime.isBefore(OffsetDateTime.now())
     return AppointmentDTO.from(
       supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(
         supplierAssessment,
@@ -57,7 +55,6 @@ class SupplierAssessmentController(
         updateAppointmentDTO.appointmentAttendance?.additionalAttendanceInformation,
         updateAppointmentDTO.appointmentBehaviour?.notifyProbationPractitioner,
         updateAppointmentDTO.appointmentBehaviour?.behaviourDescription,
-        pastAppointment
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.Appointmen
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SupplierAssessmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.validator.AppointmentValidator
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @RestController
@@ -41,6 +42,7 @@ class SupplierAssessmentController(
     val user = userMapper.fromToken(authentication)
     val supplierAssessment = supplierAssessmentService.getSupplierAssessmentById(id)
     appointmentValidator.validateUpdateAppointment(updateAppointmentDTO)
+    val pastAppointment = updateAppointmentDTO.appointmentTime.isBefore(OffsetDateTime.now())
     return AppointmentDTO.from(
       supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(
         supplierAssessment,
@@ -51,6 +53,11 @@ class SupplierAssessmentController(
         updateAppointmentDTO.sessionType,
         updateAppointmentDTO.appointmentDeliveryAddress,
         updateAppointmentDTO.npsOfficeCode,
+        updateAppointmentDTO.appointmentAttendance?.attended,
+        updateAppointmentDTO.appointmentAttendance?.additionalAttendanceInformation,
+        updateAppointmentDTO.appointmentBehaviour?.notifyProbationPractitioner,
+        updateAppointmentDTO.appointmentBehaviour?.behaviourDescription,
+        pastAppointment
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -34,6 +34,8 @@ data class UpdateAppointmentDTO(
   val sessionType: AppointmentSessionType? = null,
   val appointmentDeliveryAddress: AddressDTO? = null,
   val npsOfficeCode: String? = null,
+  val appointmentAttendance: UpdateAppointmentAttendanceDTO? = null,
+  val appointmentBehaviour: RecordAppointmentBehaviourDTO? = null,
 )
 
 data class DeliverySessionAppointmentScheduleDetailsDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -70,7 +70,8 @@ class AppointmentService(
           attended,
           additionalAttendanceInformation,
           notifyProbationPractitioner,
-          behaviourDescription
+          behaviourDescription,
+          appointmentType
         )
       }
       // the current appointment needs to be updated
@@ -105,7 +106,8 @@ class AppointmentService(
           attended,
           additionalAttendanceInformation,
           notifyProbationPractitioner,
-          behaviourDescription
+          behaviourDescription,
+          appointmentType
         )
       }
       // the appointment has already been attended
@@ -254,6 +256,7 @@ class AppointmentService(
     additionalAttendanceInformation: String?,
     notifyProbationPractitioner: Boolean?,
     behaviourDescription: String?,
+    appointmentType: AppointmentType
   ): Appointment {
     val appointment = Appointment(
       id = UUID.randomUUID(),
@@ -264,7 +267,7 @@ class AppointmentService(
       createdAt = OffsetDateTime.now(),
       referral = referral,
     )
-    setAttendanceAndBehaviourIfHistoricAppointment(appointment, appointmentTime, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser)
+    setAttendanceAndBehaviourIfHistoricAppointment(appointment, appointmentTime, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser, appointmentType)
     appointmentRepository.saveAndFlush(appointment)
     createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
     return appointment
@@ -374,15 +377,15 @@ class AppointmentService(
     additionalAttendanceInformation: String?,
     behaviourDescription: String?,
     notifyProbationPractitioner: Boolean?,
-    updatedBy: AuthUser
+    updatedBy: AuthUser,
+    appointmentType: AppointmentType,
   ) {
     if (appointmentTime.isBefore(OffsetDateTime.now())) {
       setAttendanceFields(appointment, attended!!, additionalAttendanceInformation, updatedBy)
       if (Attended.NO != attended) {
         setBehaviourFields(appointment, behaviourDescription!!, notifyProbationPractitioner!!, updatedBy)
       }
-      appointment.appointmentFeedbackSubmittedAt = OffsetDateTime.now()
-      appointment.appointmentFeedbackSubmittedBy = updatedBy
+      this.submitSessionFeedback(appointment, updatedBy, appointmentType)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -48,10 +48,10 @@ class AppointmentService(
     appointmentSessionType: AppointmentSessionType?,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
-    attended: Attended?,
-    additionalAttendanceInformation: String?,
-    notifyProbationPractitioner: Boolean?,
-    behaviourDescription: String?,
+    attended: Attended? = null,
+    additionalAttendanceInformation: String? = null,
+    notifyProbationPractitioner: Boolean? = null,
+    behaviourDescription: String? = null,
     pastAppointment: Boolean
   ): Appointment {
     val appointment = when {
@@ -149,14 +149,14 @@ class AppointmentService(
     attended: Attended?,
     notifyProbationPractitioner: Boolean?,
     behaviourDescription: String?
-  ){
-    if(attended == null){
+  ) {
+    if (attended == null) {
       throw ValidationException("Missing field 'attended' must be set for past appointment")
     }
-    if(notifyProbationPractitioner == null){
+    if (notifyProbationPractitioner == null) {
       throw ValidationException("Missing field 'notifyProbationPractitioner' must be set for past appointment")
     }
-    if(behaviourDescription == null){
+    if (behaviourDescription == null) {
       throw ValidationException("Missing field 'behaviourDescription' must be set for past appointment")
     }
   }
@@ -236,7 +236,7 @@ class AppointmentService(
     return appointment
   }
 
-   fun setAttendanceFields(
+  fun setAttendanceFields(
     appointment: Appointment,
     attended: Attended,
     additionalInformation: String?,
@@ -248,7 +248,7 @@ class AppointmentService(
     appointment.attendanceSubmittedBy = authUserRepository.save(submittedBy)
   }
 
-   fun setBehaviourFields(
+  fun setBehaviourFields(
     appointment: Appointment,
     behaviour: String,
     notifyProbationPractitioner: Boolean,
@@ -285,7 +285,7 @@ class AppointmentService(
       createdAt = OffsetDateTime.now(),
       referral = referral,
     )
-    if(pastAppointment){
+    if (pastAppointment) {
       setAttendanceFields(appointment, attended!!, additionalAttendanceInformation, createdByUser)
       setBehaviourFields(appointment, behaviourDescription!!, notifyProbationPractitioner!!, createdByUser)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -380,8 +380,8 @@ class AppointmentService(
     updatedBy: AuthUser,
     appointmentType: AppointmentType,
   ) {
-    if (appointmentTime.isBefore(OffsetDateTime.now())) {
-      setAttendanceFields(appointment, attended!!, additionalAttendanceInformation, updatedBy)
+    attended?.let {
+      setAttendanceFields(appointment, attended, additionalAttendanceInformation, updatedBy)
       if (Attended.NO != attended) {
         setBehaviourFields(appointment, behaviourDescription!!, notifyProbationPractitioner!!, updatedBy)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.Communit
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.lang.IllegalStateException
 import java.time.OffsetDateTime
@@ -109,9 +110,12 @@ class CommunityAPIBookingService(
       notes = getNotes(referral, resourceUrl, "${get(appointmentType, notesFieldQualifier)} Appointment"),
       countsTowardsRarDays = get(appointmentType, countsTowardsRarDays),
       attended = attended?.toString(),
-      notifyPPOfAttendanceBehaviour = notifyPPOfAttendanceBehaviour,
+      notifyPPOfAttendanceBehaviour = setNotifyPPIfAttendedNo(attended, notifyPPOfAttendanceBehaviour),
     )
   }
+
+  fun setNotifyPPIfAttendedNo(attended: Attended?, notifyPPOfAttendanceBehaviour: Boolean?) =
+    if (attended == NO) true else notifyPPOfAttendanceBehaviour
 
   private fun buildAppointmentRelocateRequestDTO(npsOfficeCode: String): AppointmentRelocateRequestDTO {
     return AppointmentRelocateRequestDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -316,8 +316,8 @@ class DeliverySessionService(
     notifyProbationPractitioner: Boolean?,
     updatedBy: AuthUser
   ) {
-    if (appointmentTime.isBefore(OffsetDateTime.now())) {
-      setAttendanceFields(appointment, attended!!, additionalAttendanceInformation, updatedBy)
+    attended?.let {
+      setAttendanceFields(appointment, attended, additionalAttendanceInformation, updatedBy)
       if (Attended.NO != attended) {
         setBehaviourFields(appointment, behaviourDescription!!, notifyProbationPractitioner!!, updatedBy)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -24,7 +24,6 @@ import java.util.UUID
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
-import javax.validation.ValidationException
 
 @Service
 @Transactional
@@ -152,10 +151,10 @@ class DeliverySessionService(
     appointmentSessionType: AppointmentSessionType? = null,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
-    attended: Attended?,
-    additionalAttendanceInformation: String?,
-    notifyProbationPractitioner: Boolean?,
-    behaviourDescription: String?,
+    attended: Attended? = null,
+    additionalAttendanceInformation: String? = null,
+    notifyProbationPractitioner: Boolean? = null,
+    behaviourDescription: String? = null,
     pastAppointment: Boolean = false
   ): DeliverySession {
     val session = getDeliverySessionByActionPlanIdOrThrowException(actionPlanId, sessionNumber)
@@ -182,7 +181,7 @@ class DeliverySessionService(
         deliusAppointmentId = deliusAppointmentId,
         referral = session.referral,
       )
-      if(pastAppointment) {
+      if (pastAppointment) {
         setAttendanceFields(appointment, attended!!, additionalAttendanceInformation, updatedBy)
         setBehaviourFields(appointment, behaviourDescription!!, notifyProbationPractitioner!!, updatedBy)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -4,8 +4,14 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.*
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SupplierAssessmentRepository
 import java.time.OffsetDateTime
@@ -42,10 +48,10 @@ class SupplierAssessmentService(
     appointmentSessionType: AppointmentSessionType? = null,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
-    attended: Attended?,
-    additionalAttendanceInformation: String?,
-    notifyProbationPractitioner: Boolean?,
-    behaviourDescription: String?,
+    attended: Attended? = null,
+    additionalAttendanceInformation: String? = null,
+    notifyProbationPractitioner: Boolean? = null,
+    behaviourDescription: String? = null,
     pastAppointment: Boolean = false
   ): Appointment {
     val appointment = appointmentService.createOrUpdateAppointment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -4,13 +4,8 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.*
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SupplierAssessmentRepository
 import java.time.OffsetDateTime
@@ -47,6 +42,11 @@ class SupplierAssessmentService(
     appointmentSessionType: AppointmentSessionType? = null,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String? = null,
+    attended: Attended?,
+    additionalAttendanceInformation: String?,
+    notifyProbationPractitioner: Boolean?,
+    behaviourDescription: String?,
+    pastAppointment: Boolean = false
   ): Appointment {
     val appointment = appointmentService.createOrUpdateAppointment(
       supplierAssessment.referral,
@@ -59,6 +59,11 @@ class SupplierAssessmentService(
       appointmentSessionType,
       appointmentDeliveryAddress,
       npsOfficeCode,
+      attended,
+      additionalAttendanceInformation,
+      notifyProbationPractitioner,
+      behaviourDescription,
+      pastAppointment
     )
     supplierAssessment.appointments.add(appointment)
     supplierAssessmentRepository.save(supplierAssessment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -52,7 +52,6 @@ class SupplierAssessmentService(
     additionalAttendanceInformation: String? = null,
     notifyProbationPractitioner: Boolean? = null,
     behaviourDescription: String? = null,
-    pastAppointment: Boolean = false
   ): Appointment {
     val appointment = appointmentService.createOrUpdateAppointment(
       supplierAssessment.referral,
@@ -68,8 +67,7 @@ class SupplierAssessmentService(
       attended,
       additionalAttendanceInformation,
       notifyProbationPractitioner,
-      behaviourDescription,
-      pastAppointment
+      behaviourDescription
     )
     supplierAssessment.appointments.add(appointment)
     supplierAssessmentRepository.save(supplierAssessment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointm
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import java.time.OffsetDateTime
-import javax.validation.ValidationException
 
 @Component
 class AppointmentValidator {
@@ -33,7 +32,7 @@ class AppointmentValidator {
         }
       }
     }
-    if(updateAppointmentDTO.appointmentTime.isBefore(OffsetDateTime.now())){
+    if (updateAppointmentDTO.appointmentTime.isBefore(OffsetDateTime.now())) {
       verifyPastAppointmentFields(
         updateAppointmentDTO.appointmentAttendance?.attended,
         updateAppointmentDTO.appointmentBehaviour?.notifyProbationPractitioner,
@@ -62,14 +61,14 @@ class AppointmentValidator {
     notifyProbationPractitioner: Boolean?,
     behaviourDescription: String?,
     errors: MutableList<FieldError>
-  ){
-    if(attended == null){
+  ) {
+    if (attended == null) {
       errors.add(FieldError(field = "appointmentAttendance.attended", error = Code.CANNOT_BE_EMPTY))
     }
-    if(notifyProbationPractitioner == null){
+    if (notifyProbationPractitioner == null) {
       errors.add(FieldError(field = "appointmentBehaviour.notifyProbationPractitioner", error = Code.CANNOT_BE_EMPTY))
     }
-    if(behaviourDescription == null){
+    if (behaviourDescription == null) {
       errors.add(FieldError(field = "appointmentBehaviour.behaviourDescription", error = Code.CANNOT_BE_EMPTY))
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -270,5 +270,7 @@ class CommunityAPIClientTest {
     officeLocationCode = "CRSEXTL",
     notes = "http://backLink",
     countsTowardsRarDays = true,
+    attended = null,
+    notifyPPOfAttendanceBehaviour = null,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
@@ -68,7 +68,12 @@ internal class DeliverySessionControllerTest {
         AppointmentDeliveryType.PHONE_CALL,
         AppointmentSessionType.ONE_TO_ONE,
         null,
-        null
+        null,
+        null,
+        null,
+        null,
+        null,
+        true
       )
     ).thenReturn(deliverySession)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
@@ -73,7 +73,7 @@ class SupplierAssessmentControllerTest {
       whenever(userMapper.fromToken(token)).thenReturn(user)
       whenever(referralService.getSentReferralForUser(referral.id, user)).thenReturn(referral)
       whenever(supplierAssessmentService.getSupplierAssessmentById(any())).thenReturn(supplierAssessment)
-      whenever(supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(supplierAssessment, durationInMinutes, appointmentTime, user, appointmentDeliveryType, appointmentSessionType, addressDTO, npsOfficeCode)).thenReturn(supplierAssessment.currentAppointment)
+      whenever(supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(supplierAssessment, durationInMinutes, appointmentTime, user, appointmentDeliveryType, appointmentSessionType, addressDTO, npsOfficeCode, null, null, null, null, true)).thenReturn(supplierAssessment.currentAppointment)
 
       val response = supplierAssessmentController.updateSupplierAssessmentAppointment(referral.id, update, token)
       verify(appointmentValidator).validateUpdateAppointment(eq(update))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentControllerTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.LATE
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SupplierAssessmentService
@@ -73,7 +74,33 @@ class SupplierAssessmentControllerTest {
       whenever(userMapper.fromToken(token)).thenReturn(user)
       whenever(referralService.getSentReferralForUser(referral.id, user)).thenReturn(referral)
       whenever(supplierAssessmentService.getSupplierAssessmentById(any())).thenReturn(supplierAssessment)
-      whenever(supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(supplierAssessment, durationInMinutes, appointmentTime, user, appointmentDeliveryType, appointmentSessionType, addressDTO, npsOfficeCode, null, null, null, null, true)).thenReturn(supplierAssessment.currentAppointment)
+      whenever(supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(supplierAssessment, durationInMinutes, appointmentTime, user, appointmentDeliveryType, appointmentSessionType, addressDTO, npsOfficeCode, null, null, null, null)).thenReturn(supplierAssessment.currentAppointment)
+
+      val response = supplierAssessmentController.updateSupplierAssessmentAppointment(referral.id, update, token)
+      verify(appointmentValidator).validateUpdateAppointment(eq(update))
+      assertThat(response).isNotNull
+    }
+
+    @Test
+    fun `update supplier assessment with new historic appointment`() {
+      val referral = referralFactory.createSent()
+      val durationInMinutes = 60
+      val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+      val appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL
+      val npsOfficeCode = "CRSEXT"
+      val appointmentSessionType = AppointmentSessionType.ONE_TO_ONE
+      val addressDTO = null
+      val attendanceDTO = UpdateAppointmentAttendanceDTO(LATE, "attended")
+      val behaviourDTO = RecordAppointmentBehaviourDTO("behaviour", true)
+      val update = UpdateAppointmentDTO(appointmentTime, durationInMinutes, appointmentDeliveryType, appointmentSessionType, addressDTO, npsOfficeCode, attendanceDTO, behaviourDTO)
+      val user = authUserFactory.create()
+      val token = tokenFactory.create()
+      val supplierAssessment = supplierAssessmentFactory.create()
+
+      whenever(userMapper.fromToken(token)).thenReturn(user)
+      whenever(referralService.getSentReferralForUser(referral.id, user)).thenReturn(referral)
+      whenever(supplierAssessmentService.getSupplierAssessmentById(any())).thenReturn(supplierAssessment)
+      whenever(supplierAssessmentService.createOrUpdateSupplierAssessmentAppointment(supplierAssessment, durationInMinutes, appointmentTime, user, appointmentDeliveryType, appointmentSessionType, addressDTO, npsOfficeCode, LATE, "attended", true, "behaviour")).thenReturn(supplierAssessment.currentAppointment)
 
       val response = supplierAssessmentController.updateSupplierAssessmentAppointment(referral.id, update, token)
       verify(appointmentValidator).validateUpdateAppointment(eq(update))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.YES
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryRepository
@@ -64,7 +63,7 @@ class AppointmentServiceTest {
   fun `can create new appointment with delius office location delivery`() {
     // Given
     val durationInMinutes = 60
-    val appointmentTime = OffsetDateTime.now()
+    val appointmentTime = OffsetDateTime.now().plusHours(1)
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
     val npsOfficeCode = "CRSEXT"
@@ -79,7 +78,7 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = npsOfficeCode, pastAppointment = false)
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = npsOfficeCode)
 
     // Then
     verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode)
@@ -90,7 +89,7 @@ class AppointmentServiceTest {
   fun `create new appointment if none currently exist`() {
     // Given
     val durationInMinutes = 60
-    val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+    val appointmentTime = OffsetDateTime.parse("2022-12-04T10:42:43+00:00")
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
 
@@ -104,11 +103,71 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
     // Then
     verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     verifySavedAppointment(appointmentTime, durationInMinutes, deliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    assertThat(newAppointment.attended).isNull()
+    assertThat(newAppointment.additionalAttendanceInformation).isNull()
+    assertThat(newAppointment.attendanceBehaviour).isNull()
+    assertThat(newAppointment.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(newAppointment.attendanceSubmittedAt).isNull()
+    assertThat(newAppointment.attendanceSubmittedBy).isNull()
+    assertThat(newAppointment.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(newAppointment.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(newAppointment.appointmentFeedbackSubmittedAt).isNull()
+    assertThat(newAppointment.appointmentFeedbackSubmittedBy).isNull()
+  }
+
+  @Test
+  fun `create a historic appointment`() {
+    // Given
+    val durationInMinutes = 60
+    val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+    val referral = referralFactory.createSent()
+    val deliusAppointmentId = 99L
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, YES, false))
+      .thenReturn(deliusAppointmentId)
+    val savedAppointment = appointmentFactory.create(
+      appointmentTime = appointmentTime,
+      durationInMinutes = durationInMinutes,
+      deliusAppointmentId = deliusAppointmentId,
+    )
+    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+
+    // When
+    val newAppointment = appointmentService.createOrUpdateAppointment(
+      referral,
+      null,
+      durationInMinutes,
+      appointmentTime,
+      SUPPLIER_ASSESSMENT,
+      createdByUser,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+      null,
+      null,
+      YES,
+      "additional information",
+      false,
+      "description",
+    )
+
+    // Then
+    verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifySavedAppointment(appointmentTime, durationInMinutes, deliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    assertThat(newAppointment.attended).isEqualTo(YES)
+    assertThat(newAppointment.additionalAttendanceInformation).isEqualTo("additional information")
+    assertThat(newAppointment.attendanceBehaviour).isEqualTo("description")
+    assertThat(newAppointment.notifyPPOfAttendanceBehaviour).isEqualTo(false)
+    assertThat(newAppointment.attendanceSubmittedAt).isNotNull
+    assertThat(newAppointment.attendanceSubmittedBy).isEqualTo(createdByUser)
+    assertThat(newAppointment.attendanceBehaviourSubmittedAt).isNotNull
+    assertThat(newAppointment.attendanceBehaviourSubmittedBy).isEqualTo(createdByUser)
+    assertThat(newAppointment.appointmentFeedbackSubmittedAt).isNotNull
+    assertThat(newAppointment.appointmentFeedbackSubmittedBy).isEqualTo(createdByUser)
   }
 
   @Test
@@ -130,18 +189,28 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
+    val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
     // Then
     verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     verifySavedAppointment(appointmentTime, durationInMinutes, rescheduledDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    assertThat(updatedAppointment.attended).isNull()
+    assertThat(updatedAppointment.additionalAttendanceInformation).isNull()
+    assertThat(updatedAppointment.attendanceBehaviour).isNull()
+    assertThat(updatedAppointment.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(updatedAppointment.attendanceSubmittedAt).isNull()
+    assertThat(updatedAppointment.attendanceSubmittedBy).isNull()
+    assertThat(updatedAppointment.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(updatedAppointment.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(updatedAppointment.appointmentFeedbackSubmittedAt).isNull()
+    assertThat(updatedAppointment.appointmentFeedbackSubmittedBy).isNull()
   }
 
   @Test
   fun `appointment with none attendance will create a new appointment`() {
     // Given
     val durationInMinutes = 60
-    val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+    val appointmentTime = OffsetDateTime.parse("2022-12-04T10:42:43+00:00")
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = NO)
     val referral = referralFactory.createSent()
     val additionalDeliusAppointmentId = 99L
@@ -155,11 +224,60 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
     // Then
     verifyResponse(newAppointment, existingAppointment.id, true, additionalDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     verifySavedAppointment(appointmentTime, durationInMinutes, additionalDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    assertThat(newAppointment.attended).isNull()
+    assertThat(newAppointment.additionalAttendanceInformation).isNull()
+    assertThat(newAppointment.attendanceBehaviour).isNull()
+    assertThat(newAppointment.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(newAppointment.attendanceSubmittedAt).isNull()
+    assertThat(newAppointment.attendanceSubmittedBy).isNull()
+    assertThat(newAppointment.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(newAppointment.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(newAppointment.appointmentFeedbackSubmittedAt).isNull()
+    assertThat(newAppointment.appointmentFeedbackSubmittedBy).isNull()
+  }
+
+  @Test
+  fun `appointment with none attendance will create a new historic appointment`() {
+    // Given
+    val durationInMinutes = 60
+    val appointmentTime = OffsetDateTime.parse("2021-12-04T10:42:43+00:00")
+    val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = NO)
+    val referral = referralFactory.createSent()
+    val additionalDeliusAppointmentId = 99L
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, NO, null)).thenReturn(additionalDeliusAppointmentId)
+    val savedAppointment = appointmentFactory.create(
+      appointmentTime = appointmentTime,
+      durationInMinutes = durationInMinutes,
+      deliusAppointmentId = additionalDeliusAppointmentId,
+      attended = NO,
+      additionalAttendanceInformation = "non attended",
+      attendanceBehaviour = null,
+      notifyPPOfAttendanceBehaviour = null,
+    )
+    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+
+    // When
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
+
+    // Then
+    verifyResponse(newAppointment, existingAppointment.id, true, additionalDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifySavedAppointment(appointmentTime, durationInMinutes, additionalDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    assertThat(newAppointment.attended).isEqualTo(NO)
+    assertThat(newAppointment.additionalAttendanceInformation).isEqualTo("non attended")
+    assertThat(newAppointment.attendanceBehaviour).isNull()
+    assertThat(newAppointment.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(newAppointment.attendanceSubmittedAt).isNotNull
+    assertThat(newAppointment.attendanceSubmittedBy).isEqualTo(createdByUser)
+    assertThat(newAppointment.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(newAppointment.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(newAppointment.appointmentFeedbackSubmittedAt).isNotNull
+    assertThat(newAppointment.appointmentFeedbackSubmittedBy).isEqualTo(createdByUser)
   }
 
   @Test
@@ -167,11 +285,11 @@ class AppointmentServiceTest {
     val durationInMinutes = 60
     val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
     val createdByUser = authUserFactory.create()
-    val appointment = appointmentFactory.create(attended = Attended.YES)
+    val appointment = appointmentFactory.create(attended = YES)
     val referral = referralFactory.createSent()
 
     val error = assertThrows<IllegalStateException> {
-      appointmentService.createOrUpdateAppointment(referral, appointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
+      appointmentService.createOrUpdateAppointment(referral, appointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     }
     assertThat(error.message).contains("Is it not possible to update an appointment that has already been attended")
   }
@@ -231,7 +349,7 @@ class AppointmentServiceTest {
       whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
       // When
-      val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = newNpsCode, pastAppointment = false)
+      val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = newNpsCode)
 
       // Then
       verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, newNpsCode)
@@ -286,7 +404,7 @@ class AppointmentServiceTest {
     @Test
     fun `appointment attendance can be updated`() {
       val appointmentId = UUID.randomUUID()
-      val attended = Attended.YES
+      val attended = YES
       val additionalAttendanceInformation = "information"
       val appointment = appointmentFactory.create(id = appointmentId)
       val submittedBy = authUserFactory.create()
@@ -310,7 +428,7 @@ class AppointmentServiceTest {
     @Test
     fun `appointment attendance cannot be updated if feedback has been submitted`() {
       val appointmentId = UUID.randomUUID()
-      val attended = Attended.YES
+      val attended = YES
       val additionalAttendanceInformation = "information"
       val submittedBy = authUserFactory.create()
       val feedbackSubmittedAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDelivery
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SUPPLIER_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.YES
@@ -158,6 +159,9 @@ class AppointmentServiceTest {
     // Then
     verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     verifySavedAppointment(appointmentTime, durationInMinutes, deliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verify(appointmentEventPublisher).attendanceRecordedEvent(newAppointment, false, AppointmentType.SUPPLIER_ASSESSMENT)
+    verify(appointmentEventPublisher).behaviourRecordedEvent(newAppointment, false, AppointmentType.SUPPLIER_ASSESSMENT)
+    verify(appointmentEventPublisher).sessionFeedbackRecordedEvent(newAppointment, false, AppointmentType.SUPPLIER_ASSESSMENT)
     assertThat(newAppointment.attended).isEqualTo(YES)
     assertThat(newAppointment.additionalAttendanceInformation).isEqualTo("additional information")
     assertThat(newAppointment.attendanceBehaviour).isEqualTo("description")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -79,7 +79,7 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = npsOfficeCode)
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = npsOfficeCode, pastAppointment = false)
 
     // Then
     verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode)
@@ -104,7 +104,7 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
 
     // Then
     verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -130,7 +130,7 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
 
     // Then
     verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -155,7 +155,7 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
 
     // Then
     verifyResponse(newAppointment, existingAppointment.id, true, additionalDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -171,7 +171,7 @@ class AppointmentServiceTest {
     val referral = referralFactory.createSent()
 
     val error = assertThrows<IllegalStateException> {
-      appointmentService.createOrUpdateAppointment(referral, appointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+      appointmentService.createOrUpdateAppointment(referral, appointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, pastAppointment = false)
     }
     assertThat(error.message).contains("Is it not possible to update an appointment that has already been attended")
   }
@@ -231,7 +231,7 @@ class AppointmentServiceTest {
       whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
       // When
-      val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = newNpsCode)
+      val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = newNpsCode, pastAppointment = false)
 
       // Then
       verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, newNpsCode)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -79,7 +79,9 @@ internal class CommunityAPIBookingServiceTest {
       now.plusMinutes(120),
       "CRS0001",
       notes = notes,
-      true
+      true,
+      null,
+      null
     )
     val response = AppointmentResponseDTO(1234L)
 
@@ -107,7 +109,9 @@ internal class CommunityAPIBookingServiceTest {
       now.plusMinutes(120),
       "CRSEXTL",
       notes = notes,
-      true
+      true,
+      null,
+      null
     )
     val response = AppointmentResponseDTO(1234L)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -13,6 +13,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType.SERVICE_DELIVERY
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.LATE
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.YES
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentDeliveryFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
@@ -64,64 +67,142 @@ internal class CommunityAPIBookingServiceTest {
     communityAPIClient
   )
 
-  @Test
-  fun `requests booking for a new appointment`() {
-    val now = now()
+  @Nested
+  inner class BookingAppointment {
 
-    val uri = "/appt/X1/123/CRS"
-    val notes = "Service Delivery Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
-      "http://url/pp/${referral.id}/progress"
-    val request = AppointmentCreateRequestDTO(
-      "ACC",
-      referral.sentAt!!,
-      referral.id,
-      now.plusMinutes(60),
-      now.plusMinutes(120),
-      "CRS0001",
-      notes = notes,
-      true,
-      null,
-      null
-    )
-    val response = AppointmentResponseDTO(1234L)
+    @Test
+    fun `requests booking for a new appointment`() {
+      val now = now()
 
-    whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
-      .thenReturn(response)
+      val uri = "/appt/X1/123/CRS"
+      val notes = "Service Delivery Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
+        "http://url/pp/${referral.id}/progress"
+      val request = AppointmentCreateRequestDTO(
+        "ACC",
+        referral.sentAt!!,
+        referral.id,
+        now.plusMinutes(60),
+        now.plusMinutes(120),
+        "CRS0001",
+        notes = notes,
+        true,
+        null,
+        null
+      )
+      val response = AppointmentResponseDTO(1234L)
 
-    val deliusAppointmentId = communityAPIBookingService.book(referral, null, now.plusMinutes(60), 60, SERVICE_DELIVERY, "CRS0001")
+      whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
+        .thenReturn(response)
 
-    assertThat(deliusAppointmentId).isEqualTo(1234L)
-    verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
-  }
+      val deliusAppointmentId = communityAPIBookingService.book(referral, null, now.plusMinutes(60), 60, SERVICE_DELIVERY, "CRS0001", null, null)
 
-  @Test
-  fun `requests booking for a new appointment with a office location uses default`() {
-    val now = now()
+      assertThat(deliusAppointmentId).isEqualTo(1234L)
+      verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+    }
 
-    val uri = "/appt/X1/123/CRS"
-    val notes = "Service Delivery Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
-      "http://url/pp/${referral.id}/progress"
-    val request = AppointmentCreateRequestDTO(
-      "ACC",
-      referral.sentAt!!,
-      referral.id,
-      now.plusMinutes(60),
-      now.plusMinutes(120),
-      "CRSEXTL",
-      notes = notes,
-      true,
-      null,
-      null
-    )
-    val response = AppointmentResponseDTO(1234L)
+    @Test
+    fun `requests booking for a new appointment with a office location uses default`() {
+      val now = now()
 
-    whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
-      .thenReturn(response)
+      val uri = "/appt/X1/123/CRS"
+      val notes = "Service Delivery Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
+        "http://url/pp/${referral.id}/progress"
+      val request = AppointmentCreateRequestDTO(
+        "ACC",
+        referral.sentAt!!,
+        referral.id,
+        now.plusMinutes(60),
+        now.plusMinutes(120),
+        "CRSEXTL",
+        notes = notes,
+        true,
+        null,
+        null
+      )
+      val response = AppointmentResponseDTO(1234L)
 
-    val deliusAppointmentId = communityAPIBookingService.book(referral, null, now.plusMinutes(60), 60, SERVICE_DELIVERY, null)
+      whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
+        .thenReturn(response)
 
-    assertThat(deliusAppointmentId).isEqualTo(1234L)
-    verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+      val deliusAppointmentId = communityAPIBookingService.book(referral, null, now.plusMinutes(60), 60, SERVICE_DELIVERY, null, null, null)
+
+      assertThat(deliusAppointmentId).isEqualTo(1234L)
+      verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+    }
+
+    @Test
+    fun `requests booking for a new historic appointment with attendance and behaviour`() {
+      val now = now()
+
+      val uri = "/appt/X1/123/CRS"
+      val notes = "Service Delivery Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
+        "http://url/pp/${referral.id}/progress"
+      val request = AppointmentCreateRequestDTO(
+        "ACC",
+        referral.sentAt!!,
+        referral.id,
+        now.plusMinutes(60),
+        now.plusMinutes(120),
+        "CRSEXTL",
+        notes = notes,
+        true,
+        "YES",
+        true
+      )
+      val response = AppointmentResponseDTO(1234L)
+
+      whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
+        .thenReturn(response)
+
+      val deliusAppointmentId = communityAPIBookingService.book(referral, null, now.plusMinutes(60), 60, SERVICE_DELIVERY, null, YES, true)
+
+      assertThat(deliusAppointmentId).isEqualTo(1234L)
+      verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+    }
+
+    @Test
+    fun `requests booking for a new historic appointment with non attendance resulting notifying the PP`() {
+      val now = now()
+
+      val uri = "/appt/X1/123/CRS"
+      val notes = "Service Delivery Appointment for Accommodation Referral XX123456 with Prime Provider SPN\n" +
+        "http://url/pp/${referral.id}/progress"
+      val request = AppointmentCreateRequestDTO(
+        "ACC",
+        referral.sentAt!!,
+        referral.id,
+        now.plusMinutes(60),
+        now.plusMinutes(120),
+        "CRSEXTL",
+        notes = notes,
+        true,
+        "NO",
+        true
+      )
+      val response = AppointmentResponseDTO(1234L)
+
+      whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
+        .thenReturn(response)
+
+      val deliusAppointmentId = communityAPIBookingService.book(referral, null, now.plusMinutes(60), 60, SERVICE_DELIVERY, null, NO, null)
+
+      assertThat(deliusAppointmentId).isEqualTo(1234L)
+      verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+    }
+
+    @Test
+    fun `set notify PP if PoP does not attend`() {
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(NO, null)).isTrue
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(NO, false)).isTrue
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(NO, true)).isTrue
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(YES, null)).isNull()
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(YES, false)).isFalse
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(YES, true)).isTrue
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(LATE, null)).isNull()
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(LATE, false)).isFalse
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(LATE, true)).isTrue
+      assertThat(communityAPIBookingService.setNotifyPPIfAttendedNo(null, null)).isNull()
+    }
   }
 
   @Nested
@@ -140,7 +221,7 @@ internal class CommunityAPIBookingServiceTest {
       whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
         .thenReturn(response)
 
-      communityAPIBookingService.book(referral, appointment, now, 45, SERVICE_DELIVERY, null)
+      communityAPIBookingService.book(referral, appointment, now, 45, SERVICE_DELIVERY, null, null, null)
 
       verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
     }
@@ -160,7 +241,7 @@ internal class CommunityAPIBookingServiceTest {
       whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
         .thenReturn(response)
 
-      communityAPIBookingService.book(referral, existingAppointment, now, 45, SERVICE_DELIVERY, "NEW_CODE")
+      communityAPIBookingService.book(referral, existingAppointment, now, 45, SERVICE_DELIVERY, "NEW_CODE", null, null)
 
       verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
     }
@@ -171,7 +252,7 @@ internal class CommunityAPIBookingServiceTest {
       val deliusAppointmentId = 999L
       val appointment = makeAppointment(now, now.plusDays(1), 60, deliusAppointmentId)
 
-      communityAPIBookingService.book(referral, appointment, now.plusDays(1), 60, SERVICE_DELIVERY, null)
+      communityAPIBookingService.book(referral, appointment, now.plusDays(1), 60, SERVICE_DELIVERY, null, null, null)
 
       verifyNoMoreInteractions(communityAPIClient)
     }
@@ -193,7 +274,7 @@ internal class CommunityAPIBookingServiceTest {
       val appointmentDelivery = appointmentDeliveryFactory.create(existingAppointment.id, npsOfficeCode = "NPS_CODE", appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE)
       existingAppointment.appointmentDelivery = appointmentDelivery
 
-      communityAPIBookingService.book(referral, existingAppointment, now.plusDays(1), 60, SERVICE_DELIVERY, "NPS_CODE")
+      communityAPIBookingService.book(referral, existingAppointment, now.plusDays(1), 60, SERVICE_DELIVERY, "NPS_CODE", null, null)
 
       verifyNoMoreInteractions(communityAPIClient)
     }
@@ -215,7 +296,7 @@ internal class CommunityAPIBookingServiceTest {
         whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
           .thenReturn(response)
 
-        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, "NEW_CODE")
+        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, "NEW_CODE", null, null)
 
         verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
       }
@@ -235,7 +316,7 @@ internal class CommunityAPIBookingServiceTest {
         whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
           .thenReturn(response)
 
-        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, "NEW_CODE")
+        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, "NEW_CODE", null, null)
 
         verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
       }
@@ -255,7 +336,7 @@ internal class CommunityAPIBookingServiceTest {
         whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
           .thenReturn(response)
 
-        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, crsOfficeLocation)
+        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, crsOfficeLocation, null, null)
 
         verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
       }
@@ -268,7 +349,7 @@ internal class CommunityAPIBookingServiceTest {
         val appointmentDelivery = appointmentDeliveryFactory.create(existingAppointment.id, appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL)
         existingAppointment.appointmentDelivery = appointmentDelivery
 
-        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, null)
+        communityAPIBookingService.book(referral, existingAppointment, now, 60, SERVICE_DELIVERY, null, null, null)
 
         verifyNoMoreInteractions(communityAPIClient)
       }
@@ -294,7 +375,7 @@ internal class CommunityAPIBookingServiceTest {
       communityAPIClient
     )
 
-    val deliusAppointmentId = communityAPIBookingServiceNotEnabled.book(referral, appointment, now(), 60, SERVICE_DELIVERY, null)
+    val deliusAppointmentId = communityAPIBookingServiceNotEnabled.book(referral, appointment, now(), 60, SERVICE_DELIVERY, null, null, null)
 
     assertThat(deliusAppointmentId).isNull()
     verifyZeroInteractions(communityAPIClient)
@@ -319,7 +400,7 @@ internal class CommunityAPIBookingServiceTest {
       communityAPIClient
     )
 
-    val deliusAppointmentId = communityAPIBookingServiceNotEnabled.book(referral, appointment, now(), 60, SERVICE_DELIVERY, null)
+    val deliusAppointmentId = communityAPIBookingServiceNotEnabled.book(referral, appointment, now(), 60, SERVICE_DELIVERY, null, null, null)
 
     assertThat(deliusAppointmentId).isEqualTo(1234L)
     verifyZeroInteractions(communityAPIClient)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -77,7 +77,7 @@ class DeliverySessionServiceTest @Autowired constructor(
       val session = deliverySessionFactory.createUnscheduled()
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(session.referral.id, session.sessionNumber, defaultAppointmentTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
-      verify(communityAPIBookingService).book(eq(session.referral), isNull(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull())
+      verify(communityAPIBookingService).book(eq(session.referral), isNull(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
       verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
@@ -94,7 +94,7 @@ class DeliverySessionServiceTest @Autowired constructor(
       val newTime = existingAppointment.appointmentTime.plusHours(1)
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(session.referral.id, session.sessionNumber, newTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
-      verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull())
+      verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
       verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), any(), any(), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(2)
@@ -146,7 +146,7 @@ class DeliverySessionServiceTest @Autowired constructor(
       val newTime = existingAppointment.appointmentTime.plusHours(1)
       val updatedSession = deliverySessionService.rescheduleDeliverySessionAppointment(session.referral.id, session.sessionNumber, existingAppointment.id, newTime, 2, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
-      verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull())
+      verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
       verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), any(), any(), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -141,7 +141,7 @@ internal class DeliverySessionsServiceTest {
   }
 
   @Test
-  fun `updates session appointment for a historic appointment`() {
+  fun `create session appointment for a historic appointment`() {
     val session = deliverySessionFactory.createUnscheduled()
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = session.sessionNumber
@@ -169,6 +169,9 @@ internal class DeliverySessionsServiceTest {
     )
 
     verify(appointmentService, times(1)).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), isNull(), isNull())
+    verify(actionPlanAppointmentEventPublisher).attendanceRecordedEvent(updatedSession, false)
+    verify(actionPlanAppointmentEventPublisher).behaviourRecordedEvent(updatedSession, false)
+    verify(actionPlanAppointmentEventPublisher).sessionFeedbackRecordedEvent(updatedSession, false)
     assertThat(updatedSession.currentAppointment?.appointmentTime).isEqualTo(appointmentTime)
     assertThat(updatedSession.currentAppointment?.durationInMinutes).isEqualTo(durationInMinutes)
     assertThat(updatedSession.currentAppointment?.createdBy?.userName).isEqualTo("scheduler")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -111,7 +111,7 @@ internal class DeliverySessionsServiceTest {
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
     whenever(deliverySessionRepository.save(any())).thenReturn(session)
 
-    val appointmentTime = OffsetDateTime.now()
+    val appointmentTime = OffsetDateTime.now().plusHours(1)
     val durationInMinutes = 200
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
@@ -128,6 +128,102 @@ internal class DeliverySessionsServiceTest {
     assertThat(updatedSession.currentAppointment?.appointmentTime).isEqualTo(appointmentTime)
     assertThat(updatedSession.currentAppointment?.durationInMinutes).isEqualTo(durationInMinutes)
     assertThat(updatedSession.currentAppointment?.createdBy?.userName).isEqualTo("scheduler")
+    assertThat(updatedSession.currentAppointment?.attended).isNull()
+    assertThat(updatedSession.currentAppointment?.additionalAttendanceInformation).isNull()
+    assertThat(updatedSession.currentAppointment?.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviour).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedAt).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedBy).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedAt).isNull()
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedBy).isNull()
+  }
+
+  @Test
+  fun `updates session appointment for a historic appointment`() {
+    val session = deliverySessionFactory.createUnscheduled()
+    val actionPlanId = UUID.randomUUID()
+    val sessionNumber = session.sessionNumber
+    val user = createActor("scheduler")
+
+    whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
+    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+
+    val appointmentTime = OffsetDateTime.now()
+    val durationInMinutes = 200
+    val updatedSession = deliverySessionsService.updateSessionAppointment(
+      actionPlanId,
+      sessionNumber,
+      appointmentTime,
+      durationInMinutes,
+      user,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+      null,
+      null,
+      Attended.YES,
+      "additional information",
+      false,
+      "description"
+    )
+
+    verify(appointmentService, times(1)).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), isNull(), isNull())
+    assertThat(updatedSession.currentAppointment?.appointmentTime).isEqualTo(appointmentTime)
+    assertThat(updatedSession.currentAppointment?.durationInMinutes).isEqualTo(durationInMinutes)
+    assertThat(updatedSession.currentAppointment?.createdBy?.userName).isEqualTo("scheduler")
+    assertThat(updatedSession.currentAppointment?.attended).isEqualTo(Attended.YES)
+    assertThat(updatedSession.currentAppointment?.additionalAttendanceInformation).isEqualTo("additional information")
+    assertThat(updatedSession.currentAppointment?.notifyPPOfAttendanceBehaviour).isEqualTo(false)
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviour).isEqualTo("description")
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedAt).isNotNull
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedBy).isNotNull
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedAt).isNotNull
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedBy).isNotNull
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedAt).isNotNull
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedBy).isNotNull
+  }
+
+  @Test
+  fun `updates session appointment for a historic appointment non attended`() {
+    val session = deliverySessionFactory.createUnscheduled()
+    val actionPlanId = UUID.randomUUID()
+    val sessionNumber = session.sessionNumber
+    val user = createActor("scheduler")
+
+    whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
+    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+
+    val appointmentTime = OffsetDateTime.now()
+    val durationInMinutes = 200
+    val updatedSession = deliverySessionsService.updateSessionAppointment(
+      actionPlanId,
+      sessionNumber,
+      appointmentTime,
+      durationInMinutes,
+      user,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+      null,
+      null,
+      Attended.NO,
+      "additional information"
+    )
+
+    verify(appointmentService, times(1)).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), isNull(), isNull())
+    assertThat(updatedSession.currentAppointment?.appointmentTime).isEqualTo(appointmentTime)
+    assertThat(updatedSession.currentAppointment?.durationInMinutes).isEqualTo(durationInMinutes)
+    assertThat(updatedSession.currentAppointment?.createdBy?.userName).isEqualTo("scheduler")
+    assertThat(updatedSession.currentAppointment?.attended).isEqualTo(Attended.NO)
+    assertThat(updatedSession.currentAppointment?.additionalAttendanceInformation).isEqualTo("additional information")
+    assertThat(updatedSession.currentAppointment?.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviour).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedAt).isNotNull
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedBy).isEqualTo(user)
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedAt).isNotNull
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedBy).isEqualTo(user)
   }
 
   @Test
@@ -159,6 +255,15 @@ internal class DeliverySessionsServiceTest {
     assertThat(updatedSession.currentAppointment?.appointmentTime).isEqualTo(newTime)
     assertThat(updatedSession.currentAppointment?.durationInMinutes).isEqualTo(newDuration)
     assertThat(updatedSession.currentAppointment?.createdBy?.userName).isNotEqualTo("re-scheduler")
+    assertThat(updatedSession.currentAppointment?.attended).isNull()
+    assertThat(updatedSession.currentAppointment?.additionalAttendanceInformation).isNull()
+    assertThat(updatedSession.currentAppointment?.notifyPPOfAttendanceBehaviour).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviour).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedAt).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceSubmittedBy).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedAt).isNull()
+    assertThat(updatedSession.currentAppointment?.attendanceBehaviourSubmittedBy).isNull()
+    assertThat(updatedSession.currentAppointment?.appointmentFeedbackSubmittedAt).isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
@@ -86,6 +86,11 @@ class SupplierAssessmentServiceTest {
           eq(appointmentSessionType),
           isNull(),
           isNull(),
+          isNull(),
+          isNull(),
+          isNull(),
+          isNull(),
+          eq(false)
         )
       ).thenReturn(appointment)
       whenever(supplierAssessmentRepository.save(any())).thenReturn(supplierAssessment)
@@ -117,6 +122,11 @@ class SupplierAssessmentServiceTest {
           eq(appointmentSessionType),
           isNull(),
           eq(npsOfficeCode),
+          isNull(),
+          isNull(),
+          isNull(),
+          isNull(),
+          eq(false)
         )
       ).thenReturn(appointment)
       whenever(supplierAssessmentRepository.save(any())).thenReturn(supplierAssessment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
@@ -90,7 +90,6 @@ class SupplierAssessmentServiceTest {
           isNull(),
           isNull(),
           isNull(),
-          eq(false)
         )
       ).thenReturn(appointment)
       whenever(supplierAssessmentRepository.save(any())).thenReturn(supplierAssessment)
@@ -126,7 +125,6 @@ class SupplierAssessmentServiceTest {
           isNull(),
           isNull(),
           isNull(),
-          eq(false)
         )
       ).thenReturn(appointment)
       whenever(supplierAssessmentRepository.save(any())).thenReturn(supplierAssessment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
@@ -25,14 +25,14 @@ internal class AppointmentValidatorTest {
     inner class DeliusOfficeLocationAppointment {
       @Test
       fun `can request valid a delius office appointment`() {
-        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, sessionType = AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = "CRSEXT")
+        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusDays(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, sessionType = AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = "CRSEXT")
         assertDoesNotThrow {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }
       }
       @Test
       fun `an empty delius office location throws validation error`() {
-        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, sessionType = AppointmentSessionType.ONE_TO_ONE)
+        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusDays(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, sessionType = AppointmentSessionType.ONE_TO_ONE)
         var exception = assertThrows<ValidationError> {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }
@@ -46,7 +46,7 @@ internal class AppointmentValidatorTest {
     inner class OtherLocationAppointment {
       @Test
       fun `can request valid non nps office appointment`() {
-        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("firstline", "secondLine", "town", "county", "A1 1AA"))
+        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusHours(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("firstline", "secondLine", "town", "county", "A1 1AA"))
         assertDoesNotThrow {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }
@@ -54,7 +54,7 @@ internal class AppointmentValidatorTest {
 
       @Test
       fun `can request valid non nps office appointment with null values for optional fields`() {
-        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("firstline", null, null, null, "A1 1AA"))
+        val updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusHours(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("firstline", null, null, null, "A1 1AA"))
         assertDoesNotThrow {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }
@@ -64,7 +64,7 @@ internal class AppointmentValidatorTest {
       inner class PostCodeValidation {
 
         private fun createUpdateAppointmentDTO(postCode: String): UpdateAppointmentDTO {
-          return UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("firstline", "secondLine", "town", "county", postCode))
+          return UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusHours(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("firstline", "secondLine", "town", "county", postCode))
         }
         @Test
         fun `can request valid non nps office appointment for various postcodes`() {
@@ -91,7 +91,7 @@ internal class AppointmentValidatorTest {
 
       @Test
       fun `empty address for non nps office appointment throws validation error`() {
-        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = null)
+        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusHours(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = null)
         var exception = assertThrows<ValidationError> {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }
@@ -103,7 +103,7 @@ internal class AppointmentValidatorTest {
 
       @Test
       fun `empty address fields for non nps office appointment throws validation error`() {
-        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now(), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("", "", "", "", ""))
+        var updateAppointmentDTO = UpdateAppointmentDTO(appointmentTime = OffsetDateTime.now().plusHours(1), durationInMinutes = 1, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_OTHER, sessionType = AppointmentSessionType.ONE_TO_ONE, appointmentDeliveryAddress = AddressDTO("", "", "", "", ""))
         var exception = assertThrows<ValidationError> {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }


### PR DESCRIPTION
## What does this pull request do?

Allows appointments for both saa and delivery sessions to be scheduled in the past.

## What is the intent behind these changes?

An appointment may already have happened so there needs to be the ability to schedule and add appointment information for historic appointments
