### PR TITLE
Label API services for prometheus metric scraping

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/service-data-dictionary.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/service-data-dictionary.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: data-dictionary
   labels:
+    app: data-dictionary
     {{- include "app.labels" . | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm_deploy/hmpps-interventions-service/templates/service.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ template "app.fullname" . }}
   labels:
+    app: hmpps-interventions-service
     {{- include "app.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
@@ -18,6 +19,7 @@ kind: Service
 metadata:
   name: api-suspect
   labels:
+    app: hmpps-interventions-service
     {{- include "app.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
@@ -33,6 +35,7 @@ kind: Service
 metadata:
   name: performance-report
   labels:
+    app: hmpps-interventions-service
     {{- include "app.labels" . | nindent 4 }}
 spec:
   type: ClusterIP


### PR DESCRIPTION


## What does this pull request do?

Label API services to make prometheus metric scraping work

## What is the intent behind these changes?

TIL that the `ServiceMonitor` does not match pods, it matches services
(rather obvious now that I read this sentence 😅)

So for prometheus scraping to work, we need to label all services that
expose the API

I chose `app: hmpps-interventions-service` because it follows the same
pattern as generic-service helm charts
