### PR TITLE
🐛 Use datetimes without timezones from ARN

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
@@ -49,7 +49,7 @@ data class RedactedRisk(
 
 data class SupplementaryRiskResponse(
   val supplementaryRiskId: UUID,
-  val createdDate: OffsetDateTime,
+  val createdDate: LocalDateTime,
 )
 
 @Service
@@ -100,7 +100,7 @@ class RisksAndNeedsService(
       .block()
 
     if (response.statusCode.equals(HttpStatus.CONFLICT)) {
-      if (response.body.createdDate != riskCreatedAt) {
+      if (response.body.createdDate != riskCreatedAt.toLocalDateTime()) {
         logger.error(
           "attempted to update an existing supplementary risk with new data {} {} {} {}",
           kv("crn", crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import ch.qos.logback.classic.Level
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingSpyTest
+import java.time.OffsetDateTime
+import java.util.UUID
+
+internal class RisksAndNeedsServiceTest : LoggingSpyTest(RisksAndNeedsService::class, Level.ERROR) {
+  private val mockWebServer = MockWebServer()
+  private val restClient = RestClient(
+    WebClient.create(mockWebServer.url("/").toString()),
+    "client-registration-id"
+  )
+  private val authUserFactory = AuthUserFactory()
+  private val jwtTokenFactory = JwtTokenFactory()
+
+  @BeforeEach
+  fun `set security context`() {
+    val token = jwtTokenFactory.create()
+    val context = mock<SecurityContext>()
+    whenever(context.authentication).thenReturn(token)
+    SecurityContextHolder.setContext(context)
+  }
+
+  @Nested
+  inner class createSupplementaryRisk {
+    val oasysRiskInformation = RedactedRisk(
+      "someone", "all the time", "bad", "none", "none", "none", "none",
+    )
+
+    @Test
+    fun `ignores http 409 response when risk is up to date`() {
+      mockWebServer.enqueue(
+        MockResponse()
+          .setResponseCode(409)
+          .setHeader("Content-Type", "application/json")
+          .setBody(
+            """
+        { 
+          "supplementaryRiskId": "f974d97e-9f50-4963-91f3-a619f50ad127",
+          "createdDate": "2020-12-04T10:42:43+00:00"
+        }
+            """.trimIndent()
+          )
+      )
+
+      val risksAndNeedsService = RisksAndNeedsService(
+        "/risk/supplementary",
+        true,
+        restClient,
+      )
+
+      risksAndNeedsService.createSupplementaryRisk(
+        UUID.randomUUID(),
+        "CRN123",
+        authUserFactory.createPP(),
+        OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+        "additional information",
+        oasysRiskInformation,
+      )
+
+      assertThat(logEvents).isEmpty()
+    }
+
+    @Test
+    fun `logs error and fails on http 409 response when risk is out of date`() {
+      mockWebServer.enqueue(
+        MockResponse()
+          .setResponseCode(409)
+          .setHeader("Content-Type", "application/json")
+          .setBody(
+            """
+        { 
+          "supplementaryRiskId": "f974d97e-9f50-4963-91f3-a619f50ad127",
+          "createdDate": "2020-12-04T10:42:43+00:00"
+        }
+            """.trimIndent()
+          )
+      )
+
+      val risksAndNeedsService = RisksAndNeedsService(
+        "/risk/supplementary",
+        true,
+        restClient,
+      )
+
+      assertThrows<WebClientResponseException> {
+        risksAndNeedsService.createSupplementaryRisk(
+          UUID.randomUUID(),
+          "CRN123",
+          authUserFactory.createPP(),
+          OffsetDateTime.now(),
+          "additional information",
+          oasysRiskInformation,
+        )
+      }
+
+      assertThat(logEvents[0].message).contains("attempted to update an existing supplementary risk with new data")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsServiceTest.kt
@@ -54,7 +54,7 @@ internal class RisksAndNeedsServiceTest : LoggingSpyTest(RisksAndNeedsService::c
             """
         { 
           "supplementaryRiskId": "f974d97e-9f50-4963-91f3-a619f50ad127",
-          "createdDate": "2020-12-04T10:42:43+00:00"
+          "createdDate": "2022-01-06T11:23:53.622652"
         }
             """.trimIndent()
           )
@@ -70,7 +70,7 @@ internal class RisksAndNeedsServiceTest : LoggingSpyTest(RisksAndNeedsService::c
         UUID.randomUUID(),
         "CRN123",
         authUserFactory.createPP(),
-        OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+        OffsetDateTime.parse("2022-01-06T11:23:53.622652+00:00"),
         "additional information",
         oasysRiskInformation,
       )
@@ -88,7 +88,7 @@ internal class RisksAndNeedsServiceTest : LoggingSpyTest(RisksAndNeedsService::c
             """
         { 
           "supplementaryRiskId": "f974d97e-9f50-4963-91f3-a619f50ad127",
-          "createdDate": "2020-12-04T10:42:43+00:00"
+          "createdDate": "2020-12-04T10:42:43.123456"
         }
             """.trimIndent()
           )


### PR DESCRIPTION
## What does this pull request do?

6a2b29a10c37b3244eeb6c5006f0e32378c5b739 introduced these changes but we got errors:

`com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type 'java.time.OffsetDateTime' from String "2022-01-06T11:33:18.666979": Failed to deserialize java.time.OffsetDateTime: (java.time.format.DateTimeParseException) Text '2022-01-06T11:33:18.666979' could not be parsed at index 26
 at [Source: (io.netty.buffer.ByteBufInputStream); line: 1, column: 239] (through reference chain: uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.SupplementaryRiskResponse["createdDate"])`

This was due to ARN response having datetimes without time zones.

This change was reverted in #793 and this PR reinstates it with working time types.

## What is the intent behind these changes?

Make conflict resolution in ARN work with the current payloads.