### PR TITLE
add 'submittedAt' to action plan summary DTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ActionPlanDTO.kt
@@ -69,12 +69,14 @@ data class UpdateActionPlanActivityDTO(
 data class ActionPlanSummaryDTO(
   val id: UUID,
   val approvedAt: OffsetDateTime?,
+  val submittedAt: OffsetDateTime?,
 ) {
   companion object {
     fun from(actionPlan: ActionPlan): ActionPlanSummaryDTO {
       return ActionPlanSummaryDTO(
         id = actionPlan.id,
         approvedAt = actionPlan.approvedAt,
+        submittedAt = actionPlan.submittedAt,
       )
     }
     fun from(actionPlans: List<ActionPlan>): List<ActionPlanSummaryDTO> {


### PR DESCRIPTION
## What does this pull request do?

add 'submittedAt' to action plan summary DTO

## What is the intent behind these changes?

allow API to show submitted at dates in previous AP summary tables.
