### PR TITLE
Security/bump log4j slf4j bridge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,3 +281,6 @@ workflows:
       - hmpps/trivy_latest_scan:
           slack_channel: "interventions-dev-notifications"
           context: [hmpps-common-vars]
+      - hmpps/gradle_owasp_dependency_check:
+          slack_channel: "interventions-dev-notifications"
+          context: [hmpps-common-vars]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
   // until bumped in upstream
   implementation("io.netty:netty-codec:4.1.72.Final") // CVE-2021-43797
   implementation("org.apache.logging.log4j:log4j-api:2.16.0") // CVE-2021-44228
+  implementation("org.apache.logging.log4j:log4j-to-slf4j:2.16.0") // CVE-2021-44228
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
## What does this pull request do?

1. Bump log4j-to-slf4j to mitigate CVE-2021-44228
2. Add nightly build of `./gradlew dependencyCheckAnalyze` which highlighted this issue

## What is the intent behind these changes?

Fix open vulnerabilities