### PR TITLE
explicitly bump logback from 1.2.6 -> 1.2.10 for CVE-2021-42550

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,10 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("com.nimbusds:oauth2-oidc-sdk:9.20")
+
   // until bumped in upstream
+  implementation("ch.qos.logback:logback-classic:1.2.10") // CVE-2021-42550
+  implementation("ch.qos.logback:logback-core:1.2.10") // CVE-2021-42550
   implementation("io.netty:netty-codec:4.1.72.Final") // CVE-2021-43797
   implementation("org.apache.logging.log4j:log4j-api:2.17.0") // CVE-2021-44228
   implementation("org.apache.logging.log4j:log4j-to-slf4j:2.17.1") // CVE-2021-44228


### PR DESCRIPTION
## What does this pull request do?

explicitly bump logback from 1.2.6 -> 1.2.10 

## What is the intent behind these changes?

 CVE-2021-42550
