### PR TITLE
Make new delivery session appointment endpoints accept past appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
@@ -196,6 +196,10 @@ class DeliverySessionController(
       newDeliverySessionAppointmentRequest.sessionType,
       newDeliverySessionAppointmentRequest.appointmentDeliveryAddress,
       newDeliverySessionAppointmentRequest.npsOfficeCode,
+      newDeliverySessionAppointmentRequest.appointmentAttendance?.attended,
+      newDeliverySessionAppointmentRequest.appointmentAttendance?.additionalAttendanceInformation,
+      newDeliverySessionAppointmentRequest.appointmentBehaviour?.notifyProbationPractitioner,
+      newDeliverySessionAppointmentRequest.appointmentBehaviour?.behaviourDescription,
     )
     return DeliverySessionAppointmentDTO.from(deliverySession.sessionNumber, deliverySession.currentAppointment!!)
   }
@@ -223,6 +227,10 @@ class DeliverySessionController(
       newDeliverySessionAppointmentRequest.sessionType,
       newDeliverySessionAppointmentRequest.appointmentDeliveryAddress,
       newDeliverySessionAppointmentRequest.npsOfficeCode,
+      newDeliverySessionAppointmentRequest.appointmentAttendance?.attended,
+      newDeliverySessionAppointmentRequest.appointmentAttendance?.additionalAttendanceInformation,
+      newDeliverySessionAppointmentRequest.appointmentBehaviour?.notifyProbationPractitioner,
+      newDeliverySessionAppointmentRequest.appointmentBehaviour?.behaviourDescription,
     )
     return DeliverySessionAppointmentDTO.from(deliverySession.sessionNumber, deliverySession.currentAppointment!!)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -46,6 +46,8 @@ data class DeliverySessionAppointmentScheduleDetailsDTO(
   val sessionType: AppointmentSessionType,
   val appointmentDeliveryAddress: AddressDTO? = null,
   val npsOfficeCode: String? = null,
+  val appointmentAttendance: UpdateAppointmentAttendanceDTO? = null,
+  val appointmentBehaviour: RecordAppointmentBehaviourDTO? = null,
 )
 
 data class UpdateAppointmentAttendanceDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -194,6 +194,7 @@ class DeliverySessionService(
     }
   }
 
+  @Deprecated("Deprecated in favour of method that uses common AppointmentService")
   fun recordAppointmentAttendance(
     actor: AuthUser,
     actionPlanId: UUID,
@@ -226,6 +227,7 @@ class DeliverySessionService(
     return Pair(sessionAndAppointment.first, updatedAppointment)
   }
 
+  @Deprecated("Deprecated in favour of method that uses common AppointmentService")
   fun recordBehaviour(
     actor: AuthUser,
     actionPlanId: UUID,
@@ -258,6 +260,8 @@ class DeliverySessionService(
     return Pair(sessionAndAppointment.first, updatedAppointment)
   }
 
+
+  @Deprecated("Deprecated in favour of method that uses common AppointmentService")
   fun submitSessionFeedback(actionPlanId: UUID, sessionNumber: Int, submitter: AuthUser): DeliverySession {
     val session = getDeliverySessionByActionPlanIdOrThrowException(actionPlanId, sessionNumber)
     val appointment = session.currentAppointment

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -68,7 +68,7 @@ class DeliverySessionService(
     sessionNumber: Int,
     appointmentTime: OffsetDateTime,
     durationInMinutes: Int,
-    updatedBy: AuthUser,
+    createdBy: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
     appointmentSessionType: AppointmentSessionType,
     appointmentDeliveryAddress: AddressDTO? = null,
@@ -88,7 +88,7 @@ class DeliverySessionService(
     }
     val appointment = Appointment(
       id = UUID.randomUUID(),
-      createdBy = authUserRepository.save(updatedBy),
+      createdBy = authUserRepository.save(createdBy),
       createdAt = OffsetDateTime.now(),
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ActionPlanAppointmentEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attende
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DeliverySession
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentDeliveryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
@@ -47,10 +49,14 @@ class DeliverySessionServiceTest @Autowired constructor(
   val actionPlanRepository: ActionPlanRepository,
   val referralRepository: ReferralRepository,
   val authUserRepository: AuthUserRepository,
+  appointmentDeliveryRepository: AppointmentDeliveryRepository,
 ) {
   private val actionPlanAppointmentEventPublisher = mock<ActionPlanAppointmentEventPublisher>()
   private val communityAPIBookingService = mock<CommunityAPIBookingService>()
-  private val appointmentService = mock<AppointmentService>()
+  private val appointmentEventPublisher = mock<AppointmentEventPublisher>()
+  private val appointmentService = AppointmentService(
+    appointmentRepository, communityAPIBookingService, appointmentDeliveryRepository, authUserRepository, appointmentEventPublisher, referralRepository
+  )
 
   private val deliverySessionService = DeliverySessionService(
     deliverySessionRepository, actionPlanRepository, authUserRepository,
@@ -82,7 +88,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(session.referral.id, session.sessionNumber, defaultAppointmentTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
       verify(communityAPIBookingService).book(eq(session.referral), isNull(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
       val appointment = updatedSession.appointments.first()
@@ -99,7 +104,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(session.referral.id, session.sessionNumber, newTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
       verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), any(), any(), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(2)
 
@@ -131,7 +135,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       )
 
       verify(communityAPIBookingService).book(eq(session.referral), isNull(), eq(pastDate), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
       val appointment = updatedSession.appointments.first()
@@ -144,6 +147,8 @@ class DeliverySessionServiceTest @Autowired constructor(
       assertThat(appointment.attendanceBehaviour).isEqualTo("behaviourDescription")
       assertThat(appointment.attendanceSubmittedAt).isNotNull()
       assertThat(appointment.attendanceSubmittedBy).isEqualTo(defaultUser)
+      assertThat(appointment.appointmentDelivery?.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.PHONE_CALL)
+      assertThat(appointment.appointmentDelivery?.appointmentSessionType).isEqualTo(AppointmentSessionType.ONE_TO_ONE)
     }
 
     @Test
@@ -198,7 +203,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       val updatedSession = deliverySessionService.rescheduleDeliverySessionAppointment(session.referral.id, session.sessionNumber, existingAppointment.id, newTime, 2, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
       verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), any(), any(), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
 
@@ -231,7 +235,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       )
 
       verify(communityAPIBookingService).book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), any(), any(), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
       val appointment = updatedSession.appointments.first()
@@ -244,6 +247,8 @@ class DeliverySessionServiceTest @Autowired constructor(
       assertThat(appointment.attendanceBehaviour).isEqualTo("behaviourDescription")
       assertThat(appointment.attendanceSubmittedAt).isNotNull()
       assertThat(appointment.attendanceSubmittedBy).isEqualTo(defaultUser)
+      assertThat(appointment.appointmentDelivery?.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.PHONE_CALL)
+      assertThat(appointment.appointmentDelivery?.appointmentSessionType).isEqualTo(AppointmentSessionType.ONE_TO_ONE)
     }
 
     @Test
@@ -305,7 +310,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       val deliverySession = deliverySessionFactory.createScheduled()
       val referral = deliverySession.referral
       val appointment = deliverySession.currentAppointment!!
-      whenever(appointmentService.recordAppointmentAttendance(eq(appointment), eq(Attended.YES), eq("additionalInformation"), eq(defaultUser))).thenReturn(appointment)
       val pair = deliverySessionService.recordAppointmentAttendance(referral.id, appointment.id, defaultUser, Attended.YES, "additionalInformation")
       assertThat(pair.first).isEqualTo(deliverySession)
       assertThat(pair.second).isEqualTo(appointment)
@@ -356,7 +360,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       val deliverySession = deliverySessionFactory.createScheduled()
       val referral = deliverySession.referral
       val appointment = deliverySession.currentAppointment!!
-      whenever(appointmentService.recordBehaviour(eq(appointment), eq("good"), eq(false), eq(defaultUser))).thenReturn(appointment)
       val pair = deliverySessionService.recordAppointmentBehaviour(referral.id, appointment.id, defaultUser, "good", false)
       assertThat(pair.first).isEqualTo(deliverySession)
       assertThat(pair.second).isEqualTo(appointment)
@@ -407,7 +410,9 @@ class DeliverySessionServiceTest @Autowired constructor(
       val deliverySession = deliverySessionFactory.createScheduled()
       val referral = deliverySession.referral
       val appointment = deliverySession.currentAppointment!!
-      whenever(appointmentService.submitSessionFeedback(eq(appointment), eq(defaultUser), eq(AppointmentType.SERVICE_DELIVERY))).thenReturn(appointment)
+      appointment.attended = Attended.NO
+      appointment.attendanceSubmittedAt = OffsetDateTime.now()
+      appointmentRepository.save(appointment)
       val pair = deliverySessionService.submitSessionFeedback(referral.id, appointment.id, defaultUser)
       assertThat(pair.first).isEqualTo(deliverySession)
       assertThat(pair.second).isEqualTo(appointment)
@@ -480,7 +485,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       )
 
       verify(communityAPIBookingService).book(eq(session.referral), isNull(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
       val appointment = updatedSession.appointments.first()
@@ -493,6 +497,8 @@ class DeliverySessionServiceTest @Autowired constructor(
       assertThat(appointment.attendanceBehaviour).isEqualTo("behaviourDescription")
       assertThat(appointment.appointmentFeedbackSubmittedAt).isNotNull()
       assertThat(appointment.appointmentFeedbackSubmittedBy).isNotNull()
+      assertThat(appointment.appointmentDelivery?.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.PHONE_CALL)
+      assertThat(appointment.appointmentDelivery?.appointmentSessionType).isEqualTo(AppointmentSessionType.ONE_TO_ONE)
     }
 
     @Test
@@ -522,7 +528,6 @@ class DeliverySessionServiceTest @Autowired constructor(
       )
 
       verify(communityAPIBookingService).book(eq(session.referral), isNotNull(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
-      verify(appointmentService).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(1)
       val appointment = updatedSession.appointments.first()
@@ -535,6 +540,8 @@ class DeliverySessionServiceTest @Autowired constructor(
       assertThat(appointment.attendanceBehaviour).isEqualTo("behaviourDescription")
       assertThat(appointment.appointmentFeedbackSubmittedAt).isNotNull()
       assertThat(appointment.appointmentFeedbackSubmittedBy).isNotNull()
+      assertThat(appointment.appointmentDelivery?.appointmentDeliveryType).isEqualTo(AppointmentDeliveryType.PHONE_CALL)
+      assertThat(appointment.appointmentDelivery?.appointmentSessionType).isEqualTo(AppointmentSessionType.ONE_TO_ONE)
     }
   }
 }


### PR DESCRIPTION
  Provided capability to add feedback for scheduling and rescheduling a delivery session appointment on new endpoints:
    
    POST /referral/{referralId}/delivery-session-appointments
    PUT /referral/{referralId}/delivery-session-appointments/{appointmentId}

Note:
   These endpoints aren't currently used by ui.