### PR TITLE
Downgrade postgresql to 42.2.25

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,16 +61,13 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("com.nimbusds:oauth2-oidc-sdk:9.25")
 
-  // bumps for security, until bumped in upstream
-  implementation("org.postgresql:postgresql:42.3.2") // CVE-2022-21724
-
   // database
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.hibernate:hibernate-core:5.6.5.Final")
   implementation("com.vladmihalcea:hibernate-types-52:2.14.0")
   runtimeOnly("org.flywaydb:flyway-core")
-  runtimeOnly("org.postgresql:postgresql")
+  runtimeOnly("org.postgresql:postgresql:42.2.25")
 
   // json and csv
   implementation("com.github.java-json-tools:json-patch:1.13")


### PR DESCRIPTION

## What does this pull request do?

Downgrade postgresql JDBC driver to 42.2.25

## What is the intent behind these changes?

The PostgreSQL upgrade to 42.3.x happened at the same time as we are rolling out dashboard pagination changes. We want to reduce the amount of changes so we can reliably monitor SQL performance.

After the dashboard changes, we can remove the pin.