### PR TITLE
Use unique container names per use case

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -34,7 +34,7 @@ spec:
                         - {{ template "app.name" . }}
                 topologyKey: kubernetes.io/hostname
       containers:
-        - name: hmpps-interventions-service
+        - name: provider-report-api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
             - containerPort: {{ .Values.image.ports.app }}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
@@ -34,7 +34,7 @@ spec:
                         - {{ template "app.name" . }}
                 topologyKey: kubernetes.io/hostname
       containers:
-        - name: hmpps-interventions-service
+        - name: provider-dashboard-api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
             - containerPort: {{ .Values.image.ports.app }}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                         - {{ template "app.name" . }}
                 topologyKey: kubernetes.io/hostname
       containers:
-        - name: hmpps-interventions-service
+        - name: api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
             - containerPort: {{ .Values.image.ports.app }}


### PR DESCRIPTION


## What does this pull request do?

Use unique container names per use case

## What is the intent behind these changes?

This will allow us to group monitoring:

In prometheus, if we group by `pod`, we get:

`sum by (pod)(rate(container_cpu_usage_seconds_total{namespace='hmpps-interventions-prod',container!="POD",container!=""}[5m]))`:

{pod="data-dictionary-5b48546bdc-9f29k"}
{pod="hmpps-interventions-service-864c8d4c6-pd5jr"}
{pod="performance-report-7c45df5494-k9v84"}
{pod="hmpps-interventions-service-864c8d4c6-gwhbn"}
{pod="hmpps-interventions-service-864c8d4c6-wk4rd"}
{pod="api-suspect-69fd4f8d65-7hsgn"}
{pod="api-suspect-69fd4f8d65-5kv77"}
{pod="hmpps-interventions-ui-689cd57fdd-h2l7f"}
{pod="hmpps-interventions-ui-689cd57fdd-7rbmp"}

Currently, if I want to aggregate on the different use cases, i.e. web,
dashboard, reporting, I cannot do that as all containers are named the
same:

`sum by (container)(rate(container_cpu_usage_seconds_total{namespace='hmpps-interventions-prod',container!="POD",container!=""}[5m]))`

but that results in:

{container="data-dictionary"}
{container="hmpps-interventions-service"}
{container="hmpps-interventions-ui"}

This change will ensure that we will get

{container="data-dictionary"}
{container="api"}
{container="provider-report-api"}
{container="provider-dashboard-api"}
{container="hmpps-interventions-ui"}

So we can alert/monitor on these groups separately
