### PR TITLE
check attended field is included for past appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
@@ -65,9 +65,13 @@ class AppointmentValidator {
   ) {
     if (appointmentTime.isAfter(OffsetDateTime.now()))
       return
+    if (attended == null) {
+      errors.add(FieldError(field = "appointmentAttendance.attended", error = Code.CANNOT_BE_EMPTY))
+      return
+    }
 
     when (attended) {
-      null, NO -> {
+      NO -> {
         checkValueNotSupplied(notifyProbationPractitioner, "appointmentBehaviour.notifyProbationPractitioner", Code.INVALID_VALUE, errors)
         checkValueNotSupplied(behaviourDescription, "appointmentBehaviour.behaviourDescription", Code.INVALID_VALUE, errors)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.RecordAppointmentBehaviourDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentAttendanceDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
@@ -117,7 +116,7 @@ internal class AppointmentValidatorTest {
       }
 
       @Test
-      fun `past appointment fails if no attendance reported but behaviour is`() {
+      fun `past appointment fails if no attendance reported`() {
         val updateAppointmentDTO = UpdateAppointmentDTO(
           appointmentTime = OffsetDateTime.now().minusDays(1),
           durationInMinutes = 1,
@@ -125,14 +124,13 @@ internal class AppointmentValidatorTest {
           sessionType = AppointmentSessionType.ONE_TO_ONE,
           npsOfficeCode = "CRSEXT",
           appointmentAttendance = null,
-          appointmentBehaviour = RecordAppointmentBehaviourDTO("some comments", false)
+          appointmentBehaviour = null
         )
         val exception = assertThrows<ValidationError> {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
         }
         assertThat(exception.errors).containsExactly(
-          FieldError("appointmentBehaviour.notifyProbationPractitioner", Code.INVALID_VALUE),
-          FieldError("appointmentBehaviour.behaviourDescription", Code.INVALID_VALUE),
+          FieldError("appointmentAttendance.attended", Code.CANNOT_BE_EMPTY),
         )
       }
 


### PR DESCRIPTION
## What does this pull request do?

Ensures the 'attended' field is included for past appointments.

## What is the intent behind these changes?

To prevent past appointments being created without feedback.
