### PR TITLE
fix selector labels on new performance report deploy

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/service.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/service.yaml
@@ -41,4 +41,4 @@ spec:
       targetPort: {{ .Values.image.ports.app }}
       name: http
   selector:
-    {{- include "suspectApp.selectorLabels" . | nindent 4 }}
+    {{- include "performanceReportApp.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## What does this pull request do?

fix selector labels on new performance report deploy

## What is the intent behind these changes?

ensure the perf report jobs start on the right k8s deploy
