### PR TITLE
Remove social inclusion from mentoring contract type

### DIFF
--- a/src/main/resources/db/migration/V1_93_3__remove_social_inclusion_from_mentoring.sql
+++ b/src/main/resources/db/migration/V1_93_3__remove_social_inclusion_from_mentoring.sql
@@ -1,0 +1,5 @@
+DELETE
+FROM contract_type_service_category
+-- Mentoring
+WHERE contract_type_id = 'bc65434d-089b-4c37-80c2-50efebb76933'
+  AND service_category_id = 'c036826e-f077-49a5-8b33-601dca7ad479'; -- Social Inclusion


### PR DESCRIPTION
## What does this pull request do?

Remove social inclusion from mentoring contract type

## What is the intent behind these changes?

In the versions of the onboarding spreadsheets, social inclusion was
mentioned as part of mentoring, but now it seems it does not have to be

As far as I can see, ongoing mentoring referrals with social inclusion outcomes will be
⛔ **blocked** if this goes live, as we validate that the categories given must
be part of the contract type ([`validateDraftReferralUpdate` in `ReferralService.kt`](https://github.com/ministryofjustice/hmpps-interventions-service/blob/2d74d12ac52529c01f4de99199f663384d5d0648/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt#L341-L347))

@tomsmyers @rgforsyth do you agree? Am I misinterpreting?