### PR TITLE
Expose application metrics to prometheus

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-batch")
 
   // monitoring and logging
+  implementation("io.micrometer:micrometer-registry-prometheus")
   implementation("io.sentry:sentry-spring-boot-starter:5.6.2")
   implementation("io.sentry:sentry-logback:5.6.2")
   implementation("io.github.microutils:kotlin-logging-jvm:2.1.21")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ResourceServerConfiguration.kt
@@ -32,6 +32,7 @@ class ResourceServerConfiguration(private val tokenVerifier: TokenVerifier) : We
       sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
       authorizeRequests {
         authorize("/health/**", permitAll)
+        authorize("/prometheus/**", permitAll)
         authorize("/info", permitAll)
         authorize("/v3/api-docs/**", permitAll)
         authorize("/swagger-ui/**", permitAll)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,7 +85,7 @@ management:
     web:
       base-path: /
       exposure:
-        include: 'info, health'
+        include: 'info, health, prometheus'
   endpoint:
     health:
       cache:


### PR DESCRIPTION
## What does this pull request do?

Expose application metrics to prometheus

Currently only these services have this turned on: https://prometheus.live.cloud-platform.service.justice.gov.uk/graph?g0.expr=avg(jvm_memory_usage_after_gc_percent)%20by%20(service)&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h

## What is the intent behind these changes?

My goal is to be able to correlate events across network, database, http requests, CPU, memory at a glance.

Exposing internal metrics like JVM garbage collection data helps us to expand the capability and removes the need to have both AppInsights and Grafana open.

(Our hosting platform provides Grafana, Prometheus, etc. by default so we can leverage those)

## Added benefit

This will also make `spring_data_repository_invocations_seconds_sum` stuff available for alerting and graphing, so we can monitor specific hotspots for performance, if needed