### PR TITLE
Bugfix: FK violation when saving appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -184,8 +184,8 @@ class DeliverySessionService(
       deliusAppointmentId = deliusAppointmentId,
       referral = session.referral,
     )
-    appointmentService.createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
     appointmentRepository.saveAndFlush(appointment)
+    appointmentService.createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
     session.appointments.add(appointment)
     deliverySessionRepository.save(session)
     return deliverySessionRepository.save(session).also {


### PR DESCRIPTION
We must ensure that appointment is saved before setting the appointment delievery details otherwise fk_appointment_delivery_to_appointment will be thrown by hibernate.
