### PR TITLE
remove unnecessary filtering on SP sent referral queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
 
 import org.springframework.data.jpa.domain.Specification
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthGroupID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.criteria.JoinType
@@ -56,25 +54,6 @@ class ReferralSpecifications {
         val interventionJoin = root.join<Referral, Intervention>("intervention", JoinType.INNER)
         val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.LEFT)
         dynamicContractJoin.`in`(contracts)
-      }
-    }
-
-    fun matchingPrimeProviderReferrals(serviceProviders: Set<ServiceProvider>): Specification<Referral> {
-      return Specification<Referral> { root, query, cb ->
-        val interventionJoin = root.join<Referral, Intervention>("intervention", JoinType.INNER)
-        val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.LEFT)
-        query.distinct(true)
-        dynamicContractJoin.get<ServiceProvider>("primeProvider").`in`(serviceProviders)
-      }
-    }
-
-    fun matchingSubContractorReferrals(serviceProviders: Set<ServiceProvider>): Specification<Referral> {
-      return Specification<Referral> { root, query, cb ->
-        val interventionJoin = root.join<Referral, Intervention>("intervention", JoinType.INNER)
-        val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.INNER)
-        val serviceProviderJoin = dynamicContractJoin.joinSet<DynamicFrameworkContract, ServiceProvider>("subcontractorProviders", JoinType.LEFT)
-        query.distinct(true)
-        serviceProviderJoin.get<AuthGroupID>("id").`in`(serviceProviders.map { it.id })
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -153,15 +153,8 @@ class ReferralService(
   }
 
   private fun getSentReferralsForServiceProviderUser(user: AuthUser, sentReferralFilterSpecification: Specification<Referral>, page: Pageable?): Iterable<Referral> {
-    val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
-
     // todo: query for referrals where the service provider has been granted nominated access only
-    val specification = where(
-      ReferralSpecifications.matchingPrimeProviderReferrals(serviceProviders)
-        .or(ReferralSpecifications.matchingSubContractorReferrals(serviceProviders))
-    ).and(sentReferralFilterSpecification)
-
-    val filteredSpec = referralAccessFilter.serviceProviderReferrals(specification, user)
+    val filteredSpec = referralAccessFilter.serviceProviderReferrals(sentReferralFilterSpecification, user)
     return if (page == null) referralRepository.findAll(filteredSpec).sortedBy { it.sentAt } else referralRepository.findAll(filteredSpec, page)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
@@ -131,64 +131,6 @@ class ReferralSpecificationsTest @Autowired constructor(
   }
 
   @Nested
-  inner class matchingPrimeProviderReferrals {
-    @Test
-    fun `only referrals with that are prime providers of the service providers are returned`() {
-      val userServiceProvider_1 = serviceProviderFactory.create("userServiceProvider_1")
-      val grantedReferral = referralFactory.createSent(
-        intervention = interventionFactory.create(contract = dynamicFrameworkContractFactory.create(primeProvider = userServiceProvider_1))
-      )
-      val userServiceProvider_2 = serviceProviderFactory.create("userServiceProvider_2 ${1 + 1}")
-      interventionFactory.create(contract = dynamicFrameworkContractFactory.create(primeProvider = userServiceProvider_2))
-
-      val someOtherServiceProvider = serviceProviderFactory.create("someOtherServiceProvider")
-      val restrictedReferral = referralFactory.createSent(
-        intervention = interventionFactory.create(contract = dynamicFrameworkContractFactory.create(primeProvider = someOtherServiceProvider))
-      )
-
-      val result = referralRepository.findAll(ReferralSpecifications.matchingPrimeProviderReferrals(setOf(userServiceProvider_1, userServiceProvider_2)))
-      Assertions.assertThat(result).containsExactly(grantedReferral)
-      Assertions.assertThat(result).doesNotContain(restrictedReferral)
-    }
-  }
-
-  @Nested
-  inner class matchingSubContractorReferrals {
-    @Test
-    fun `only referrals with that are sub contractors of the service providers are returned`() {
-      val userServiceProvider_1 = serviceProviderFactory.create("userServiceProvider_1")
-      val userServiceProvider_2 = serviceProviderFactory.create("userServiceProvider_2")
-      val someOtherServiceProvider = serviceProviderFactory.create("someOtherServiceProvider")
-
-      val grantedReferral = referralFactory.createSent(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            primeProvider = serviceProviderFactory.create("randomServiceProvider_1"),
-            subcontractorProviders = setOf(
-              userServiceProvider_1, someOtherServiceProvider
-            )
-          )
-        )
-      )
-
-      val restrictedReferral = referralFactory.createSent(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            primeProvider = serviceProviderFactory.create("randomServiceProvider_2"),
-            subcontractorProviders = setOf(
-              someOtherServiceProvider
-            )
-          )
-        )
-      )
-
-      val result = referralRepository.findAll(ReferralSpecifications.matchingSubContractorReferrals(setOf(userServiceProvider_1, userServiceProvider_2)))
-      Assertions.assertThat(result).containsExactly(grantedReferral)
-      Assertions.assertThat(result).doesNotContain(restrictedReferral)
-    }
-  }
-
-  @Nested
   inner class assignedTo {
     @Test
     fun `returns referral if user is currently assigned`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -1,15 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.mockito.AdditionalAnswers
-import org.mockito.ArgumentMatchers.anyList
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
@@ -18,8 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.jpa.domain.Specification
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
@@ -29,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.Serv
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.Views
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
@@ -57,7 +54,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFacto
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProviderFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.SupplierAssessmentFactory
 import java.time.LocalDate
 import java.time.LocalTime
@@ -79,7 +75,6 @@ class ReferralServiceTest @Autowired constructor(
 ) {
 
   private val userFactory = AuthUserFactory(entityManager)
-  private val serviceUserFactory = ServiceUserFactory(entityManager)
   private val interventionFactory = InterventionFactory(entityManager)
   private val contractFactory = DynamicFrameworkContractFactory(entityManager)
   private val serviceProviderFactory = ServiceProviderFactory(entityManager)
@@ -99,10 +94,9 @@ class ReferralServiceTest @Autowired constructor(
   private val referralAccessChecker: ReferralAccessChecker = mock()
   private val userTypeChecker = UserTypeChecker()
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper = mock()
-  private val referralAccessFilter: ReferralAccessFilter = mock()
+  private val referralAccessFilter = ReferralAccessFilter(serviceProviderAccessScopeMapper)
   private val communityAPIReferralService: CommunityAPIReferralService = mock()
   private val serviceUserAccessChecker: ServiceUserAccessChecker = mock()
-  private val authentication: JwtAuthenticationToken = mock()
   private val assessRisksAndNeedsService: RisksAndNeedsService = mock()
   private val communityAPIOffenderService: CommunityAPIOffenderService = mock()
   private val supplierAssessmentService: SupplierAssessmentService = mock()
@@ -134,342 +128,355 @@ class ReferralServiceTest @Autowired constructor(
     draftOasysRiskInformationService
   )
 
-  // reset before each test
-  private lateinit var sampleReferral: Referral
-  private lateinit var sampleIntervention: Intervention
-  private lateinit var sampleCohortIntervention: Intervention
+  @AfterEach
+  fun `clear referrals`() {
+    referralRepository.deleteAll()
+  }
 
-  @BeforeEach
-  fun beforeEach() {
-    sampleReferral = SampleData.persistReferral(
-      entityManager,
-      SampleData.sampleReferral("X123456", "Harmony Living")
-    )
-    sampleIntervention = sampleReferral.intervention
+  @Nested
+  @DisplayName("create / find / update / send draft referrals")
+  inner class createFindUpdateAndSendDraftReferrals {
 
-    sampleCohortIntervention = SampleData.persistIntervention(
-      entityManager,
-      SampleData.sampleIntervention(
-        dynamicFrameworkContract = SampleData.sampleContract(
-          primeProvider = sampleReferral.intervention.dynamicFrameworkContract.primeProvider,
-          contractType = SampleData.sampleContractType(
-            name = "Personal Wellbeing",
-            code = "PWB",
-            serviceCategories = mutableSetOf(
-              SampleData.sampleServiceCategory(),
-              SampleData.sampleServiceCategory(name = "Social inclusion")
+    private lateinit var sampleReferral: Referral
+    private lateinit var sampleIntervention: Intervention
+    private lateinit var sampleCohortIntervention: Intervention
+
+    @BeforeEach
+    fun beforeEach() {
+      sampleReferral = SampleData.persistReferral(
+        entityManager,
+        SampleData.sampleReferral("X123456", "Harmony Living")
+      )
+      sampleIntervention = sampleReferral.intervention
+
+      sampleCohortIntervention = SampleData.persistIntervention(
+        entityManager,
+        SampleData.sampleIntervention(
+          dynamicFrameworkContract = SampleData.sampleContract(
+            primeProvider = sampleReferral.intervention.dynamicFrameworkContract.primeProvider,
+            contractType = SampleData.sampleContractType(
+              name = "Personal Wellbeing",
+              code = "PWB",
+              serviceCategories = mutableSetOf(
+                SampleData.sampleServiceCategory(),
+                SampleData.sampleServiceCategory(name = "Social inclusion")
+              )
             )
           )
         )
       )
-    )
-  }
-
-  @Test
-  fun `assignment to a user adds a new assignment record to the trail of assignments`() {
-    val r = referralFactory.createSent()
-    val assigner = userFactory.create(id = "1000", userName = "test-admin@example.org")
-    val assignedTo1 = userFactory.create(id = "5000", userName = "assignee1@example.org")
-    val assignedTo2 = userFactory.create(id = "5001", userName = "assignee2@example.org")
-
-    referralService.assignSentReferral(r, assigner, assignedTo1)
-    referralService.assignSentReferral(r, assigner, assignedTo2)
-
-    with(r.assignments[0]) {
-      assertThat(this.assignedBy).isEqualTo(assigner)
-      assertThat(this.assignedTo).isEqualTo(assignedTo1)
-    }
-    with(r.assignments[1]) {
-      assertThat(this.assignedAt).isAfterOrEqualTo(r.assignments[0].assignedAt)
-      assertThat(this.assignedBy).isEqualTo(assigner)
-      assertThat(this.assignedTo).isEqualTo(assignedTo2)
-    }
-  }
-
-  @Test
-  fun `assignment to a user marks older records superseded`() {
-    val r = referralFactory.createSent()
-    val assigner = userFactory.create(id = "1000", userName = "test-admin@example.org")
-    val assignedTo1 = userFactory.create(id = "5000", userName = "assignee1@example.org")
-    val assignedTo2 = userFactory.create(id = "5001", userName = "assignee2@example.org")
-    val assignedTo3 = userFactory.create(id = "5002", userName = "assignee3@example.org")
-
-    referralService.assignSentReferral(r, assigner, assignedTo1)
-    referralService.assignSentReferral(r, assigner, assignedTo2)
-    referralService.assignSentReferral(r, assigner, assignedTo3)
-
-    assertThat(r.assignments.map { it.superseded })
-      .containsExactly(true, true, false)
-  }
-
-  @Test
-  fun `update cannot overwrite identifier fields`() {
-    val draftReferral = DraftReferralDTO(
-      id = UUID.fromString("ce364949-7301-497b-894d-130f34a98bff"),
-      createdAt = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
-    )
-
-    val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
-    assertThat(updated.id).isEqualTo(sampleReferral.id)
-    assertThat(updated.createdAt).isEqualTo(sampleReferral.createdAt)
-  }
-
-  @Test
-  fun `null fields in the update do not overwrite original fields`() {
-    sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
-    entityManager.persistAndFlush(sampleReferral)
-
-    val draftReferral = DraftReferralDTO(completionDeadline = null)
-
-    val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
-    assertThat(updated.completionDeadline).isEqualTo(LocalDate.of(2021, 6, 26))
-  }
-
-  @Test
-  fun `non-null fields in the update overwrite original fields`() {
-    sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
-    entityManager.persistAndFlush(sampleReferral)
-
-    val today = LocalDate.now()
-    val draftReferral = DraftReferralDTO(completionDeadline = today)
-
-    val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
-    assertThat(updated.completionDeadline).isEqualTo(today)
-  }
-
-  @Test
-  fun `update mutates the original object`() {
-    sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
-    entityManager.persistAndFlush(sampleReferral)
-
-    val today = LocalDate.now()
-    val draftReferral = DraftReferralDTO(completionDeadline = today)
-
-    val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
-    assertThat(updated.completionDeadline).isEqualTo(today)
-  }
-
-  @Test
-  fun `update successfully persists the updated draft referral`() {
-    sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
-    entityManager.persistAndFlush(sampleReferral)
-
-    val today = LocalDate.now()
-    val draftReferral = DraftReferralDTO(completionDeadline = today)
-    referralService.updateDraftReferral(sampleReferral, draftReferral)
-    val savedDraftReferral = referralService.getDraftReferralForUser(sampleReferral.id, userFactory.create())
-    assertThat(savedDraftReferral!!.id).isEqualTo(sampleReferral.id)
-    assertThat(savedDraftReferral.createdAt).isEqualTo(sampleReferral.createdAt)
-    assertThat(savedDraftReferral.completionDeadline).isEqualTo(draftReferral.completionDeadline)
-  }
-
-  @Test
-  fun `create and persist non-cohort draft referral`() {
-    val authUser = AuthUser("user_id", "delius", "user_name")
-    val draftReferral = referralService.createDraftReferral(authUser, "X123456", sampleIntervention.id)
-    entityManager.flush()
-
-    val savedDraftReferral = referralService.getDraftReferralForUser(draftReferral.id, authUser)
-    assertThat(savedDraftReferral!!.id).isNotNull
-    assertThat(savedDraftReferral.createdAt).isNotNull
-    assertThat(savedDraftReferral.createdBy).isEqualTo(authUser)
-    assertThat(savedDraftReferral.serviceUserCRN).isEqualTo("X123456")
-    assertThat(savedDraftReferral.selectedServiceCategories).hasSize(1)
-    assertThat(savedDraftReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(sampleIntervention.dynamicFrameworkContract.contractType.serviceCategories.elementAt(0).id)
-  }
-
-  @Test
-  fun `create and persist cohort draft referral`() {
-    val authUser = AuthUser("user_id", "delius", "user_name")
-    val draftReferral = referralService.createDraftReferral(authUser, "X123456", sampleCohortIntervention.id)
-    entityManager.flush()
-
-    val savedDraftReferral = referralService.getDraftReferralForUser(draftReferral.id, authUser)
-    assertThat(savedDraftReferral!!.id).isNotNull
-    assertThat(savedDraftReferral.createdAt).isNotNull
-    assertThat(savedDraftReferral.createdBy).isEqualTo(authUser)
-    assertThat(savedDraftReferral.serviceUserCRN).isEqualTo("X123456")
-    assertThat(savedDraftReferral.selectedServiceCategories).isNull()
-  }
-
-  @Test
-  fun `get a draft referral`() {
-    sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
-    entityManager.persistAndFlush(sampleReferral)
-
-    val savedDraftReferral = referralService.getDraftReferralForUser(sampleReferral.id, userFactory.create())
-    assertThat(savedDraftReferral!!.id).isEqualTo(sampleReferral.id)
-    assertThat(savedDraftReferral.createdAt).isEqualTo(sampleReferral.createdAt)
-    assertThat(savedDraftReferral.completionDeadline).isEqualTo(sampleReferral.completionDeadline)
-  }
-
-  @Test
-  fun `find by userID returns list of draft referrals`() {
-    val user1 = AuthUser("123", "delius", "bernie.b")
-    val user2 = AuthUser("456", "delius", "sheila.h")
-    val user3 = AuthUser("789", "delius", "tom.myers")
-    referralService.createDraftReferral(user1, "X123456", sampleIntervention.id)
-    referralService.createDraftReferral(user1, "X123456", sampleIntervention.id)
-    referralService.createDraftReferral(user2, "X123456", sampleIntervention.id)
-    entityManager.flush()
-
-    whenever(referralAccessFilter.probationPractitionerReferrals(anyList(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
-
-    val single = referralService.getDraftReferralsForUser(user2)
-    assertThat(single).hasSize(1)
-
-    val multiple = referralService.getDraftReferralsForUser(user1)
-    assertThat(multiple).hasSize(2)
-
-    val none = referralService.getDraftReferralsForUser(user3)
-    assertThat(none).hasSize(0)
-  }
-
-  @Test
-  fun `completion date must be in the future`() {
-    val update = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 1, 1))
-    val error = assertThrows<ValidationError> {
-      referralService.updateDraftReferral(sampleReferral, update)
-    }
-    assertThat(error.errors.size).isEqualTo(1)
-    assertThat(error.errors[0].field).isEqualTo("completionDeadline")
-  }
-
-  @Test
-  fun `when needsInterpreter is true, interpreterLanguage must be set`() {
-    // this is fine
-    referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(needsInterpreter = false))
-
-    val error = assertThrows<ValidationError> {
-      // this throws ValidationError
-      referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(needsInterpreter = true))
-    }
-    assertThat(error.errors.size).isEqualTo(1)
-    assertThat(error.errors[0].field).isEqualTo("needsInterpreter")
-
-    // this is also fine
-    referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(needsInterpreter = true, interpreterLanguage = "German"))
-  }
-
-  @Test
-  fun `when hasAdditionalResponsibilities is true, whenUnavailable must be set`() {
-    // this is fine
-    referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(hasAdditionalResponsibilities = false))
-
-    val error = assertThrows<ValidationError> {
-      // this throws ValidationError
-      referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(hasAdditionalResponsibilities = true))
-    }
-    assertThat(error.errors.size).isEqualTo(1)
-    assertThat(error.errors[0].field).isEqualTo("hasAdditionalResponsibilities")
-
-    // this is also fine
-    referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(hasAdditionalResponsibilities = true, whenUnavailable = "wednesdays"))
-  }
-
-  @Test
-  fun `multiple errors at once`() {
-    val update = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 1, 1), needsInterpreter = true)
-    val error = assertThrows<ValidationError> {
-      referralService.updateDraftReferral(sampleReferral, update)
-    }
-    assertThat(error.errors.size).isEqualTo(2)
-  }
-
-  @Test
-  fun `the referral isn't actually updated if any of the fields contain validation errors`() {
-    // any invalid fields should mean that no fields are written to the db
-    val update = DraftReferralDTO(
-      // valid field
-      additionalNeedsInformation = "requires wheelchair access",
-      // invalid field
-      completionDeadline = LocalDate.of(2020, 1, 1),
-    )
-    val error = assertThrows<ValidationError> {
-      referralService.updateDraftReferral(sampleReferral, update)
     }
 
-    entityManager.flush()
-    assertThat(referralService.getDraftReferralForUser(sampleReferral.id, userFactory.create())!!.additionalNeedsInformation).isNull()
-  }
+    @Test
+    fun `assignment to a user adds a new assignment record to the trail of assignments`() {
+      val r = referralFactory.createSent()
+      val assigner = userFactory.create(id = "1000", userName = "test-admin@example.org")
+      val assignedTo1 = userFactory.create(id = "5000", userName = "assignee1@example.org")
+      val assignedTo2 = userFactory.create(id = "5001", userName = "assignee2@example.org")
 
-  @Test
-  fun `once a draft referral is sent it's id is no longer is a valid draft referral`() {
-    val user = AuthUser("user_id", "delius", "user_name")
-    val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
-    draftReferral.additionalRiskInformation = "risk"
+      referralService.assignSentReferral(r, assigner, assignedTo1)
+      referralService.assignSentReferral(r, assigner, assignedTo2)
 
-    assertThat(referralService.getDraftReferralForUser(draftReferral.id, user)).isNotNull()
-
-    val sentReferral = referralService.sendDraftReferral(draftReferral, user)
-
-    assertThat(referralService.getDraftReferralForUser(draftReferral.id, user)).isNull()
-    assertThat(referralService.getSentReferralForUser(draftReferral.id, user)).isNotNull()
-  }
-
-  @Test
-  fun `sending a draft referral generates a referral reference number`() {
-    val user = AuthUser("user_id", "delius", "user_name")
-    val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
-    draftReferral.additionalRiskInformation = "risk"
-
-    assertThat(draftReferral.referenceNumber).isNull()
-
-    val sentReferral = referralService.sendDraftReferral(draftReferral, user)
-    assertThat(sentReferral.referenceNumber).isNotNull()
-  }
-
-  @Test
-  fun `sending a draft referral generates a unique reference, even if the previous reference already exists`() {
-    val user = AuthUser("user_id", "delius", "user_name")
-    val draft1 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
-    val draft2 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
-    draft1.additionalRiskInformation = "risk"
-    draft2.additionalRiskInformation = "risk"
-
-    whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.name))
-      .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
-
-    val sent1 = referralService.sendDraftReferral(draft1, user)
-    assertThat(sent1.referenceNumber).isEqualTo("AA0000ZZ")
-
-    val sent2 = referralService.sendDraftReferral(draft2, user)
-    assertThat(sent2.referenceNumber).isNotEqualTo("AA0000ZZ").isEqualTo("BB0000ZZ")
-  }
-
-  @Test
-  fun `sending a draft referral triggers an event`() {
-    val user = AuthUser("user_id", "delius", "user_name")
-    val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
-    draftReferral.additionalRiskInformation = "risk"
-
-    referralService.sendDraftReferral(draftReferral, user)
-    verify(communityAPIReferralService).send(draftReferral)
-    verify(referralEventPublisher).referralSentEvent(draftReferral)
-  }
-
-  @Test
-  fun `multiple draft referrals can be started by the same user`() {
-    val user = AuthUser("multi_user_id", "delius", "user_name")
-    whenever(referralAccessFilter.probationPractitionerReferrals(anyList(), any())).then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
-
-    for (i in 1..3) {
-      assertDoesNotThrow { referralService.createDraftReferral(user, "X123456", sampleIntervention.id) }
+      with(r.assignments[0]) {
+        assertThat(this.assignedBy).isEqualTo(assigner)
+        assertThat(this.assignedTo).isEqualTo(assignedTo1)
+      }
+      with(r.assignments[1]) {
+        assertThat(this.assignedAt).isAfterOrEqualTo(r.assignments[0].assignedAt)
+        assertThat(this.assignedBy).isEqualTo(assigner)
+        assertThat(this.assignedTo).isEqualTo(assignedTo2)
+      }
     }
-    assertThat(referralService.getDraftReferralsForUser(user)).hasSize(3)
+
+    @Test
+    fun `assignment to a user marks older records superseded`() {
+      val r = referralFactory.createSent()
+      val assigner = userFactory.create(id = "1000", userName = "test-admin@example.org")
+      val assignedTo1 = userFactory.create(id = "5000", userName = "assignee1@example.org")
+      val assignedTo2 = userFactory.create(id = "5001", userName = "assignee2@example.org")
+      val assignedTo3 = userFactory.create(id = "5002", userName = "assignee3@example.org")
+
+      referralService.assignSentReferral(r, assigner, assignedTo1)
+      referralService.assignSentReferral(r, assigner, assignedTo2)
+      referralService.assignSentReferral(r, assigner, assignedTo3)
+
+      assertThat(r.assignments.map { it.superseded })
+        .containsExactly(true, true, false)
+    }
+
+    @Test
+    fun `update cannot overwrite identifier fields`() {
+      val draftReferral = DraftReferralDTO(
+        id = UUID.fromString("ce364949-7301-497b-894d-130f34a98bff"),
+        createdAt = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
+      )
+
+      val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
+      assertThat(updated.id).isEqualTo(sampleReferral.id)
+      assertThat(updated.createdAt).isEqualTo(sampleReferral.createdAt)
+    }
+
+    @Test
+    fun `null fields in the update do not overwrite original fields`() {
+      sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
+      entityManager.persistAndFlush(sampleReferral)
+
+      val draftReferral = DraftReferralDTO(completionDeadline = null)
+
+      val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
+      assertThat(updated.completionDeadline).isEqualTo(LocalDate.of(2021, 6, 26))
+    }
+
+    @Test
+    fun `non-null fields in the update overwrite original fields`() {
+      sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
+      entityManager.persistAndFlush(sampleReferral)
+
+      val today = LocalDate.now()
+      val draftReferral = DraftReferralDTO(completionDeadline = today)
+
+      val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
+      assertThat(updated.completionDeadline).isEqualTo(today)
+    }
+
+    @Test
+    fun `update mutates the original object`() {
+      sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
+      entityManager.persistAndFlush(sampleReferral)
+
+      val today = LocalDate.now()
+      val draftReferral = DraftReferralDTO(completionDeadline = today)
+
+      val updated = referralService.updateDraftReferral(sampleReferral, draftReferral)
+      assertThat(updated.completionDeadline).isEqualTo(today)
+    }
+
+    @Test
+    fun `update successfully persists the updated draft referral`() {
+      sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
+      entityManager.persistAndFlush(sampleReferral)
+
+      val today = LocalDate.now()
+      val draftReferral = DraftReferralDTO(completionDeadline = today)
+      referralService.updateDraftReferral(sampleReferral, draftReferral)
+      val savedDraftReferral = referralService.getDraftReferralForUser(sampleReferral.id, userFactory.create())
+      assertThat(savedDraftReferral!!.id).isEqualTo(sampleReferral.id)
+      assertThat(savedDraftReferral.createdAt).isEqualTo(sampleReferral.createdAt)
+      assertThat(savedDraftReferral.completionDeadline).isEqualTo(draftReferral.completionDeadline)
+    }
+
+    @Test
+    fun `create and persist non-cohort draft referral`() {
+      val authUser = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = referralService.createDraftReferral(authUser, "X123456", sampleIntervention.id)
+      entityManager.flush()
+
+      val savedDraftReferral = referralService.getDraftReferralForUser(draftReferral.id, authUser)
+      assertThat(savedDraftReferral!!.id).isNotNull
+      assertThat(savedDraftReferral.createdAt).isNotNull
+      assertThat(savedDraftReferral.createdBy).isEqualTo(authUser)
+      assertThat(savedDraftReferral.serviceUserCRN).isEqualTo("X123456")
+      assertThat(savedDraftReferral.selectedServiceCategories).hasSize(1)
+      assertThat(savedDraftReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(
+        sampleIntervention.dynamicFrameworkContract.contractType.serviceCategories.elementAt(
+          0
+        ).id
+      )
+    }
+
+    @Test
+    fun `create and persist cohort draft referral`() {
+      val authUser = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = referralService.createDraftReferral(authUser, "X123456", sampleCohortIntervention.id)
+      entityManager.flush()
+
+      val savedDraftReferral = referralService.getDraftReferralForUser(draftReferral.id, authUser)
+      assertThat(savedDraftReferral!!.id).isNotNull
+      assertThat(savedDraftReferral.createdAt).isNotNull
+      assertThat(savedDraftReferral.createdBy).isEqualTo(authUser)
+      assertThat(savedDraftReferral.serviceUserCRN).isEqualTo("X123456")
+      assertThat(savedDraftReferral.selectedServiceCategories).isNull()
+    }
+
+    @Test
+    fun `get a draft referral`() {
+      sampleReferral.completionDeadline = LocalDate.of(2021, 6, 26)
+      entityManager.persistAndFlush(sampleReferral)
+
+      val savedDraftReferral = referralService.getDraftReferralForUser(sampleReferral.id, userFactory.create())
+      assertThat(savedDraftReferral!!.id).isEqualTo(sampleReferral.id)
+      assertThat(savedDraftReferral.createdAt).isEqualTo(sampleReferral.createdAt)
+      assertThat(savedDraftReferral.completionDeadline).isEqualTo(sampleReferral.completionDeadline)
+    }
+
+    @Test
+    fun `find by userID returns list of draft referrals`() {
+      val user1 = AuthUser("123", "delius", "bernie.b")
+      val user2 = AuthUser("456", "delius", "sheila.h")
+      val user3 = AuthUser("789", "delius", "tom.myers")
+      referralService.createDraftReferral(user1, "X123456", sampleIntervention.id)
+      referralService.createDraftReferral(user1, "X123456", sampleIntervention.id)
+      referralService.createDraftReferral(user2, "X123456", sampleIntervention.id)
+      entityManager.flush()
+
+      val single = referralService.getDraftReferralsForUser(user2)
+      assertThat(single).hasSize(1)
+
+      val multiple = referralService.getDraftReferralsForUser(user1)
+      assertThat(multiple).hasSize(2)
+
+      val none = referralService.getDraftReferralsForUser(user3)
+      assertThat(none).hasSize(0)
+    }
+
+    @Test
+    fun `completion date must be in the future`() {
+      val update = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 1, 1))
+      val error = assertThrows<ValidationError> {
+        referralService.updateDraftReferral(sampleReferral, update)
+      }
+      assertThat(error.errors.size).isEqualTo(1)
+      assertThat(error.errors[0].field).isEqualTo("completionDeadline")
+    }
+
+    @Test
+    fun `when needsInterpreter is true, interpreterLanguage must be set`() {
+      // this is fine
+      referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(needsInterpreter = false))
+
+      val error = assertThrows<ValidationError> {
+        // this throws ValidationError
+        referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(needsInterpreter = true))
+      }
+      assertThat(error.errors.size).isEqualTo(1)
+      assertThat(error.errors[0].field).isEqualTo("needsInterpreter")
+
+      // this is also fine
+      referralService.updateDraftReferral(
+        sampleReferral,
+        DraftReferralDTO(needsInterpreter = true, interpreterLanguage = "German")
+      )
+    }
+
+    @Test
+    fun `when hasAdditionalResponsibilities is true, whenUnavailable must be set`() {
+      // this is fine
+      referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(hasAdditionalResponsibilities = false))
+
+      val error = assertThrows<ValidationError> {
+        // this throws ValidationError
+        referralService.updateDraftReferral(sampleReferral, DraftReferralDTO(hasAdditionalResponsibilities = true))
+      }
+      assertThat(error.errors.size).isEqualTo(1)
+      assertThat(error.errors[0].field).isEqualTo("hasAdditionalResponsibilities")
+
+      // this is also fine
+      referralService.updateDraftReferral(
+        sampleReferral,
+        DraftReferralDTO(hasAdditionalResponsibilities = true, whenUnavailable = "wednesdays")
+      )
+    }
+
+    @Test
+    fun `multiple errors at once`() {
+      val update = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 1, 1), needsInterpreter = true)
+      val error = assertThrows<ValidationError> {
+        referralService.updateDraftReferral(sampleReferral, update)
+      }
+      assertThat(error.errors.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `the referral isn't actually updated if any of the fields contain validation errors`() {
+      // any invalid fields should mean that no fields are written to the db
+      val update = DraftReferralDTO(
+        // valid field
+        additionalNeedsInformation = "requires wheelchair access",
+        // invalid field
+        completionDeadline = LocalDate.of(2020, 1, 1),
+      )
+      val error = assertThrows<ValidationError> {
+        referralService.updateDraftReferral(sampleReferral, update)
+      }
+
+      entityManager.flush()
+      assertThat(
+        referralService.getDraftReferralForUser(
+          sampleReferral.id,
+          userFactory.create()
+        )!!.additionalNeedsInformation
+      ).isNull()
+    }
+
+    @Test
+    fun `once a draft referral is sent it's id is no longer is a valid draft referral`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+
+      assertThat(referralService.getDraftReferralForUser(draftReferral.id, user)).isNotNull()
+
+      val sentReferral = referralService.sendDraftReferral(draftReferral, user)
+
+      assertThat(referralService.getDraftReferralForUser(draftReferral.id, user)).isNull()
+      assertThat(referralService.getSentReferralForUser(draftReferral.id, user)).isNotNull()
+    }
+
+    @Test
+    fun `sending a draft referral generates a referral reference number`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+
+      assertThat(draftReferral.referenceNumber).isNull()
+
+      val sentReferral = referralService.sendDraftReferral(draftReferral, user)
+      assertThat(sentReferral.referenceNumber).isNotNull()
+    }
+
+    @Test
+    fun `sending a draft referral generates a unique reference, even if the previous reference already exists`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draft1 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      val draft2 = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draft1.additionalRiskInformation = "risk"
+      draft2.additionalRiskInformation = "risk"
+
+      whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.name))
+        .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
+
+      val sent1 = referralService.sendDraftReferral(draft1, user)
+      assertThat(sent1.referenceNumber).isEqualTo("AA0000ZZ")
+
+      val sent2 = referralService.sendDraftReferral(draft2, user)
+      assertThat(sent2.referenceNumber).isNotEqualTo("AA0000ZZ").isEqualTo("BB0000ZZ")
+    }
+
+    @Test
+    fun `sending a draft referral triggers an event`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = referralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+
+      referralService.sendDraftReferral(draftReferral, user)
+      verify(communityAPIReferralService).send(draftReferral)
+      verify(referralEventPublisher).referralSentEvent(draftReferral)
+    }
+
+    @Test
+    fun `multiple draft referrals can be started by the same user`() {
+      val user = AuthUser("multi_user_id", "delius", "user_name")
+
+      for (i in 1..3) {
+        assertDoesNotThrow { referralService.createDraftReferral(user, "X123456", sampleIntervention.id) }
+      }
+      assertThat(referralService.getDraftReferralsForUser(user)).hasSize(3)
+    }
   }
 
   @Nested
   @DisplayName("get sent referrals with a probation practitioner user")
   inner class GetSentReferralsPPUser {
-    @BeforeEach
-    fun setup() {
-      // do not test access restrictions in these tests; only test selection of referrals
-      val anySpec: Specification<Referral> = any()
-      whenever(referralAccessFilter.probationPractitionerReferrals(anySpec, any()))
-        .then(AdditionalAnswers.returnsFirstArg<Specification<Referral>>())
-    }
-
     @Test
     fun `returns referrals started by the user`() {
       val user = userFactory.create("pp_user_1", "delius")
@@ -534,9 +541,259 @@ class ReferralServiceTest @Autowired constructor(
       (1..8).map { referralFactory.createSent(createdBy = user) }
 
       val pageSize = 5
-      val page = referralService.getSentReferralsForUser(user, null, null, null, null, Pageable.ofSize(pageSize)) as Page<Referral>
+      val page = referralService.getSentReferralsForUser(
+        user,
+        null,
+        null,
+        null,
+        null,
+        Pageable.ofSize(pageSize)
+      ) as Page<Referral>
       assertThat(page.content.size).isEqualTo(pageSize)
       assertThat(page.totalElements).isEqualTo(8)
+    }
+  }
+
+  @Nested
+  @DisplayName("get sent referrals with a provider user")
+  inner class GetSentReferralsSPUser {
+    @Test
+    fun `returns a Page of results if the page parameter is not null`() {
+      val referrals = (1..8).map { referralFactory.createSent() }
+      val contracts = referrals.map { it.intervention.dynamicFrameworkContract }
+      val user = userFactory.create("test_user", "auth")
+
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(serviceProviderFactory.create()), contracts.toSet()))
+
+      val pageSize = 5
+      val page = referralService.getSentReferralsForUser(
+        user,
+        null,
+        null,
+        null,
+        null,
+        Pageable.ofSize(pageSize)
+      ) as Page<Referral>
+      assertThat(page.content.size).isEqualTo(pageSize)
+      assertThat(page.totalElements).isEqualTo(8)
+    }
+
+    @Test
+    fun `filters sent referrals based on users contract groups`() {
+      val validContracts = (1..3).map { contractFactory.create() }
+      val invalidContracts = (1..2).map { contractFactory.create() }
+
+      (validContracts + invalidContracts).forEach { referralFactory.createSent(intervention = interventionFactory.create(contract = it)) }
+      val user = userFactory.create("test_user", "auth")
+
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(serviceProviderFactory.create()), validContracts.toSet()))
+
+      val filteredReferrals = referralService.getSentReferralsForUser(user, null, null, null, null, null)
+      assertThat((filteredReferrals as List<Views.SentReferral>).size).isEqualTo(3)
+      assertThat(filteredReferrals.map { it.intervention.dynamicFrameworkContract }).doesNotContain(*invalidContracts.toTypedArray())
+    }
+  }
+
+  @Nested
+  @DisplayName("get sent referrals summary with a service provider user")
+  inner class GetServiceProviderSummaries {
+    @Test
+    fun `user with multiple providers can see referrals where the providers are subcontractors`() {
+      val userProviders = listOf("test_org_1", "test_org_2").map { id -> serviceProviderFactory.create(id = id, name = id) }
+      val contractWithUserProviderAsPrime = contractFactory.create(primeProvider = userProviders[0])
+      val contractWithUserProviderAsSub = contractFactory.create(subcontractorProviders = setOf(userProviders[0]))
+      val contractWithUserProviderAsBothPrimeAndSub = contractFactory.create(primeProvider = userProviders[0], subcontractorProviders = setOf(userProviders[1]))
+      val contractWithNoUserProviders = contractFactory.create()
+
+      val primeRef = referralFactory.createSent(intervention = interventionFactory.create(contract = contractWithUserProviderAsPrime))
+      val primeAndSubRef = referralFactory.createSent(intervention = interventionFactory.create(contract = contractWithUserProviderAsBothPrimeAndSub))
+      val refWithAllProvidersBeingSubs = referralFactory.createSent(intervention = interventionFactory.create(contract = contractWithUserProviderAsSub))
+      val subRef = referralFactory.createSent(intervention = interventionFactory.create(contract = contractWithUserProviderAsSub))
+      val noAccess = referralFactory.createSent(intervention = interventionFactory.create(contract = contractWithNoUserProviders))
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(userProviders.toSet(), setOf(contractWithUserProviderAsBothPrimeAndSub, contractWithUserProviderAsPrime, contractWithUserProviderAsSub)))
+
+      val result = referralService.getServiceProviderSummaries(user)
+      assertThat(result.size).isEqualTo(4)
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
+      assertThat(referralIds).doesNotContain(noAccess.id)
+      assertThat(referralIds).containsAll(
+        listOf(
+          primeRef.id,
+          primeAndSubRef.id,
+          refWithAllProvidersBeingSubs.id,
+          subRef.id
+        )
+      )
+    }
+
+    @Test
+    fun `referrals that are sent, premature end requested or prematurely ended are returned`() {
+      val provider = serviceProviderFactory.create(id = "test")
+      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
+
+      val refLive = referralFactory.createSent(intervention = intervention)
+      val refPrematureEnded = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        endRequestedAt = OffsetDateTime.now(),
+        concludedAt = OffsetDateTime.now(),
+      ).also { referral ->
+        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral)
+      }
+
+      val refPrematureEndRequested = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        endRequestedAt = OffsetDateTime.now(),
+        concludedAt = null
+      )
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
+      val result = referralService.getServiceProviderSummaries(user)
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
+      assertThat(referralIds).containsExactlyInAnyOrder(refLive.id, refPrematureEnded.id, refPrematureEndRequested.id)
+    }
+
+    @Test
+    fun `referrals that are cancelled with no SAA feedback are not returned`() {
+      val provider = serviceProviderFactory.create(id = "test")
+      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
+
+      val refCancelled = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        concludedAt = OffsetDateTime.now(),
+        endOfServiceReport = null,
+      )
+
+      val appointment = appointmentFactory.create(referral = refCancelled)
+      val supplierAssessmentAppointment =
+        supplierAssessmentFactory.create(appointment = appointment, referral = refCancelled)
+      refCancelled.supplierAssessment = supplierAssessmentAppointment
+      entityManager.refresh(refCancelled)
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
+      val result = referralService.getServiceProviderSummaries(user)
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
+      assertThat(referralIds).isEmpty()
+    }
+
+    @Test
+    fun `referrals that are cancelled with SAA feedback are returned`() {
+      val provider = serviceProviderFactory.create(id = "test")
+      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
+
+      val refCancelled = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        concludedAt = OffsetDateTime.now(),
+        endOfServiceReport = null,
+      )
+
+      val appointment =
+        appointmentFactory.create(referral = refCancelled, attendanceSubmittedAt = OffsetDateTime.now())
+      val supplierAssessmentAppointment =
+        supplierAssessmentFactory.create(appointment = appointment, referral = refCancelled)
+      refCancelled.supplierAssessment = supplierAssessmentAppointment
+      entityManager.refresh(refCancelled)
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
+      val result = referralService.getServiceProviderSummaries(user)
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
+      assertThat(referralIds).containsExactly(refCancelled.id)
+    }
+
+    @Test
+    fun `referrals that are cancelled with Action Plan created but not submitted are not returned`() {
+      val provider = serviceProviderFactory.create(id = "test")
+      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
+
+      val refCancelled = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        concludedAt = OffsetDateTime.now(),
+        endOfServiceReport = null,
+      )
+
+      actionPlanFactory.create(referral = refCancelled)
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
+      val result = referralService.getServiceProviderSummaries(user)
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
+      assertThat(referralIds).isEmpty()
+    }
+
+    @Test
+    fun `referrals that are cancelled with Action Plan submitted are returned`() {
+      val provider = serviceProviderFactory.create(id = "test")
+      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
+
+      val refCancelled = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        concludedAt = OffsetDateTime.now(),
+        endOfServiceReport = null,
+      )
+
+      actionPlanFactory.createSubmitted(referral = refCancelled)
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
+      val result = referralService.getServiceProviderSummaries(user)
+      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
+      assertThat(referralIds).containsExactly(refCancelled.id)
+    }
+
+    @Test
+    fun `sent referral summary provides correct details for end of service report`() {
+      val provider = serviceProviderFactory.create(id = "test")
+      val contract = contractFactory.create(primeProvider = provider)
+      val intervention = interventionFactory.create(contract = contract)
+
+      val refLive = referralFactory.createSent(intervention = intervention)
+      val endOfServiceReportCreated = referralFactory.createSent(
+        intervention = intervention
+      ).also { referral ->
+        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral)
+      }
+      val endOfServiceReportSubmitted = referralFactory.createEnded(
+        intervention = intervention,
+        endRequestedReason = cancellationReasonFactory.create("ANY"),
+        concludedAt = OffsetDateTime.now(),
+      ).also { referral ->
+        referral.endOfServiceReport =
+          endOfServiceReportFactory.create(referral = referral, submittedAt = OffsetDateTime.now())
+      }
+
+      val user = userFactory.create("test_user", "auth")
+      whenever(serviceProviderAccessScopeMapper.fromUser(user))
+        .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
+      val result = referralService.getServiceProviderSummaries(user)
+
+      val refLiveSummary = result.find { it.referralId == refLive.id.toString() }
+      assertThat(refLiveSummary!!.endOfServiceReportId).isNull()
+      assertThat(refLiveSummary!!.endOfServiceReportSubmittedAt).isNull()
+      val endOfServiceReportCreatedSummary = result.find { it.referralId == endOfServiceReportCreated.id.toString() }
+      assertThat(endOfServiceReportCreatedSummary!!.endOfServiceReportId).isNotNull()
+      assertThat(endOfServiceReportCreatedSummary!!.endOfServiceReportSubmittedAt).isNull()
+      val endOfServiceReportSubmittedSummary =
+        result.find { it.referralId == endOfServiceReportSubmitted.id.toString() }
+      assertThat(endOfServiceReportSubmittedSummary!!.endOfServiceReportId).isNotNull()
+      assertThat(endOfServiceReportSubmittedSummary!!.endOfServiceReportSubmittedAt).isNotNull()
     }
   }
 
@@ -555,7 +812,6 @@ class ReferralServiceTest @Autowired constructor(
 
     @BeforeEach
     fun `setup referrals`() {
-
       user = userFactory.create("test_user", "auth")
       otherUser = userFactory.create(id = "randomId1236798", userName = "otherUserName")
       provider = serviceProviderFactory.create("test")
@@ -596,10 +852,6 @@ class ReferralServiceTest @Autowired constructor(
         )
       )
 
-      // not testing access restrictions; only test selection of referrals
-      val anySpec: Specification<Referral> = any()
-      whenever(referralAccessFilter.serviceProviderReferrals(anySpec, any()))
-        .then(AdditionalAnswers.returnsFirstArg<Specification<Referral>>())
       whenever(serviceProviderAccessScopeMapper.fromUser(user))
         .thenReturn(ServiceProviderAccessScope(setOf(provider), setOf(intervention.dynamicFrameworkContract)))
     }
@@ -607,7 +859,13 @@ class ReferralServiceTest @Autowired constructor(
     @Test
     fun `by default only non sent referrals are filtered`() {
       val result = referralService.getSentReferralsForUser(user, null, null, null, null, null)
-      assertThat(result).containsExactlyInAnyOrder(completedReferral, liveReferral, cancelledReferral, selfAssignedReferral, otherAssignedReferral)
+      assertThat(result).containsExactlyInAnyOrder(
+        completedReferral,
+        liveReferral,
+        cancelledReferral,
+        selfAssignedReferral,
+        otherAssignedReferral
+      )
       assertThat(result).doesNotContain(draftReferral)
     }
 
@@ -629,14 +887,28 @@ class ReferralServiceTest @Autowired constructor(
     fun `setting cancelled returns only cancelled referrals`() {
       val result = referralService.getSentReferralsForUser(user, null, true, null, null, null)
       assertThat(result).containsExactlyInAnyOrder(cancelledReferral)
-      assertThat(result).doesNotContain(draftReferral, completedReferral, liveReferral, selfAssignedReferral, otherAssignedReferral)
+      assertThat(result).doesNotContain(
+        draftReferral,
+        completedReferral,
+        liveReferral,
+        selfAssignedReferral,
+        otherAssignedReferral
+      )
     }
 
     @Test
     fun `setting not cancelled returns only non cancelled referrals`() {
       val result = referralService.getSentReferralsForUser(user, null, false, null, null, null)
-      assertThat(result).containsExactlyInAnyOrder(completedReferral, liveReferral, selfAssignedReferral, otherAssignedReferral)
-      assertThat(result).doesNotContain(draftReferral, cancelledReferral)
+
+      assertThat(result).containsExactlyInAnyOrder(
+        completedReferral,
+        liveReferral,
+        selfAssignedReferral,
+        otherAssignedReferral
+      )
+
+      assertThat(result).doesNotContain(cancelledReferral)
+      assertThat(result).doesNotContain(draftReferral)
     }
 
     @Test
@@ -657,289 +929,53 @@ class ReferralServiceTest @Autowired constructor(
     fun `setting assigned to returns referrals with correct assignments`() {
       val result = referralService.getSentReferralsForUser(user, null, null, false, otherUser.id, null)
       assertThat(result).containsExactlyInAnyOrder(otherAssignedReferral)
-      assertThat(result).doesNotContain(draftReferral, completedReferral, liveReferral, cancelledReferral, selfAssignedReferral)
+      assertThat(result).doesNotContain(
+        draftReferral,
+        completedReferral,
+        liveReferral,
+        cancelledReferral,
+        selfAssignedReferral
+      )
     }
 
     @Test
     fun `setting assigned to with unknown user returns no referrals`() {
       val result = referralService.getSentReferralsForUser(user, null, null, false, "unknown", null)
       assertThat(result).isEmpty()
-      assertThat(result).doesNotContain(draftReferral, completedReferral, liveReferral, cancelledReferral, otherAssignedReferral, selfAssignedReferral)
+      assertThat(result).doesNotContain(
+        draftReferral,
+        completedReferral,
+        liveReferral,
+        cancelledReferral,
+        otherAssignedReferral,
+        selfAssignedReferral
+      )
     }
 
     @Test
     fun `setting all filter options to true will return cancelled and unassigned referral`() {
       val result = referralService.getSentReferralsForUser(user, true, true, true, null, null)
       assertThat(result).containsExactlyInAnyOrder(cancelledReferral)
-      assertThat(result).doesNotContain(draftReferral, completedReferral, liveReferral, selfAssignedReferral, otherAssignedReferral)
+      assertThat(result).doesNotContain(
+        draftReferral,
+        completedReferral,
+        liveReferral,
+        selfAssignedReferral,
+        otherAssignedReferral
+      )
     }
 
     @Test
     fun `setting all filter options to false will return an assigned referral`() {
       val result = referralService.getSentReferralsForUser(user, false, false, false, user.id, null)
       assertThat(result).containsExactlyInAnyOrder(selfAssignedReferral)
-      assertThat(result).doesNotContain(draftReferral, completedReferral, liveReferral, cancelledReferral, otherAssignedReferral)
-    }
-  }
-
-  @Nested
-  @DisplayName("get sent referrals with a provider user")
-  inner class GetSentReferralsSPUser {
-    private lateinit var otherPrime: ServiceProvider
-    private lateinit var otherSub: ServiceProvider
-
-    private fun newReferralWithProviders(prime: ServiceProvider, vararg subs: ServiceProvider): Referral {
-      val intervention = interventionFactory.create(
-        contract = contractFactory.create(primeProvider = prime, subcontractorProviders = subs.toSet())
+      assertThat(result).doesNotContain(
+        draftReferral,
+        completedReferral,
+        liveReferral,
+        cancelledReferral,
+        otherAssignedReferral
       )
-      return referralFactory.createSent(intervention = intervention)
-    }
-
-    @BeforeEach
-    fun setup() {
-      val anySpec: Specification<Referral> = any()
-      whenever(referralAccessFilter.serviceProviderReferrals(anySpec, any()))
-        .then(AdditionalAnswers.returnsFirstArg<Specification<Referral>>())
-      otherPrime = serviceProviderFactory.create("other_prime")
-      otherSub = serviceProviderFactory.create("other_sub")
-    }
-
-    @Test
-    fun `user with multiple providers can see referrals where the providers are subcontractors`() {
-
-      val userProviders = listOf("test_org_1", "test_org_2").map(serviceProviderFactory::create)
-
-      val primeRef1 = newReferralWithProviders(userProviders[0])
-      val primeRef2 = newReferralWithProviders(userProviders[1])
-      val primeAndSubRef = newReferralWithProviders(userProviders[0], userProviders[1])
-      val refWithAllProvidersBeingSubs = newReferralWithProviders(otherPrime, userProviders[0], userProviders[1])
-      val subRef = newReferralWithProviders(otherPrime, userProviders[1])
-      val noAccess = newReferralWithProviders(otherPrime, otherSub)
-
-      val user = userFactory.create("test_user", "auth")
-
-      // not testing access restrictions; only test selection of referrals
-      val contacts = setOf(primeRef1, primeRef2, primeAndSubRef, refWithAllProvidersBeingSubs, subRef, noAccess).map { it.intervention.dynamicFrameworkContract }
-      whenever(serviceProviderAccessScopeMapper.fromUser(user))
-        .thenReturn(ServiceProviderAccessScope(userProviders.toSet(), contacts.toSet()))
-
-      val result = referralService.getSentReferralsForUser(user, null, null, null, null, null) as List<Referral>
-      assertThat(result).doesNotContain(noAccess)
-      assertThat(result).containsAll(listOf(primeRef1, primeRef2, primeAndSubRef, refWithAllProvidersBeingSubs, subRef))
-      assertThat(result.size).isEqualTo(5)
-    }
-
-    @Test
-    fun `returns a Page of results if the page parameter is not null`() {
-      val referrals = (1..8).map { newReferralWithProviders(otherPrime) }
-      val contracts = referrals.map { it.intervention.dynamicFrameworkContract }
-      val user = userFactory.create("test_user", "auth")
-
-      whenever(serviceProviderAccessScopeMapper.fromUser(user))
-        .thenReturn(ServiceProviderAccessScope(setOf(otherPrime), contracts.toSet()))
-
-      val pageSize = 5
-      val page = referralService.getSentReferralsForUser(user, null, null, null, null, Pageable.ofSize(pageSize)) as Page<Referral>
-      assertThat(page.content.size).isEqualTo(pageSize)
-      assertThat(page.totalElements).isEqualTo(8)
-    }
-  }
-
-  @Nested
-  @DisplayName("get sent referrals summary with a service provider user")
-  inner class GetServiceProviderSummaries {
-    private lateinit var otherPrime: ServiceProvider
-    private lateinit var otherSub: ServiceProvider
-
-    private fun userWithProviders(providers: List<ServiceProvider>): AuthUser {
-      val user = userFactory.create("test_user", "auth")
-      whenever(serviceProviderAccessScopeMapper.fromUser(user))
-        .thenReturn(ServiceProviderAccessScope(providers.toSet(), setOf()))
-      return user
-    }
-
-    private fun newReferralWithProviders(prime: ServiceProvider, vararg subs: ServiceProvider): Referral {
-      val intervention = interventionFactory.create(
-        contract = contractFactory.create(primeProvider = prime, subcontractorProviders = subs.toSet())
-      )
-      return referralFactory.createSent(intervention = intervention)
-    }
-
-    @BeforeEach
-    fun setup() {
-      // do not test access restrictions in these tests; only test selection of referrals
-      whenever(referralAccessFilter.serviceProviderReferralSummaries(any(), any()))
-        .then(AdditionalAnswers.returnsFirstArg<List<Referral>>())
-
-      otherPrime = serviceProviderFactory.create("other_prime")
-      otherSub = serviceProviderFactory.create("other_sub")
-    }
-
-    @Test
-    fun `user with multiple providers can see referrals where the providers are subcontractors`() {
-      val userProviders = listOf("test_org_1", "test_org_2").map { id -> serviceProviderFactory.create(id = id, name = id) }
-
-      val primeRef1 = newReferralWithProviders(userProviders[0])
-      val primeRef2 = newReferralWithProviders(userProviders[1])
-      val primeAndSubRef = newReferralWithProviders(userProviders[0], userProviders[1])
-      val refWithAllProvidersBeingSubs = newReferralWithProviders(otherPrime, userProviders[0], userProviders[1])
-      val subRef = newReferralWithProviders(otherPrime, userProviders[1])
-      val noAccess = newReferralWithProviders(otherPrime, otherSub)
-
-      val multiSubUser = userWithProviders(userProviders)
-
-      val result = referralService.getServiceProviderSummaries(multiSubUser)
-      assertThat(result.size).isEqualTo(5)
-      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
-      assertThat(referralIds).doesNotContain(noAccess.id)
-      assertThat(referralIds).containsAll(listOf(primeRef1.id, primeRef2.id, primeAndSubRef.id, refWithAllProvidersBeingSubs.id, subRef.id))
-    }
-
-    @Test
-    fun `referrals that are sent, premature end requested or prematurely ended are returned`() {
-      val provider = serviceProviderFactory.create(id = "test")
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-
-      val refLive = referralFactory.createSent(intervention = intervention)
-      val refPrematureEnded = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        endRequestedAt = OffsetDateTime.now(),
-        concludedAt = OffsetDateTime.now(),
-      ).also { referral ->
-        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral)
-      }
-
-      val refPrematureEndRequested = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        endRequestedAt = OffsetDateTime.now(),
-        concludedAt = null
-      )
-
-      val user = userWithProviders(listOf(provider))
-      val result = referralService.getServiceProviderSummaries(user)
-      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
-      assertThat(referralIds).containsExactlyInAnyOrder(refLive.id, refPrematureEnded.id, refPrematureEndRequested.id)
-    }
-
-    @Test
-    fun `referrals that are cancelled with no SAA feedback are not returned`() {
-      val provider = serviceProviderFactory.create(id = "test")
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-
-      val refCancelled = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        concludedAt = OffsetDateTime.now(),
-        endOfServiceReport = null,
-      )
-
-      val appointment = appointmentFactory.create(referral = refCancelled)
-      val supplierAssessmentAppointment = supplierAssessmentFactory.create(appointment = appointment, referral = refCancelled)
-      refCancelled.supplierAssessment = supplierAssessmentAppointment
-      entityManager.refresh(refCancelled)
-
-      val user = userWithProviders(listOf(provider))
-      val result = referralService.getServiceProviderSummaries(user)
-      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
-      assertThat(referralIds).isEmpty()
-    }
-
-    @Test
-    fun `referrals that are cancelled with SAA feedback are returned`() {
-      val provider = serviceProviderFactory.create(id = "test")
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-
-      val refCancelled = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        concludedAt = OffsetDateTime.now(),
-        endOfServiceReport = null,
-      )
-
-      val appointment = appointmentFactory.create(referral = refCancelled, attendanceSubmittedAt = OffsetDateTime.now())
-      val supplierAssessmentAppointment = supplierAssessmentFactory.create(appointment = appointment, referral = refCancelled)
-      refCancelled.supplierAssessment = supplierAssessmentAppointment
-      entityManager.refresh(refCancelled)
-
-      val user = userWithProviders(listOf(provider))
-      val result = referralService.getServiceProviderSummaries(user)
-      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
-      assertThat(referralIds).containsExactly(refCancelled.id)
-    }
-
-    @Test
-    fun `referrals that are cancelled with Action Plan created but not submitted are not returned`() {
-      val provider = serviceProviderFactory.create(id = "test")
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-
-      val refCancelled = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        concludedAt = OffsetDateTime.now(),
-        endOfServiceReport = null,
-      )
-
-      actionPlanFactory.create(referral = refCancelled)
-
-      val user = userWithProviders(listOf(provider))
-      val result = referralService.getServiceProviderSummaries(user)
-      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
-      assertThat(referralIds).isEmpty()
-    }
-
-    @Test
-    fun `referrals that are cancelled with Action Plan submitted are returned`() {
-      val provider = serviceProviderFactory.create(id = "test")
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-
-      val refCancelled = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        concludedAt = OffsetDateTime.now(),
-        endOfServiceReport = null,
-      )
-
-      actionPlanFactory.createSubmitted(referral = refCancelled)
-
-      val user = userWithProviders(listOf(provider))
-      val result = referralService.getServiceProviderSummaries(user)
-      val referralIds = result.map { summary -> UUID.fromString(summary.referralId) }
-      assertThat(referralIds).containsExactly(refCancelled.id)
-    }
-
-    @Test
-    fun `sent referral summary provides correct details for end of service report`() {
-      val provider = serviceProviderFactory.create(id = "test")
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-
-      val refLive = referralFactory.createSent(intervention = intervention)
-      val endOfServiceReportCreated = referralFactory.createSent(
-        intervention = intervention
-      ).also { referral ->
-        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral)
-      }
-      val endOfServiceReportSubmitted = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        concludedAt = OffsetDateTime.now(),
-      ).also { referral ->
-        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral, submittedAt = OffsetDateTime.now())
-      }
-
-      val user = userWithProviders(listOf(provider))
-      val result = referralService.getServiceProviderSummaries(user)
-
-      val refLiveSummary = result.find { it.referralId == refLive.id.toString() }
-      assertThat(refLiveSummary!!.endOfServiceReportId).isNull()
-      assertThat(refLiveSummary!!.endOfServiceReportSubmittedAt).isNull()
-      val endOfServiceReportCreatedSummary = result.find { it.referralId == endOfServiceReportCreated.id.toString() }
-      assertThat(endOfServiceReportCreatedSummary!!.endOfServiceReportId).isNotNull()
-      assertThat(endOfServiceReportCreatedSummary!!.endOfServiceReportSubmittedAt).isNull()
-      val endOfServiceReportSubmittedSummary = result.find { it.referralId == endOfServiceReportSubmitted.id.toString() }
-      assertThat(endOfServiceReportSubmittedSummary!!.endOfServiceReportId).isNotNull()
-      assertThat(endOfServiceReportSubmittedSummary!!.endOfServiceReportSubmittedAt).isNotNull()
     }
   }
 
@@ -950,8 +986,10 @@ class ReferralServiceTest @Autowired constructor(
     val serviceCategoryId2 = UUID.randomUUID()
     val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
     val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId2)
-    val serviceCategory1 = serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = mutableListOf(desiredOutcome1))
-    val serviceCategory2 = serviceCategoryFactory.create(id = serviceCategoryId2, desiredOutcomes = mutableListOf(desiredOutcome2))
+    val serviceCategory1 =
+      serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = mutableListOf(desiredOutcome1))
+    val serviceCategory2 =
+      serviceCategoryFactory.create(id = serviceCategoryId2, desiredOutcomes = mutableListOf(desiredOutcome2))
 
     val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1, serviceCategory2))
     val referral = referralFactory.createDraft(
@@ -976,7 +1014,8 @@ class ReferralServiceTest @Autowired constructor(
   fun `ensure that service categories constraint is not thrown when service categories is reselected with an already selected desired outcome`() {
     val serviceCategoryId = UUID.randomUUID()
     val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
-    val serviceCategory = serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = mutableListOf(desiredOutcome))
+    val serviceCategory =
+      serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = mutableListOf(desiredOutcome))
 
     val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory))
     val referral = referralFactory.createDraft(


### PR DESCRIPTION
## What does this pull request do?

the filtering of providers increases the complexity of the query
(adding several joins) but is unecessary, because the referrals are
filtered by user contract anyway.

sorry about the messy diff on the test file. this test was a bit of a mess so i moved a few things around and it's made the diff very hard to grep. i have annotated a few key changes.

## What is the intent behind these changes?
this change actually also fixes a bug fix that appears when you try to use the API sorting for paged SP referrals. it's some JPA quirk that appears when the query has DISTINCT applied.
