### PR TITLE
Patch CVE-2022-0778

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,12 @@ RUN ./gradlew clean assemble -Dorg.gradle.daemon=false
 FROM adoptopenjdk/openjdk11:alpine-jre
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
       curl \
-      openssl>1.1.1n-r0 \
       tzdata
 
 ENV TZ=Europe/London

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
       curl \
+      openssl>1.1.1n-r0 \
       tzdata
 
 ENV TZ=Europe/London


### PR DESCRIPTION

## What does this pull request do?

Patch CVE-2022-0778 (upgrade openssl) by forcing `apk upgrade` to always run

## What is the intent behind these changes?

https://nvd.nist.gov/vuln/detail/CVE-2022-0778