### PR TITLE
Split supplier assessment into schedule/reschedule

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -30,6 +30,7 @@ class SupplierAssessmentController(
   private val appointmentValidator: AppointmentValidator,
   private val appointmentService: AppointmentService,
 ) {
+
   @PutMapping("/supplier-assessment/{id}/schedule-appointment")
   fun updateSupplierAssessmentAppointment(
     @PathVariable id: UUID,
@@ -51,6 +52,26 @@ class SupplierAssessmentController(
         updateAppointmentDTO.npsOfficeCode,
       )
     )
+  }
+
+  @PostMapping("/referral/{referralId}/supplier-assessment")
+  fun scheduleSupplierAssessmentAppointment(
+    @PathVariable referralId: UUID,
+    @RequestBody updateAppointmentDTO: UpdateAppointmentDTO,
+    authentication: JwtAuthenticationToken,
+  ): AppointmentDTO {
+    val user = userMapper.fromToken(authentication)
+    appointmentValidator.validateUpdateAppointment(updateAppointmentDTO)
+    val appointment = supplierAssessmentService.scheduleNewSupplierAssessmentAppointment(
+      referralId,
+      updateAppointmentDTO.durationInMinutes,
+      updateAppointmentDTO.appointmentTime,
+      user,
+      updateAppointmentDTO.appointmentDeliveryType,
+      updateAppointmentDTO.appointmentDeliveryAddress,
+      updateAppointmentDTO.npsOfficeCode
+    )
+    return AppointmentDTO.from(appointment)
   }
 
   @PutMapping("/referral/{referralId}/supplier-assessment/record-behaviour")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -31,6 +31,7 @@ class SupplierAssessmentController(
   private val appointmentService: AppointmentService,
 ) {
 
+  @Deprecated("superseded by POST /referral/{referralId}/supplier-assessment and PUT /referral/{referralId}/supplier-assessment/{appointmentId}")
   @PutMapping("/supplier-assessment/{id}/schedule-appointment")
   fun updateSupplierAssessmentAppointment(
     @PathVariable id: UUID,
@@ -68,6 +69,29 @@ class SupplierAssessmentController(
       updateAppointmentDTO.appointmentTime,
       user,
       updateAppointmentDTO.appointmentDeliveryType,
+      updateAppointmentDTO.appointmentDeliveryAddress,
+      updateAppointmentDTO.npsOfficeCode
+    )
+    return AppointmentDTO.from(appointment)
+  }
+
+  @PutMapping("/referral/{referralId}/supplier-assessment/{appointmentId}")
+  fun rescheduleSupplierAssessmentAppointment(
+    @PathVariable referralId: UUID,
+    @PathVariable appointmentId: UUID,
+    @RequestBody updateAppointmentDTO: UpdateAppointmentDTO,
+    authentication: JwtAuthenticationToken,
+  ): AppointmentDTO {
+    val user = userMapper.fromToken(authentication)
+    appointmentValidator.validateUpdateAppointment(updateAppointmentDTO)
+    val appointment = supplierAssessmentService.rescheduleSupplierAssessmentAppointment(
+      referralId,
+      appointmentId,
+      updateAppointmentDTO.durationInMinutes,
+      updateAppointmentDTO.appointmentTime,
+      user,
+      updateAppointmentDTO.appointmentDeliveryType,
+      updateAppointmentDTO.sessionType,
       updateAppointmentDTO.appointmentDeliveryAddress,
       updateAppointmentDTO.npsOfficeCode
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -17,8 +17,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.time.OffsetDateTime
 import java.util.UUID
+import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
 
 @Service
@@ -29,6 +31,7 @@ class AppointmentService(
   val appointmentDeliveryRepository: AppointmentDeliveryRepository,
   val authUserRepository: AuthUserRepository,
   val appointmentEventPublisher: AppointmentEventPublisher,
+  val referralRepository: ReferralRepository,
 ) {
 
   // TODO complexity of this method can be reduced
@@ -289,5 +292,36 @@ class AppointmentService(
       appointmentDeliveryAddress.postCode = appointmentDeliveryAddressDTO.postCode
     }
     return appointmentDeliveryAddress
+  }
+
+  fun scheduleNewAppointment(
+    sentReferralId: UUID,
+    appointmentType: AppointmentType,
+    durationInMinutes: Int,
+    appointmentTime: OffsetDateTime,
+    createdByUser: AuthUser,
+    appointmentDeliveryType: AppointmentDeliveryType,
+    appointmentSessionType: AppointmentSessionType,
+    appointmentDeliveryAddress: AddressDTO? = null,
+    npsOfficeCode: String? = null,
+  ): Appointment {
+    val sentReferral = referralRepository.findByIdAndSentAtIsNotNull(sentReferralId) ?: throw EntityNotFoundException(
+      "Sent Referral not found [referralId=$sentReferralId]"
+    )
+    val deliusAppointmentId =
+      communityAPIBookingService.book(sentReferral, null, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode)
+    val appointment = Appointment(
+      id = UUID.randomUUID(),
+      appointmentTime = appointmentTime,
+      durationInMinutes = durationInMinutes,
+      deliusAppointmentId = deliusAppointmentId,
+      createdBy = authUserRepository.save(createdByUser),
+      createdAt = OffsetDateTime.now(),
+      referral = sentReferral,
+    )
+    appointmentRepository.saveAndFlush(appointment)
+    createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
+    appointmentEventPublisher.appointmentScheduledEvent(appointment, appointmentType)
+    return appointment
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SupplierAssessmentRepository
 import java.time.OffsetDateTime
 import java.util.UUID
+import javax.persistence.EntityExistsException
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
 
@@ -55,6 +57,47 @@ class SupplierAssessmentService(
       createdByUser,
       appointmentDeliveryType,
       appointmentSessionType,
+      appointmentDeliveryAddress,
+      npsOfficeCode,
+    )
+    supplierAssessment.appointments.add(appointment)
+    supplierAssessmentRepository.save(supplierAssessment)
+    return appointment
+  }
+
+  fun scheduleNewSupplierAssessmentAppointment(
+    referralId: UUID,
+    durationInMinutes: Int,
+    appointmentTime: OffsetDateTime,
+    createdByUser: AuthUser,
+    appointmentDeliveryType: AppointmentDeliveryType,
+    appointmentDeliveryAddress: AddressDTO? = null,
+    npsOfficeCode: String? = null,
+  ): Appointment {
+
+    val sentReferral = referralRepository.findByIdAndSentAtIsNotNull(referralId) ?: throw EntityNotFoundException("Sent Referral not found [referralId=$referralId]")
+    val supplierAssessment = sentReferral.supplierAssessment ?: run {
+      SupplierAssessment(
+        id = UUID.randomUUID(),
+        referral = sentReferral,
+      )
+    }
+    supplierAssessment.currentAppointment?.let {
+      latestAppointment ->
+      if (latestAppointment.appointmentTime.isAfter(appointmentTime)) {
+        throw EntityExistsException("can't schedule new supplier assessment appointment; new appointment occurs before previously scheduled appointment [referralId=$referralId]")
+      }
+      latestAppointment.appointmentFeedbackSubmittedAt ?: throw ValidationError("can't schedule new supplier assessment appointment; latest appointment has no feedback delivered [referralId=$referralId]", listOf())
+    }
+    val appointment = appointmentService.scheduleNewAppointment(
+      sentReferral.id,
+      SUPPLIER_ASSESSMENT,
+      durationInMinutes,
+      appointmentTime,
+      createdByUser,
+      appointmentDeliveryType,
+      // Supplier assessment is always ONE_TO_ONE
+      AppointmentSessionType.ONE_TO_ONE,
       appointmentDeliveryAddress,
       npsOfficeCode,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceRepositoryTest.kt
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.EntityNotFoundException
+
+@RepositoryTest
+class AppointmentServiceRepositoryTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val appointmentRepository: AppointmentRepository,
+  val appointmentDeliveryRepository: AppointmentDeliveryRepository,
+  val authUserRepository: AuthUserRepository,
+  val referralRepository: ReferralRepository,
+) {
+
+  private val communityAPIBookingService: CommunityAPIBookingService = mock()
+  private val appointmentEventPublisher: AppointmentEventPublisher = mock()
+
+  private val appointmentService = AppointmentService(
+    appointmentRepository,
+    communityAPIBookingService,
+    appointmentDeliveryRepository,
+    authUserRepository,
+    appointmentEventPublisher,
+    referralRepository,
+  )
+
+  private val userFactory = AuthUserFactory(entityManager)
+  private val referralFactory = ReferralFactory(entityManager)
+
+  val defaultDuration = 1
+  val defaultAppointmentTime = OffsetDateTime.now()
+
+  lateinit var defaultUser: AuthUser
+
+  @BeforeEach
+  fun beforeEach() {
+    defaultUser = userFactory.create()
+  }
+
+  @Nested
+  inner class ScheduleNewAppointment {
+
+    @Test
+    fun `can schedule new appointment`() {
+      val referral = referralFactory.createSent()
+      val appointment = appointmentService.scheduleNewAppointment(
+        referral.id,
+        AppointmentType.SUPPLIER_ASSESSMENT,
+        defaultDuration,
+        defaultAppointmentTime,
+        defaultUser,
+        AppointmentDeliveryType.PHONE_CALL,
+        AppointmentSessionType.ONE_TO_ONE,
+      )
+
+      Assertions.assertThat(appointment).isNotNull
+    }
+
+    @Test
+    fun `expect failure when sent referral does not exist`() {
+      val referralId = UUID.randomUUID()
+      val error = assertThrows<EntityNotFoundException> {
+        appointmentService.scheduleNewAppointment(
+          referralId,
+          AppointmentType.SUPPLIER_ASSESSMENT,
+          defaultDuration,
+          defaultAppointmentTime,
+          defaultUser,
+          AppointmentDeliveryType.PHONE_CALL,
+          AppointmentSessionType.ONE_TO_ONE,
+        )
+      }
+      Assertions.assertThat(error.message).contains("Sent Referral not found")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attende
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -37,6 +38,7 @@ class AppointmentServiceTest {
   private val communityAPIBookingService: CommunityAPIBookingService = mock()
   private val appointmentDeliveryRepository: AppointmentDeliveryRepository = mock()
   private val appointmentEventPublisher: AppointmentEventPublisher = mock()
+  private val referralRepository: ReferralRepository = mock()
 
   private val authUserFactory = AuthUserFactory()
   private val appointmentFactory = AppointmentFactory()
@@ -49,7 +51,8 @@ class AppointmentServiceTest {
     communityAPIBookingService,
     appointmentDeliveryRepository,
     authUserRepository,
-    appointmentEventPublisher
+    appointmentEventPublisher,
+    referralRepository,
   )
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceRepositoryTest.kt
@@ -1,0 +1,164 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SupplierAssessmentRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.SupplierAssessmentFactory
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.EntityExistsException
+import javax.persistence.EntityNotFoundException
+
+@RepositoryTest
+class SupplierAssessmentServiceRepositoryTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val supplierAssessmentRepository: SupplierAssessmentRepository,
+  val referralRepository: ReferralRepository,
+) {
+
+  private val appointmentService = mock<AppointmentService>()
+
+  private val supplierAssessmentService = SupplierAssessmentService(
+    supplierAssessmentRepository, referralRepository, appointmentService
+
+  )
+
+  private val supplierAssessmentFactory = SupplierAssessmentFactory(entityManager)
+  private val referralFactory = ReferralFactory(entityManager)
+  private val appointmentFactory = AppointmentFactory(entityManager)
+  private val userFactory = AuthUserFactory(entityManager)
+
+  val defaultDuration = 1
+  val defaultAppointmentTime = OffsetDateTime.now()
+
+  lateinit var defaultUser: AuthUser
+
+  @BeforeEach
+  fun beforeEach() {
+    defaultUser = userFactory.create()
+  }
+
+  @Nested
+  inner class ScheduleNewSupplierAssessment {
+
+    @Test
+    fun `can schedule new supplier assessment appointment with no supplier assessment`() {
+      val referral = referralFactory.createSent()
+      val appointment = appointmentFactory.create()
+      whenever(
+        appointmentService.scheduleNewAppointment(
+          eq(referral.id),
+          eq(AppointmentType.SUPPLIER_ASSESSMENT),
+          eq(defaultDuration),
+          eq(defaultAppointmentTime),
+          eq(defaultUser),
+          eq(AppointmentDeliveryType.PHONE_CALL),
+          eq(AppointmentSessionType.ONE_TO_ONE),
+          anyOrNull(),
+          anyOrNull()
+        )
+      ).thenReturn(appointment)
+
+      val actualAppointment = supplierAssessmentService.scheduleNewSupplierAssessmentAppointment(
+        referral.id,
+        defaultDuration, defaultAppointmentTime, defaultUser, AppointmentDeliveryType.PHONE_CALL
+      )
+
+      assertThat(actualAppointment).isEqualTo(appointment)
+    }
+
+    @Test
+    fun `can schedule new supplier assessment appointment with existing appointment on supplier assessment`() {
+      val existingAppointment = appointmentFactory.create(appointmentTime = OffsetDateTime.now().minusDays(1), appointmentFeedbackSubmittedAt = OffsetDateTime.now())
+      val referral = existingAppointment.referral
+      supplierAssessmentFactory.createWithMultipleAppointments(referral = referral, appointments = mutableSetOf(existingAppointment))
+      val newAppointment = appointmentFactory.create()
+      whenever(
+        appointmentService.scheduleNewAppointment(
+          eq(referral.id),
+          eq(AppointmentType.SUPPLIER_ASSESSMENT),
+          eq(defaultDuration),
+          eq(defaultAppointmentTime),
+          eq(defaultUser),
+          eq(AppointmentDeliveryType.PHONE_CALL),
+          eq(AppointmentSessionType.ONE_TO_ONE),
+          anyOrNull(),
+          anyOrNull()
+        )
+      ).thenReturn(newAppointment)
+
+      val actualAppointment = supplierAssessmentService.scheduleNewSupplierAssessmentAppointment(
+        referral.id,
+        defaultDuration, defaultAppointmentTime, defaultUser, AppointmentDeliveryType.PHONE_CALL
+      )
+
+      assertThat(actualAppointment).isEqualTo(newAppointment)
+    }
+
+    @Test
+    fun `expect failure if sent referral does not exist`() {
+      val referralId = UUID.randomUUID()
+
+      val error = assertThrows<EntityNotFoundException> {
+        supplierAssessmentService.scheduleNewSupplierAssessmentAppointment(
+          referralId,
+          defaultDuration, defaultAppointmentTime, defaultUser, AppointmentDeliveryType.PHONE_CALL
+        )
+      }
+      assertThat(error.message).contains("Sent Referral not found")
+    }
+
+    @Test
+    fun `expect failure if current supplier assessment appointment is later`() {
+      val existingAppointment = appointmentFactory.create(appointmentTime = OffsetDateTime.now().plusMonths(1), appointmentFeedbackSubmittedAt = OffsetDateTime.now())
+      val referral = existingAppointment.referral
+      val supplierAssessment = supplierAssessmentFactory.createWithMultipleAppointments(referral = referral, appointments = mutableSetOf(existingAppointment))
+      referral.supplierAssessment = supplierAssessment
+      entityManager.refresh(referral)
+
+      val error = assertThrows<EntityExistsException> {
+        supplierAssessmentService.scheduleNewSupplierAssessmentAppointment(
+          referral.id,
+          defaultDuration, defaultAppointmentTime, defaultUser, AppointmentDeliveryType.PHONE_CALL
+        )
+      }
+      assertThat(error.message).contains("can't schedule new supplier assessment appointment; new appointment occurs before previously scheduled appointment")
+    }
+
+    @Test
+    fun `expect failure if current supplier assessment appointment has no feedback`() {
+      val existingAppointment = appointmentFactory.create(appointmentTime = OffsetDateTime.now().minusDays(1), appointmentFeedbackSubmittedAt = null)
+      val referral = existingAppointment.referral
+      val supplierAssessment = supplierAssessmentFactory.createWithMultipleAppointments(referral = referral, appointments = mutableSetOf(existingAppointment))
+      referral.supplierAssessment = supplierAssessment
+      entityManager.refresh(referral)
+
+      val error = assertThrows<ValidationError> {
+        supplierAssessmentService.scheduleNewSupplierAssessmentAppointment(
+          referral.id,
+          defaultDuration, defaultAppointmentTime, defaultUser, AppointmentDeliveryType.PHONE_CALL
+        )
+      }
+      assertThat(error.message).contains("can't schedule new supplier assessment appointment; latest appointment has no feedback delivered")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
@@ -42,7 +42,7 @@ class SupplierAssessmentServiceTest {
   private val supplierAssessmentService = SupplierAssessmentService(
     supplierAssessmentRepository,
     referralRepository,
-    appointmentService,
+    appointmentService
   )
 
   @Test


### PR DESCRIPTION
The purpose of this PR is to unify the supplier assessment appointment endpoints with the delivery session appointment endpoints.

This splits the existing scheduleOrRescheduleSupplierAssessmentAppointment into scheduleSupplierAssessmentAppointment and rescheduleSupplierAssessmentAppointment.

This makes the api more consistent and less confusing; but mainly it also provides greater control on validation of user expectations.

commit 9863aaf9122823231cb7369a57261af8fa0307e2

new endpoint POST /referral/{referralId}/supplier-assessment which schedules a completely new supplier assessment appointment.

The existing endpoint PUT /supplier-assessment/{id}/schedule-appointment does both schedule and reschedule depending on the state of the existing appointment.

The reasons for splitting is so the caller's intention are known explicitly and further validation can be performed on the request.


commit 699488dc2a110ef93acafb9d706f6ad7a8c46e50 

Added new endpoint PUT /referral/{referralId}/supplier-assessment/{appointmentId} which rescheuldes the existing appointment based on appointmentId.
This is split out from the existing endpoint PUT /supplier-assessment/{id}/schedule-appointment which reschedules the latest appointment if it exists or creates a new appointment if it does not exist.
