### PR TITLE
allow a future appointment to be reschedules to the past with feedback

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -83,10 +83,16 @@ class AppointmentService(
           durationInMinutes,
           appointmentTime,
           deliusAppointmentId,
+          createdByUser,
           appointmentDeliveryType,
           appointmentSessionType,
           appointmentDeliveryAddress,
-          npsOfficeCode
+          npsOfficeCode,
+          attended,
+          additionalAttendanceInformation,
+          notifyProbationPractitioner,
+          behaviourDescription,
+          appointmentType
         )
       }
       // an additional appointment is required
@@ -278,14 +284,21 @@ class AppointmentService(
     durationInMinutes: Int,
     appointmentTime: OffsetDateTime,
     deliusAppointmentId: Long?,
+    createdByUser: AuthUser,
     appointmentDeliveryType: AppointmentDeliveryType,
     appointmentSessionType: AppointmentSessionType?,
     appointmentDeliveryAddress: AddressDTO? = null,
     npsOfficeCode: String?,
+    attended: Attended?,
+    additionalAttendanceInformation: String?,
+    notifyProbationPractitioner: Boolean?,
+    behaviourDescription: String?,
+    appointmentType: AppointmentType,
   ): Appointment {
     appointment.durationInMinutes = durationInMinutes
     appointment.appointmentTime = appointmentTime
     appointment.deliusAppointmentId = deliusAppointmentId
+    setAttendanceAndBehaviourIfHistoricAppointment(appointment, appointmentTime, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser, appointmentType)
     val appointment = appointmentRepository.save(appointment)
     createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
     return appointment


### PR DESCRIPTION
## What does this pull request do?

Allows the rescheduling of a saa appointment to be a historic appointment containing feedback.

## What is the intent behind these changes?

There is currently an issue where feedback is not stored for rescheduling an saa appointment to a historic one
