### PR TITLE
add custom app insights event to track data about paged dashboard requests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
+import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -52,8 +53,17 @@ internal class ReferralControllerTest {
   private val cancellationReasonMapper = mock<CancellationReasonMapper>()
   private val actionPlanService = mock<ActionPlanService>()
   private val draftOasysRiskInformationService = mock<DraftOasysRiskInformationService>()
+  private val telemetryClient = mock<TelemetryClient>()
   private val referralController = ReferralController(
-    referralService, referralConcluder, serviceCategoryService, userMapper, clientApiAccessChecker, cancellationReasonMapper, actionPlanService, draftOasysRiskInformationService
+    referralService,
+    referralConcluder,
+    serviceCategoryService,
+    userMapper,
+    clientApiAccessChecker,
+    cancellationReasonMapper,
+    actionPlanService,
+    draftOasysRiskInformationService,
+    telemetryClient,
   )
   private val tokenFactory = JwtTokenFactory()
   private val referralFactory = ReferralFactory()


### PR DESCRIPTION
## What does this pull request do?

add custom app insights event to track data about paged dashboard requests

## What is the intent behind these changes?

allow us to gather date to help understand how the new paged referrals endpoint is performing for service providers.
