### PR TITLE
route performance report requests to a seperate deploy

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_helpers.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_helpers.tpl
@@ -63,6 +63,10 @@ release: {{ .Release.Name }}
 app: api-suspect
 release: {{ .Release.Name }}
 {{- end }}
+{{- define "performanceReportApp.selectorLabels" -}}
+app: performance-report
+release: {{ .Release.Name }}
+{{- end }}
 {{- define "dataDictionary.selectorLabels" -}}
 app: data-dictionary
 release: {{ .Release.Name }}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: performance-report
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "performanceReportApp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "performanceReportApp.selectorLabels" . | nindent 8 }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ template "app.name" . }}
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: hmpps-interventions-service
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.image.ports.app }}
+              protocol: TCP
+          volumeMounts:
+            - name: heap-dumps
+              mountPath: /dumps
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: {{ .Values.image.ports.app }}
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: {{ .Values.image.ports.app }}
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 10
+  {{- include "deployment.envs" . | nindent 10 }}
+      volumes:
+        - name: heap-dumps
+          emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -37,6 +37,10 @@ spec:
             backend:
               serviceName: api-suspect
               servicePort: http
+          - path: /reports/service-provider/performance
+            backend:
+              serviceName: performance-report
+              servicePort: http
           - path: /
             backend:
               serviceName: {{ $fullName }}

--- a/helm_deploy/hmpps-interventions-service/templates/service.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/service.yaml
@@ -27,3 +27,18 @@ spec:
       name: http
   selector:
     {{- include "suspectApp.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: performance-report
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: {{ .Values.image.ports.app }}
+      name: http
+  selector:
+    {{- include "suspectApp.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION


## What does this pull request do?

takes requests for the SP performance report and runs them on a seperate k8s deploy.

## What is the intent behind these changes?

reduce memory consumption and db connections which may be interfering with the regular function of the application
