### PR TITLE
CI: 🐛 Use correct veracode team and credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,8 +273,11 @@ workflows:
                 - main
     jobs:
       - hmpps/veracode_policy_scan:
+          teams: hmpps-interventions
           slack_channel: "interventions-dev-notifications"
-          context: [hmpps-common-vars]
+          context:
+            - hmpps-common-vars
+            - veracode-credentials
       - hmpps/trivy_latest_scan:
           slack_channel: "interventions-dev-notifications"
           context: [hmpps-common-vars]


### PR DESCRIPTION

## What does this pull request do?

Use correct veracode team and credentials

## What is the intent behind these changes?

I forgot to include these in 617ab47c72e1a8c8e502e7df664a72b13b5abd44

(Veracode is our security tooling to provide org-wide reporting on application vulnerabilities)