### PR TITLE
order approved action plan ids by 'approvedAt' in sent referral DTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -40,7 +40,8 @@ class SentReferralDTO(
         relevantSentenceId = referral.relevantSentenceId!!,
         actionPlanId = referral.currentActionPlan?.id,
         currentActionPlanId = referral.currentActionPlan?.id,
-        approvedActionPlanIds = referral.actionPlans?.filter { it.approvedAt != null }?.map { it.id },
+        approvedActionPlanIds = referral.actionPlans?.filter { it.approvedAt != null }
+          ?.sortedByDescending { it.approvedAt }?.map { it.id },
         endRequestedAt = referral.endRequestedAt,
         endRequestedReason = referral.endRequestedReason?.let { it.description },
         endRequestedComments = referral.endRequestedComments,


### PR DESCRIPTION
## What does this pull request do?

order approved action plan ids by 'approvedAt' in sent referral DTO

## What is the intent behind these changes?

make it easier for API consumers to determine 'most recently approved action plan' without making additional API calls.
