### PR TITLE
Unblock deploy: 🐛 Validate helm with the new dev environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,9 @@ workflows:
           requires:
             - build_docker
             - build_and_publish_docker
-      - validate_helm
+      - validate_helm:
+          context:
+            - hmpps-interventions-dev-deploy
       - hmpps/build_docker:
           name: build_and_publish_docker
           <<: *snyk_options


### PR DESCRIPTION

## What does this pull request do?

Unblocks deployments by
🐛 Fix: validate helm with the new dev environment

## What is the intent behind these changes?

The live-1 dev namespace is now deleted, which fails the `validate_helm` job as it's trying to `kubectl apply --dry-run=server` with the old namespace

The intent of `validate_helm` is to apply the helm configuration (without Service and Ingress resources) on the development namespace to detect any issues with syntax and semantics. Perhaps we could revert to the standard `helm_lint` as well...