### PR TITLE
propagate appinsights trace context in events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   implementation("io.sentry:sentry-spring-boot-starter:5.4.3")
   implementation("io.sentry:sentry-logback:5.4.3")
   implementation("io.github.microutils:kotlin-logging-jvm:2.1.15")
+  implementation("io.opentelemetry:opentelemetry-api:1.6.0")
 
   // openapi
   implementation("org.springdoc:springdoc-openapi-ui:1.5.13")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanAppointmentEventPublisher.kt
@@ -13,7 +13,13 @@ enum class ActionPlanAppointmentEventType {
   SESSION_FEEDBACK_RECORDED,
 }
 
-class ActionPlanAppointmentEvent(source: Any, val type: ActionPlanAppointmentEventType, val deliverySession: DeliverySession, val detailUrl: String, val notifyPP: Boolean) : ApplicationEvent(source) {
+class ActionPlanAppointmentEvent(
+  source: Any,
+  val type: ActionPlanAppointmentEventType,
+  val deliverySession: DeliverySession,
+  val detailUrl: String,
+  val notifyPP: Boolean
+) : TraceableEvent(source) {
   override fun toString(): String {
     return "ActionPlanAppointmentEvent(type=$type, deliverySessionId=${deliverySession.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -21,23 +27,23 @@ class ActionPlanAppointmentEvent(source: Any, val type: ActionPlanAppointmentEve
 
 @Component
 class ActionPlanAppointmentEventPublisher(
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val eventPublisher: TracePropagatingEventPublisher,
   private val locationMapper: LocationMapper
 ) {
   fun attendanceRecordedEvent(session: DeliverySession, notifyPP: Boolean) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       ActionPlanAppointmentEvent(this, ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, session, getAppointmentURL(session), notifyPP)
     )
   }
 
   fun behaviourRecordedEvent(session: DeliverySession, notifyPP: Boolean) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       ActionPlanAppointmentEvent(this, ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, session, getAppointmentURL(session), notifyPP)
     )
   }
 
   fun sessionFeedbackRecordedEvent(session: DeliverySession, notifyPP: Boolean) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       ActionPlanAppointmentEvent(this, ActionPlanAppointmentEventType.SESSION_FEEDBACK_RECORDED, session, getAppointmentURL(session), notifyPP)
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ActionPlanEventPublisher.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
 
-import org.springframework.context.ApplicationEvent
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.ActionPlanController
@@ -12,7 +10,7 @@ enum class ActionPlanEventType {
   APPROVED,
 }
 
-class ActionPlanEvent(source: Any, val type: ActionPlanEventType, val actionPlan: ActionPlan, val detailUrl: String) : ApplicationEvent(source) {
+class ActionPlanEvent(source: Any, val type: ActionPlanEventType, val actionPlan: ActionPlan, val detailUrl: String) : TraceableEvent(source) {
   override fun toString(): String {
     return "ActionPlanEvent(type=$type, actionPlanId=${actionPlan.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -20,16 +18,16 @@ class ActionPlanEvent(source: Any, val type: ActionPlanEventType, val actionPlan
 
 @Component
 class ActionPlanEventPublisher(
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val eventPublisher: TracePropagatingEventPublisher,
   private val locationMapper: LocationMapper
 ) {
 
   fun actionPlanSubmitEvent(actionPlan: ActionPlan) {
-    applicationEventPublisher.publishEvent(ActionPlanEvent(this, ActionPlanEventType.SUBMITTED, actionPlan, createDetailUrl(actionPlan)))
+    eventPublisher.publishEvent(ActionPlanEvent(this, ActionPlanEventType.SUBMITTED, actionPlan, createDetailUrl(actionPlan)))
   }
 
   fun actionPlanApprovedEvent(actionPlan: ActionPlan) {
-    applicationEventPublisher.publishEvent(ActionPlanEvent(this, ActionPlanEventType.APPROVED, actionPlan, createDetailUrl(actionPlan)))
+    eventPublisher.publishEvent(ActionPlanEvent(this, ActionPlanEventType.APPROVED, actionPlan, createDetailUrl(actionPlan)))
   }
 
   private fun createDetailUrl(actionPlan: ActionPlan): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/AppointmentEventPublisher.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
 
-import org.springframework.context.ApplicationEvent
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.ReferralController
@@ -23,7 +21,7 @@ class AppointmentEvent(
   val detailUrl: String,
   val notifyPP: Boolean,
   val appointmentType: AppointmentType
-) : ApplicationEvent(source) {
+) : TraceableEvent(source) {
   override fun toString(): String {
     return "AppointmentEvent(type=$type, appointmentId=${appointment.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -31,11 +29,11 @@ class AppointmentEvent(
 
 @Component
 class AppointmentEventPublisher(
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val eventPublisher: TracePropagatingEventPublisher,
   private val locationMapper: LocationMapper
 ) {
   fun appointmentScheduledEvent(appointment: Appointment, appointmentType: AppointmentType) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       AppointmentEvent(
         this,
         AppointmentEventType.SCHEDULED,
@@ -48,7 +46,7 @@ class AppointmentEventPublisher(
   }
 
   fun attendanceRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       AppointmentEvent(
         this,
         AppointmentEventType.ATTENDANCE_RECORDED,
@@ -61,7 +59,7 @@ class AppointmentEventPublisher(
   }
 
   fun behaviourRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       AppointmentEvent(
         this,
         AppointmentEventType.BEHAVIOUR_RECORDED,
@@ -74,7 +72,7 @@ class AppointmentEventPublisher(
   }
 
   fun sessionFeedbackRecordedEvent(appointment: Appointment, notifyPP: Boolean, appointmentType: AppointmentType) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       AppointmentEvent(
         this,
         AppointmentEventType.SESSION_FEEDBACK_RECORDED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
 
-import org.springframework.context.ApplicationEvent
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.CaseNoteController
@@ -15,17 +13,17 @@ class CreateCaseNoteEvent(
   val sentBy: AuthUser,
   val detailUrl: String,
   val referralId: UUID,
-) : ApplicationEvent(source) {
+) : TraceableEvent(source) {
   override fun toString(): String = "CreateCaseNoteEvent(caseNoteId=$caseNoteId, referralId=$referralId)"
 }
 
 @Component
 class CaseNoteEventPublisher(
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val eventPublisher: TracePropagatingEventPublisher,
   private val locationMapper: LocationMapper,
 ) {
   fun caseNoteSentEvent(caseNote: CaseNote) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       CreateCaseNoteEvent(
         this,
         caseNote.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/EndOfServiceReportEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/EndOfServiceReportEventPublisher.kt
@@ -17,7 +17,7 @@ class EndOfServiceReportEvent(
   val endOfServiceReport: EndOfServiceReport,
   val detailUrl: String
 ) :
-  ApplicationEvent(source) {
+  TraceableEvent(source) {
   override fun toString(): String {
     return "EndOfServiceReportEvent(type=$type, referralId=${endOfServiceReport.referral.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -25,11 +25,11 @@ class EndOfServiceReportEvent(
 
 @Component
 class EndOfServiceReportEventPublisher(
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val eventPublisher: TracePropagatingEventPublisher,
   private val locationMapper: LocationMapper
 ) {
   fun endOfServiceReportSubmittedEvent(endOfServiceReport: EndOfServiceReport) {
-    applicationEventPublisher.publishEvent(
+    eventPublisher.publishEvent(
       EndOfServiceReportEvent(
         this, EndOfServiceReportEventType.SUBMITTED,
         endOfServiceReport, getEndOfServiceReportUrl(endOfServiceReport)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -12,7 +12,7 @@ enum class ReferralEventType {
   SENT, ASSIGNED, CANCELLED, PREMATURELY_ENDED, COMPLETED
 }
 
-class ReferralEvent(source: Any, val type: ReferralEventType, val referral: Referral, val detailUrl: String) : ApplicationEvent(source) {
+class ReferralEvent(source: Any, val type: ReferralEventType, val referral: Referral, val detailUrl: String) : TraceableEvent(source) {
   override fun toString(): String {
     return "ReferralEvent(type=$type, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
   }
@@ -20,22 +20,22 @@ class ReferralEvent(source: Any, val type: ReferralEventType, val referral: Refe
 
 @Component
 class ReferralEventPublisher(
-  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val eventPublisher: TracePropagatingEventPublisher,
   private val locationMapper: LocationMapper
 ) {
   companion object : KLogging()
 
   fun referralSentEvent(referral: Referral) {
-    applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.SENT, referral, getSentReferralURL(referral)))
+    eventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.SENT, referral, getSentReferralURL(referral)))
   }
 
   fun referralAssignedEvent(referral: Referral) {
-    applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.ASSIGNED, referral, getSentReferralURL(referral)))
+    eventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.ASSIGNED, referral, getSentReferralURL(referral)))
   }
 
   fun referralConcludedEvent(referral: Referral, eventType: ReferralEventType) {
     referral.currentAssignee ?: logger.warn("Concluding referral has no current assignment ${referral.id} for event type $eventType")
-    applicationEventPublisher.publishEvent(ReferralEvent(this, eventType, referral, getSentReferralURL(referral)))
+    eventPublisher.publishEvent(ReferralEvent(this, eventType, referral, getSentReferralURL(referral)))
   }
 
   private fun getSentReferralURL(referral: Referral): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/TracePropagatingEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/TracePropagatingEventListener.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
+
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.TextMapGetter
+import org.springframework.context.ApplicationListener
+
+interface TracePropagatingEventListener: ApplicationListener<TraceableEvent> {
+  fun processTraceableEvent(event: TraceableEvent)
+
+  override fun onApplicationEvent(event: TraceableEvent) {
+    val context = W3CTraceContextPropagator.getInstance().extract(Context.current(), event, object: TextMapGetter<TraceableEvent> {
+      override fun keys(event: TraceableEvent): MutableIterable<String> { return event.attributes.keys }
+      override fun get(event: TraceableEvent?, key: String): String? { return event?.attributes?.get(key) }
+    })
+
+    context.makeCurrent().use {
+      processTraceableEvent(event)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/TracePropagatingEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/TracePropagatingEventPublisher.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events
+
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+open class TraceableEvent(source: Any): ApplicationEvent(source) {
+  val attributes: MutableMap<String, String> = mutableMapOf()
+}
+
+@Component
+class TracePropagatingEventPublisher(
+  private val context: ApplicationContext,
+): ApplicationEventPublisher {
+  fun publishEvent(traceableEvent: TraceableEvent) {
+    W3CTraceContextPropagator.getInstance().inject(Context.current(), traceableEvent) { event, key, value ->
+      event?.attributes?.put(key, value)
+    }
+    publishEvent(traceableEvent as Any)
+  }
+
+  override fun publishEvent(event: Any) {
+    context.publishEvent(event)
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -196,3 +196,8 @@ webclient:
     max-retry-attempts: 2
     connect-timeout-seconds: 3
     read-timeout-seconds: 3
+
+azure:
+  application-insights:
+    web:
+      enabled: false # let the v3 application insights agent handle all the telemetry


### PR DESCRIPTION
the internal event processing happens outside the request context, so we first have to propagate the trace through the event publisher/listener mechanism

`TracePropagatingEventPublisher` handles this, and all the changes to classes like `ReferralEventPublisher` are just changing to inherit from this new class

on the other side `TracePropagatingEventListener` extracts the trace context, ands runs the existing listener code in a new trace span (`context.makeCurrent().use {`)

all the changes in `SNSService` are just moving existing listener code into new methods so we can utilize a generic `TraceableEvent` listener for all of them

next, `SNSPublisher` includes the opentracing headers as string message attributes. the headers looks like this:

```
"traceparent": {"Type": "String", "Value": "00-52908ba66f5742caa2856e9707ce6428-50ed11e4dbdbd1c9-01"}, "tracestate": {"Type": "String", "Value": "ai-internal-sp=100"
```

lastly, app insights falls over itself and doesn't work properly if you use the agent and the old v2 web instrumention. the config changes turn off the latter.

all this means, the listener gets those message attributes in the message. i've yet to fully get it working end to end, because again, app insights doesn't do what it says it does. but i'm confident we can make it work. when i got it working using the opentelemetry agent it auto-parsed the newly included message attributes. app insights in theory uses the same instrumentation, but it's not working OOTB.