### PR TITLE
Enable selecting all API pods with a label

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_helpers.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_helpers.tpl
@@ -57,14 +57,17 @@ Selector labels
 */}}
 {{- define "app.selectorLabels" -}}
 app: {{ include "app.name" . }}
+section: api
 release: {{ .Release.Name }}
 {{- end }}
 {{- define "suspectApp.selectorLabels" -}}
-app: api-suspect
+app: {{ include "app.name" . }}
+section: dashboard-api
 release: {{ .Release.Name }}
 {{- end }}
 {{- define "performanceReportApp.selectorLabels" -}}
-app: performance-report
+app: {{ include "app.name" . }}
+section: performance-report-api
 release: {{ .Release.Name }}
 {{- end }}
 {{- define "dataDictionary.selectorLabels" -}}


### PR DESCRIPTION


## What does this pull request do?

Enable selecting all API pods with a single label

## What is the intent behind these changes?

In the `ServiceMonitor` resource we can tell prometheus to scrape `/prometheus` endpoint on all pods matching the label `app: hmpps-interventions-service`

Currently, the alternative would be to define matching labels for all `app`s

Note: `release: hmpps-interventions-service` does not work as the data dictionary is currently labelled with that too
