### PR TITLE
Switched the extract table python to shell script

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -13,7 +13,7 @@ spec:
           - name: data-extractor-analytics
             image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
-            args: ["extract_psql_all_tables_to_jsonl.sh && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
+            args: ["extract_table_names.py && extract_psql_all_tables_to_jsonl.sh && transfer_local_to_s3.sh"]
             env:
               - name: PGHOST
                 valueFrom:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -13,7 +13,7 @@ spec:
           - name: data-extractor-analytics
             image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
-            args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
+            args: ["extract_psql_all_tables_to_jsonl.sh && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             env:
               - name: PGHOST
                 valueFrom:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -13,7 +13,7 @@ spec:
           - name: data-extractor-analytics
             image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
-            args: ["extract_table_names.py && extract_psql_all_tables_to_jsonl.sh && transfer_local_to_s3.sh"]
+            args: ["extract_psql_all_tables_to_jsonl.sh && transfer_local_to_s3.sh"]
             env:
               - name: PGHOST
                 valueFrom:


### PR DESCRIPTION
## What does this pull request do?

The table extraction functionality is switched to shell script from python 

## What is the intent behind these changes?

Sort the memory issue caused by large data load. 
