### PR TITLE
Make use of docker layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN ./gradlew assemble
 FROM adoptopenjdk/openjdk11:alpine-jre
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
+# force a rebuild of `apk upgrade` below by invalidating the BUILD_NUMBER env variable on every commit
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 


### PR DESCRIPTION
## What does this pull request do?

Restructures the `Dockerfile` to make use of our docker layer caching.

In an event of a full cache hit (no dependency and no `src/main/` changes) the entire build step now finishes in a minute
<img width="968" alt="image" src="https://user-images.githubusercontent.com/1526295/158699272-7e5efd18-8943-4c25-94a5-3f9b73fdf017.png">

In the event of a partial cache hit (no dependency updates), the entire build step would take about ~3 minutes I believe

## How?

`ADD . .` copies all files, including `.git/` directory

This forces `./gradlew clean assemble` to always be a fresh build on all commits

Since we have docker layer caching on, we can split this into 3 steps:

1. download gradle and most dependencies
2. compile the runtime classes
3. parse .git information and create the JAR file

Each step only copies the relevant files, making it possible to cache the `./gradlew` layer.

The `.git` folder changes on every single file change, which means we have to ignore `generateGitProperties` task. We only copy git files when it is the least costly thing to do.

## What is the intent behind these changes?

To improve docker build times.