### PR TITLE
Include the intervention title in the SentReferralSummaryDTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTO.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class SentReferralSummaryDTO(
+data class SentReferralSummaryDTO(
   val id: UUID,
   val sentAt: OffsetDateTime,
   val sentBy: AuthUserDTO,
@@ -17,7 +17,8 @@ class SentReferralSummaryDTO(
   val endRequestedComments: String?,
   val endOfServiceReport: EndOfServiceReportDTO?,
   val concludedAt: OffsetDateTime?,
-  val supplementaryRiskId: UUID
+  val supplementaryRiskId: UUID,
+  val interventionTitle: String
 ) {
   companion object {
     fun from(referral: Referral): SentReferralSummaryDTO {
@@ -35,6 +36,7 @@ class SentReferralSummaryDTO(
         endOfServiceReport = referral.endOfServiceReport?.let { EndOfServiceReportDTO.from(it) },
         concludedAt = referral.concludedAt,
         supplementaryRiskId = referral.supplementaryRiskId!!,
+        interventionTitle = referral.intervention.title
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralSummaryDTOTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUse
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -19,6 +20,7 @@ import java.util.UUID
 class SentReferralSummaryDTOTest(@Autowired private val json: JacksonTester<SentReferralSummaryDTO>) {
   private val referralFactory = ReferralFactory()
   private val actionPlanFactory = ActionPlanFactory()
+  private val interventionFactory = InterventionFactory()
 
   @Test
   fun `sent referral requires reference number, sent timestamp, sentBy, and risk id`() {
@@ -230,6 +232,19 @@ class SentReferralSummaryDTOTest(@Autowired private val json: JacksonTester<Sent
         "concludedAt": "2021-01-13T21:57:13Z"
       }
     }
+    """
+    )
+  }
+
+  @Test
+  fun `sent referral DTO includes intervention title`() {
+    val referral = referralFactory.createSent(intervention = interventionFactory.create(title = "Accommodation Services for Yorkshire"))
+    val out = json.write(SentReferralSummaryDTO.from(referral))
+    Assertions.assertThat(out).isEqualToJson(
+      """
+      {
+        "interventionTitle": "Accommodation Services for Yorkshire"
+      }
     """
     )
   }


### PR DESCRIPTION


## What does this pull request do?

Include the intervention title in the SentReferralSummaryDTO

## What is the intent behind these changes?

The intention behind this change is to remove the need for the UI
to make additional processing and API calls just to get the
intervention title.
