### PR TITLE
Mitigate CVE-2022-23181

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("com.nimbusds:oauth2-oidc-sdk:9.22.2")
 
-  // until bumped in upstream
+  // bumps for security, until bumped in upstream
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.58") // CVE-2022-23181
+  implementation("org.apache.tomcat.embed:tomcat-embed-websocket:9.0.58") // CVE-2022-23181
   implementation("org.postgresql:postgresql:42.3.2") // CVE-2022-21724
 
   // database

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,11 +63,6 @@ dependencies {
 
   // until bumped in upstream
   implementation("org.postgresql:postgresql:42.3.2") // CVE-2022-21724
-  implementation("ch.qos.logback:logback-classic:1.2.10") // CVE-2021-42550
-  implementation("ch.qos.logback:logback-core:1.2.10") // CVE-2021-42550
-  implementation("io.netty:netty-codec:4.1.73.Final") // CVE-2021-43797
-  implementation("org.apache.logging.log4j:log4j-api:2.17.1") // CVE-2021-44228
-  implementation("org.apache.logging.log4j:log4j-to-slf4j:2.17.1") // CVE-2021-44228
 
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
## What does this pull request do?

- Mitigate CVE-2022-23181
- Remove unnecessarily pinned dependencies (cleanup)

## What is the intent behind these changes?

Reduce vulnerabilities; this has been flagged by `./gradlew dependencyCheckAnalyze --info`