### PR TITLE
Update log4j-api to 2.17 to address CVE-2021-45105.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
   implementation("com.nimbusds:oauth2-oidc-sdk:9.20")
   // until bumped in upstream
   implementation("io.netty:netty-codec:4.1.72.Final") // CVE-2021-43797
-  implementation("org.apache.logging.log4j:log4j-api:2.16.0") // CVE-2021-44228
-  implementation("org.apache.logging.log4j:log4j-to-slf4j:2.17.0") // CVE-2021-44228
+  implementation("org.apache.logging.log4j:log4j-api:2.17.0") // CVE-2021-45105
+  implementation("org.apache.logging.log4j:log4j-to-slf4j:2.17.0") // CVE-2021-45105
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
## What does this pull request do?

Update log4j-api to 2.17 to address CVE-2021-45105.

## What is the intent behind these changes?

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105