### PR TITLE
Allow AppInsights to encode OffsetDateTime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   implementation("io.sentry:sentry-spring-boot-starter:5.4.3")
   implementation("io.sentry:sentry-logback:5.4.3")
   implementation("io.github.microutils:kotlin-logging-jvm:2.1.16")
+  runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0") // needed for OffsetDateTime for AppInsights
 
   // openapi
   implementation("org.springdoc:springdoc-openapi-ui:1.6.0")


### PR DESCRIPTION
## What does this pull request do?

Allow AppInsights to encode OffsetDateTime by including `jackson-datatype-jsr310` as a runtime dependency

## What is the intent behind these changes?

Noticed this log message:

> Error encoding telemetry items: Java 8 date/time type `java.time.OffsetDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: com.microsoft.applicationinsights.agent.internal.exporter.models.TelemetryItem["time"])

Fixing this would mean more telemetry information is available for us, which is a good thing

📝 This message doesn't seem to appear on `pre-prod` or `prod` environments, only on **dev**
