### PR TITLE
Mitigate CVE-2022-21724

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
   implementation("com.nimbusds:oauth2-oidc-sdk:9.22.2")
 
   // until bumped in upstream
+  implementation("org.postgresql:postgresql:42.3.2") // CVE-2022-21724
   implementation("ch.qos.logback:logback-classic:1.2.10") // CVE-2021-42550
   implementation("ch.qos.logback:logback-core:1.2.10") // CVE-2021-42550
   implementation("io.netty:netty-codec:4.1.73.Final") // CVE-2021-43797


### PR DESCRIPTION
🪠 Unblocks CI pipeline

## What does this pull request do?

Mitigate CVE-2022-21724 as flagged by trivy

```
+---------------------------+------------------+----------+-------------------+-----------------+---------------------------------------+
|          LIBRARY          | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+---------------------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| org.postgresql:postgresql | CVE-2022-21724   | HIGH     | 42.2.24           | 42.3.2, 42.2.25 | Remote code execution vulnerability   |
|                           |                  |          |                   |                 | using plugin features                 |
|                           |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-21724 |
+---------------------------+------------------+----------+-------------------+-----------------+---------------------------------------+
```

## What is the intent behind these changes?

Mitigate security vulnerabilities

<img width="492" alt="image" src="https://user-images.githubusercontent.com/1526295/152395600-375b74ed-0540-49a1-a241-ad3b7ce6ead6.png">
