### PR TITLE
bug fix: appointment in the past

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -185,6 +185,7 @@ class DeliverySessionService(
       appointmentService.createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
       session.appointments.add(appointment)
     } else {
+      setAttendanceAndBehaviourIfHistoricAppointment(session, existingAppointment, appointmentTime, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, updatedBy)
       existingAppointment.appointmentTime = appointmentTime
       existingAppointment.durationInMinutes = durationInMinutes
       existingAppointment.deliusAppointmentId = deliusAppointmentId


### PR DESCRIPTION
Fixed bug with update Delivery session appointment where past appointment feedback details are ignored if there already is a scheduled appointment.
