### PR TITLE
Add new endpoints for recording feedback for service delivery appointments by referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -277,6 +277,13 @@ class DeliverySessionService(
     return session
   }
 
+  fun submitSessionFeedback(referralId: UUID, appointmentId: UUID, submitter: AuthUser): Pair<DeliverySession, Appointment> {
+    var sessionAndAppointment = getDeliverySessionAppointmentOrThrowException(referralId, appointmentId)
+    val appointment = sessionAndAppointment.second
+    val updatedAppointment = appointmentService.submitSessionFeedback(appointment, submitter, SERVICE_DELIVERY)
+    return Pair(sessionAndAppointment.first, updatedAppointment)
+  }
+
   fun getSessions(referralId: UUID): List<DeliverySession> {
     return deliverySessionRepository.findAllByReferralId(referralId)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DeliverySessionService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
@@ -39,8 +40,9 @@ internal class DeliverySessionControllerTest {
   private val userMapper = UserMapper(authUserRepository)
   private val referralService = mock<ReferralService>()
   private val referralAccessChecker = mock<ReferralAccessChecker>()
+  private val appointmentService = mock<AppointmentService>()
 
-  private val sessionsController = DeliverySessionController(actionPlanService, sessionsService, locationMapper, userMapper, appointmentValidator, referralAccessChecker, referralService)
+  private val sessionsController = DeliverySessionController(actionPlanService, sessionsService, locationMapper, userMapper, appointmentValidator, referralAccessChecker, referralService, appointmentService)
   private val actionPlanFactory = ActionPlanFactory()
   private val deliverySessionFactory = DeliverySessionFactory()
   private val jwtTokenFactory = JwtTokenFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.isNotNull
 import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanA
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
@@ -193,6 +195,57 @@ class DeliverySessionServiceTest @Autowired constructor(
         deliverySessionService.rescheduleDeliverySessionAppointment(session.referral.id, session.sessionNumber, existingAppointment.id, newTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
       }
       assertThat(error.message).contains("can't reschedule appointment for session; appointment feedback already supplied")
+    }
+  }
+
+  @Nested
+  inner class RecordAppointmentAttendance {
+    @Test
+    fun `can record attendance`() {
+      val deliverySession = deliverySessionFactory.createScheduled()
+      val referral = deliverySession.referral
+      val appointment = deliverySession.currentAppointment!!
+      whenever(appointmentService.recordAppointmentAttendance(eq(appointment), eq(Attended.YES), eq("additionalInformation"), eq(defaultUser))).thenReturn(appointment)
+      val pair = deliverySessionService.recordAppointmentAttendance(referral.id, appointment.id, defaultUser, Attended.YES, "additionalInformation")
+      assertThat(pair.first).isEqualTo(deliverySession)
+      assertThat(pair.second).isEqualTo(appointment)
+    }
+
+    @Test
+    fun `expect failure when no referral exists`() {
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentAttendance(UUID.randomUUID(), UUID.randomUUID(), defaultUser, Attended.YES, "additionalInformation")
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no session exists`() {
+      val referral = referralFactory.createSent()
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentAttendance(referral.id, UUID.randomUUID(), defaultUser, Attended.YES, "additionalInformation")
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no appointment exists`() {
+      val deliverySession = deliverySessionFactory.createUnscheduled()
+      val referral = deliverySession.referral
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentAttendance(referral.id, UUID.randomUUID(), defaultUser, Attended.YES, "additionalInformation")
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no matching appointment exists`() {
+      val deliverySession = deliverySessionFactory.createScheduled()
+      val referral = deliverySession.referral
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentAttendance(referral.id, UUID.randomUUID(), defaultUser, Attended.YES, "additionalInformation")
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -299,4 +299,55 @@ class DeliverySessionServiceTest @Autowired constructor(
       assertThat(error.message).contains("No Delivery Session Appointment found")
     }
   }
+
+  @Nested
+  inner class SubmitSessionFeedback {
+    @Test
+    fun `can submit feedback`() {
+      val deliverySession = deliverySessionFactory.createScheduled()
+      val referral = deliverySession.referral
+      val appointment = deliverySession.currentAppointment!!
+      whenever(appointmentService.submitSessionFeedback(eq(appointment), eq(defaultUser), eq(AppointmentType.SERVICE_DELIVERY))).thenReturn(appointment)
+      val pair = deliverySessionService.submitSessionFeedback(referral.id, appointment.id, defaultUser)
+      assertThat(pair.first).isEqualTo(deliverySession)
+      assertThat(pair.second).isEqualTo(appointment)
+    }
+
+    @Test
+    fun `expect failure when no referral exists`() {
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.submitSessionFeedback(UUID.randomUUID(), UUID.randomUUID(), defaultUser)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no session exists`() {
+      val referral = referralFactory.createSent()
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.submitSessionFeedback(referral.id, UUID.randomUUID(), defaultUser)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no appointment exists`() {
+      val deliverySession = deliverySessionFactory.createUnscheduled()
+      val referral = deliverySession.referral
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.submitSessionFeedback(referral.id, UUID.randomUUID(), defaultUser)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no matching appointment exists`() {
+      val deliverySession = deliverySessionFactory.createScheduled()
+      val referral = deliverySession.referral
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.submitSessionFeedback(referral.id, UUID.randomUUID(), defaultUser)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -248,4 +248,55 @@ class DeliverySessionServiceTest @Autowired constructor(
       assertThat(error.message).contains("No Delivery Session Appointment found")
     }
   }
+
+  @Nested
+  inner class RecordAppointmentBehaviour {
+    @Test
+    fun `can record behaviour`() {
+      val deliverySession = deliverySessionFactory.createScheduled()
+      val referral = deliverySession.referral
+      val appointment = deliverySession.currentAppointment!!
+      whenever(appointmentService.recordBehaviour(eq(appointment), eq("good"), eq(false), eq(defaultUser))).thenReturn(appointment)
+      val pair = deliverySessionService.recordAppointmentBehaviour(referral.id, appointment.id, defaultUser, "good", false)
+      assertThat(pair.first).isEqualTo(deliverySession)
+      assertThat(pair.second).isEqualTo(appointment)
+    }
+
+    @Test
+    fun `expect failure when no referral exists`() {
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentBehaviour(UUID.randomUUID(), UUID.randomUUID(), defaultUser, "good", false)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no session exists`() {
+      val referral = referralFactory.createSent()
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentBehaviour(referral.id, UUID.randomUUID(), defaultUser, "good", false)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no appointment exists`() {
+      val deliverySession = deliverySessionFactory.createUnscheduled()
+      val referral = deliverySession.referral
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentBehaviour(referral.id, UUID.randomUUID(), defaultUser, "good", false)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+
+    @Test
+    fun `expect failure when no matching appointment exists`() {
+      val deliverySession = deliverySessionFactory.createScheduled()
+      val referral = deliverySession.referral
+      val error = assertThrows<EntityNotFoundException> {
+        deliverySessionService.recordAppointmentBehaviour(referral.id, UUID.randomUUID(), defaultUser, "good", false)
+      }
+      assertThat(error.message).contains("No Delivery Session Appointment found")
+    }
+  }
 }


### PR DESCRIPTION
This PR is part of a larger feature to allow the ability to schedule and provide appointment feedback using referral id and appointment id as reference.

commit 1ae77cf34664290de279506e7b7edf126d17fad7

Added new endpoint PUT /referral/{referralId}/delivery-session-appointments/{appointmentId}/ttendance which provides ability to record attendance for an appointment based on the referral id rather than referring to action plan and session number.

commit a1a94ba14e98875ae296e458720314ccfba58e2c

Added new endpoint PUT /referral/{referralId}/delivery-session-appointments/{appointmentId}/behaviour which provides ability to record behaviour for an delivery session appointment using referralId and appointmentId rather than actionPlanId and sessionNumber.

commit dc3420765a5548beabf5165f3261cccc37969e72

Added new endpoint POST /referral/{referralId}/delivery-session-appointments/{appointmentId}/submit-feedback which allows delivery session appointment feedback submission with referralId and appointmentId rather than actionPlanId and sessionNumber.

Rather than actionPlanEvents created upon successful submission, appointmentEvents will be created instead - these are located within the AppointmentService class.
