### PR TITLE
Switch from serial GC to G1GC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 
 USER 2000
 
-ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-XX:+AlwaysActAsServerClassMachine", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/dumps", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -13,7 +13,7 @@ env:
   {{ end }}
 
   - name: JAVA_OPTS
-    value: "-Xmx750m -XX:+AlwaysActAsServerClassMachine -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps"
+    value: "-Xmx750m"
 
   - name: APPLICATIONINSIGHTS_CONNECTION_STRING
     valueFrom:

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -13,7 +13,7 @@ env:
   {{ end }}
 
   - name: JAVA_OPTS
-    value: "-Xmx750m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps"
+    value: "-Xmx750m -XX:+AlwaysActAsServerClassMachine -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps"
 
   - name: APPLICATIONINSIGHTS_CONNECTION_STRING
     valueFrom:


### PR DESCRIPTION

## What does this pull request do?

Switch from serial GC to G1GC by forcing JVM to treat the instance as "server"

## What is the intent behind these changes?

On our current dockerised configurations, our app is running with serial
GC (https://stackoverflow.com/questions/52474162/why-is-serialgc-chosen-over-g1gc#52477898)

The serial GC "works by freezing all the application threads and
it will create a single thread to perform garbage collection", which is
not preferable in production due to its "stop the world" nature

By adding `-XX:+AlwaysActAsServerClassMachine` the default 'server' G1GC
will be chosen, which is more adequate for our use case
