### PR TITLE
Only require feedback for appointments that happened on a previous day.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointm
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
+import java.time.LocalTime
 import java.time.OffsetDateTime
 
 @Component
@@ -63,8 +64,11 @@ class AppointmentValidator {
     behaviourDescription: String?,
     errors: MutableList<FieldError>
   ) {
-    if (appointmentTime.isAfter(OffsetDateTime.now()))
+    // if the appointment occurred today or on a date in the future, no attendance validation is required
+    if (appointmentTime.isAfter(OffsetDateTime.now().with(LocalTime.MIN))) {
       return
+    }
+
     if (attended == null) {
       errors.add(FieldError(field = "appointmentAttendance.attended", error = Code.CANNOT_BE_EMPTY))
       return

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
@@ -116,6 +116,22 @@ internal class AppointmentValidatorTest {
       }
 
       @Test
+      fun `past appointment on same day allowed if no attendance reported`() {
+        val updateAppointmentDTO = UpdateAppointmentDTO(
+          appointmentTime = OffsetDateTime.now().minusMinutes(1), // will fail if the test runs just after midnight
+          durationInMinutes = 1,
+          appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE,
+          sessionType = AppointmentSessionType.ONE_TO_ONE,
+          npsOfficeCode = "CRSEXT",
+          appointmentAttendance = null,
+          appointmentBehaviour = null
+        )
+        assertDoesNotThrow {
+          deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO)
+        }
+      }
+
+      @Test
       fun `past appointment fails if no attendance reported`() {
         val updateAppointmentDTO = UpdateAppointmentDTO(
           appointmentTime = OffsetDateTime.now().minusDays(1),


### PR DESCRIPTION
## What does this pull request do?

Only require feedback for appointments that happened on a previous day.

## What is the intent behind these changes?

This replicates the current behaviour of the API, allowing the existing UI
to continue to function as normal without any changes.

Once the UI is allowing appointments to be created in the past, we can revert
this change to ensure that any past appointment, even if it was on the current
day, requires that attendance information be passed along side the scheduling
information.
