### PR TITLE
CI: Remove (unused) kubernetes orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ parameters:
 orbs:
   hmpps: ministryofjustice/hmpps@3.11
   gradle: circleci/gradle@2.2.0
-  kubernetes: circleci/kubernetes@0.11.2
   mem: circleci/rememborb@0.0.1
   veracode: orb-01scan/sast-orb@0.0.9
 


### PR DESCRIPTION
## What does this pull request do?

CI: Remove (unused) kubernetes orb

## What is the intent behind these changes?

Should have been removed in 69251c2c0c13d6f1fc9978048f76ce4786f17fa0
when the research environment was removed