### PR TITLE
Add referral indices to appointments and case notes

### DIFF
--- a/src/main/resources/db/migration/V1_94__add_referral_indices_to_appointmnets_and_case_notes.sql
+++ b/src/main/resources/db/migration/V1_94__add_referral_indices_to_appointmnets_and_case_notes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_appointment_referral ON appointment (referral_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_case_note_referral ON case_note (referral_id);


### PR DESCRIPTION
## What does this pull request do?

I noticed the appointment not indexed when I was writing some queries investigating when certain events have happened

Then I reviewed if there were any other tables with similar situations and discovered case notes are missing a lookup index too

The former is not a big deal -- most of our access is through indexed join tables; the case notes however should have a material impact

Case note query:
```SQL
EXPLAIN ANALYSE
SELECT *
FROM case_note
WHERE referral_id = '65ab2054-26ce-4c3a-9715-c09afff9f906';
```

**Before**
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/1526295/157205921-c68d9f07-3c1a-4107-af0e-2cc5aa36ddb0.png">

**After**
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/1526295/157205975-fc4746ef-2cb7-4c55-ae9b-dd9454013cfa.png">



## What is the intent behind these changes?

Primarily to improve case notes and ad-hoc appointment lookup performance
