### PR TITLE
Hide metrics endpoint until we can template URIs

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -33,6 +33,10 @@ spec:
     - host: {{ .host }}
       http:
         paths:
+          - path: /prometheus
+            backend:
+              serviceName: default-http-backend
+              servicePort: 80
           - path: /sent-referrals/summary/service-provider
             backend:
               serviceName: api-suspect


### PR DESCRIPTION
## What does this pull request do?
Hide metrics endpoint until we can template URIs

## What is the intent behind these changes?

We have noticed that Spring's default `http_client_requests_seconds`
metric exposes the path paramaters, eg.

`http_client_requests_seconds_count{clientName="community-api-secure.test.delius.probation.hmpps.dsd.io",method="GET",outcome="SUCCESS",status="200",uri="/secure/offenders/crn/ACTUAL_PERSON_CRN/user/REFER_MONITOR_PP/userAccess",} 20.0`

We do not want to expose those as

1. we do not want to expose personal information unnecessarily
2. they are arguments and it messes with aggregation

Until we can rework our client class to use URI templates for this
metric, this change makes it impossible to scrape these publicly

## How to revert this change?

Once we have the above metric uses the URI template format:

`http_client_requests_seconds_count{clientName="community-api-secure.test.delius.probation.hmpps.dsd.io",method="GET",outcome="SUCCESS",status="200",uri="/secure/offenders/crn/{crn}/user/{username}/userAccess",} 20.0`

According Spring Boot docs (https://docs.spring.io/spring-boot/docs/2.6.4/reference/html/actuator.html#actuator.metrics.supported.http-clients), this `uri` key should already support templating

<img width="972" alt="image" src="https://user-images.githubusercontent.com/1526295/158603891-1c36455a-213d-4bca-8b73-ee9ffe36013d.png">
