### PR TITLE
log the number of referrals for both 'sent-referrals' endpoints (as well as some supplementary information)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 import ServiceProviderSentReferralSummaryDTO
 import com.fasterxml.jackson.annotation.JsonView
 import mu.KLogging
+import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
@@ -117,7 +118,14 @@ class ReferralController(
     @Nullable @RequestParam(name = "assignedTo", required = false) assignedToUserId: String?,
   ): List<SentReferralSummaryDTO> {
     val user = userMapper.fromToken(authentication)
-    return referralService.getSentReferralsForUser(user, concluded, cancelled, unassigned, assignedToUserId).map { SentReferralSummaryDTO.from(it) }
+    val referrals = referralService.getSentReferralsForUser(user, concluded, cancelled, unassigned, assignedToUserId)
+    logger.info(
+      "returning list of referrals from /sent-referrals",
+      kv("userType", user.authSource),
+      kv("numberOfReferrals", referrals.size),
+      kv("params", mapOf("concluded" to concluded, "cancelled" to cancelled, "unassigned" to unassigned, "assignedTo" to (assignedToUserId != null)))
+    )
+    return referrals.map { SentReferralSummaryDTO.from(it) }
   }
 
   @Deprecated(message = "This is a temporary solution to by-pass the extremely long wait times in production that occurs with /sent-referrals")
@@ -129,7 +137,13 @@ class ReferralController(
   ): List<ServiceProviderSentReferralSummaryDTO> {
     val user = userMapper.fromToken(authentication)
     var dashboardType = dashboardTypeSelection?.let { DashboardType.valueOf(it) }
-    return referralService.getServiceProviderSummaries(user, dashboardType).map { ServiceProviderSentReferralSummaryDTO.from(it) }
+    val referrals = referralService.getServiceProviderSummaries(user, dashboardType)
+    logger.info(
+      "returning list of referrals from /sent-referrals/summary/service-provider",
+      kv("numberOfReferrals", referrals.size),
+      kv("dashboardType", dashboardType),
+    )
+    return referrals.map { ServiceProviderSentReferralSummaryDTO.from(it) }
   }
 
   @JsonView(Views.SentReferral::class)


### PR DESCRIPTION
## What does this pull request do?

log the number of referrals for both 'sent-referrals' endpoints (as well as some supplementary information)

## What is the intent behind these changes?

so we can actually see how many referrals are being returned in average SP/PP dashboard lists 
