### PR TITLE
add app insights event to make measuring the performance of SP dashboards as number of cases vary more simple

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -162,13 +162,14 @@ class ReferralController(
   ): List<ServiceProviderSentReferralSummaryDTO> {
     val user = userMapper.fromToken(authentication)
     var dashboardType = dashboardTypeSelection?.let { DashboardType.valueOf(it) }
-    val referrals = referralService.getServiceProviderSummaries(user, dashboardType)
-    logger.info(
-      "returning list of referrals from /sent-referrals/summary/service-provider",
-      kv("numberOfReferrals", referrals.size),
-      kv("dashboardType", dashboardType),
-    )
-    return referrals.map { ServiceProviderSentReferralSummaryDTO.from(it) }
+    return referralService.getServiceProviderSummaries(user, dashboardType)
+      .map { ServiceProviderSentReferralSummaryDTO.from(it) }.also {
+        telemetryClient.trackEvent(
+          "ServiceProviderReferralSummaryRequest",
+          null,
+          mutableMapOf("totalNumberOfReferrals" to it.size.toDouble())
+        )
+      }
   }
 
   @JsonView(Views.SentReferral::class)


### PR DESCRIPTION

## What does this pull request do?

add app insights event to existing SP referral summary endpoint which allows us to measure the total number of referrals returned.

## What is the intent behind these changes?

make measuring the performance of SP dashboards as number of cases vary more simple
