### PR TITLE
Change the circleCI config to release from the `release/code-freeze` branch instead of main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: false
   pact_consumer_tags:
     type: string
-    default: main
+    default: release/code-freeze
 
 orbs:
   hmpps: ministryofjustice/hmpps@3.11
@@ -56,7 +56,7 @@ jobs:
           name: Run main migrations then branch migrations to detect clashes
           command: |
             flyway clean -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password"
-            git reset --hard origin/main
+            git reset --hard origin/release/code-freeze
             flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration"
             git reset --hard "$CIRCLE_SHA1"
             flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration"
@@ -99,7 +99,7 @@ jobs:
             docker tag data-dictionary "quay.io/hmpps/${CIRCLE_PROJECT_REPONAME}:data-dictionary-${APP_VERSION}"
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ release/code-freeze, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: Publish docker image
@@ -192,14 +192,14 @@ workflows:
           persist_container_image: true
           filters:
             branches:
-              only: [main]
+              only: [release/code-freeze]
       - hmpps/build_docker:
           name: build_docker
           publish: false
           persist_container_image: true
           filters:
             branches:
-              ignore: [main]
+              ignore: [release/code-freeze]
       - hmpps/trivy_pipeline_scan:
           name: vulnerability_scan
           requires: [build_docker, build_and_publish_docker]
@@ -211,7 +211,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - release/code-freeze
           requires:
             - validate
             - validate_db
@@ -270,7 +270,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - release/code-freeze
     jobs:
       - hmpps/veracode_policy_scan:
           teams: hmpps-interventions

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ pactbroker:
   host: pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk
   scheme: https
   consumerversionselectors:
-    tags: main
+    tags: release/code-freeze
 
 spring:
   jpa:


### PR DESCRIPTION
## What does this pull request do?

Change the circleCI config to release from the `release/code-freeze` branch instead of main

## What is the intent behind these changes?

The reason for doing this is that we want to revert the release to a previous known
safe version of the code. We also want to be unblocked from releasing small critical
bug fixes or CVE updates without being blocked by queued changes in `main`. The
`release/code-freeze` branch was taken from the previous release, with some critical
library upgrades cherry-picked.
