### PR TITLE
Remove shared services from Manchester's women's services

### DIFF
--- a/src/main/resources/db/migration/V1_93_1__remove_shared_services_from_manchester_women_service.sql
+++ b/src/main/resources/db/migration/V1_93_1__remove_shared_services_from_manchester_women_service.sql
@@ -1,0 +1,7 @@
+DELETE
+FROM contract_type_service_category
+-- Women's Support Services (GM)
+WHERE contract_type_id = 'a93c152c-ed56-48f9-92e8-401ff7aa2fa8'
+  AND service_category_id IN ('428ee70f-3001-4399-95a6-ad25eaaede16', -- Accommodation
+                              '96a63c39-4371-4f17-a6ec-265755f0cf7b', -- Finance, Benefits and Debt
+                              '76bcdb97-1dea-41c1-a4f8-899d88e5d679'); -- Dependency and Recovery

--- a/src/main/resources/db/migration/V1_93_2__add_manchester_pcc.sql
+++ b/src/main/resources/db/migration/V1_93_2__add_manchester_pcc.sql
@@ -1,0 +1,2 @@
+INSERT INTO pcc_region (id, name, nps_region_id)
+VALUES ('greater-manchester', 'Greater Manchester', 'L');


### PR DESCRIPTION
## What does this pull request do?

- Remove shared services from Manchester's women's services
- Add Manchester as a PCC region to make it show up in the filter

## What is the intent behind these changes?

All other Manchester services can now accept both male and female participants, meaning these offerings are no longer necessary under "Women's Support Services (GM)"

*Bonus* We were missing a Manchester PCC region, which meant the UI cannot filter for our new services.