### PR TITLE
Auto merge dependency updates up to minor versions

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,13 @@
+name: dependencies
+
+on: [pull_request]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.gh_personal_access_token }}


### PR DESCRIPTION


## What does this pull request do?

Auto merge dependency updates up to minor versions

**Note**
We need to disable the "only team members can merge" setting in GitHub as the action asks dependabot to do the merge (I've already done this)

## What is the intent behind these changes?

To help us manage the chore of merging and rebasing them


