### PR TITLE
Do not alert InvalidAssumptionError into Sentry

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -41,8 +41,6 @@ class ValidationError(override val message: String, val errors: List<FieldError>
 
 class AccessError(val user: AuthUser, override val message: String, val errors: List<String>) : RuntimeException(message)
 
-class InvalidAssumptionError(assumption: String) : RuntimeException("assumption proved invalid: $assumption")
-
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
   val status: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -109,7 +109,7 @@ class CommunityAPIOffenderService(
       ?.staffIdentifier
   }
 
-  fun getResponsibleOfficer(crn: String): ResponsibleOfficer {
+  fun getResponsibleOfficer(crn: String): ResponsibleOfficer? {
     val offenderManagersPath = UriComponentsBuilder.fromPath(offenderManagersLocation)
       .buildAndExpand(crn)
       .toString()
@@ -125,12 +125,11 @@ class CommunityAPIOffenderService(
     // as with many community API endpoints, we have a few assumptions about the data.
     // if there are no ROs, we can't recover. if there are more than one, we just take
     // the first.
-    responsibleOfficers.size.let {
+    responsibleOfficers?.size?.let {
       when {
         it == 0 -> telemetryService.reportInvalidAssumption(
           "service users always have a responsible officer",
           mapOf("crn" to crn),
-          recoverable = false
         )
         it > 1 -> telemetryService.reportInvalidAssumption(
           "service users only have one responsible officer",
@@ -139,6 +138,6 @@ class CommunityAPIOffenderService(
       }
     }
 
-    return responsibleOfficers.first()
+    return responsibleOfficers?.firstOrNull()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -655,8 +655,7 @@ class ReferralService(
   }
 
   fun getResponsibleProbationPractitioner(referral: Referral): ResponsibleProbationPractitioner {
-    val sentBy = referral.sentBy?.let { it } ?: null
-    return getResponsibleProbationPractitioner(referral.serviceUserCRN, sentBy, referral.createdBy)
+    return getResponsibleProbationPractitioner(referral.serviceUserCRN, referral.sentBy, referral.createdBy)
   }
 
   fun getResponsibleProbationPractitioner(crn: String, sentBy: AuthUser?, createdBy: AuthUser): ResponsibleProbationPractitioner {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
@@ -2,21 +2,16 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.InvalidAssumptionError
 
 @Service
 class TelemetryService(
   private val telemetryClient: TelemetryClient,
 ) {
-  fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap(), recoverable: Boolean = true) {
+  fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap()) {
     telemetryClient.trackEvent(
       "InterventionsInvalidAssumption",
       mapOf("assumption" to assumption).plus(information),
       null
     )
-
-    if (!recoverable) {
-      throw InvalidAssumptionError(assumption)
-    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -11,7 +11,6 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.InvalidAssumptionError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 
 private data class MockedResponse(
@@ -98,11 +97,10 @@ internal class CommunityAPIOffenderServiceTest {
   }
 
   @Test
-  fun `getResponsibleOfficer fails when there are no responsible officers`() {
+  fun `getResponsibleOfficer returns null when there are no responsible officers`() {
     val offenderService = offenderServiceFactory(createMockedRestClient(MockedResponse(offenderManagersLocation, HttpStatus.OK, "[]")))
-    assertThrows<InvalidAssumptionError> {
-      offenderService.getResponsibleOfficer("X123456")
-    }
+    val result = offenderService.getResponsibleOfficer("X123456")
+    assertThat(result).isNull()
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

Removes the `InvalidAssumptionError` exception.

We have to monitor the occurrence of this longer-term, which is possible through AppInsights via [`customEvents | where cloud_RoleName == 'interventions-service' and name == 'InterventionsInvalidAssumption'`](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0suLS7Jz3UtS80rKVaoUSjPSC1KVUjOyS9NiQ%252FKz0n1S8xNVbC1VVDPzCtJLQKpyszPK9YtBrIzk1PVFRLzUhTyYGo8kdV45pUl5mSmOBYXl%252BYWgETUASZPoUZrAAAA/timespan/P1D)

🎯 Sprint goal: "Reduce noise in #interventions-alerts channel". This error is ignored, but occured 121 times over 14 days.

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/1526295/166440143-7a453531-3dea-42ce-9103-273771b4dec6.png">


## What is the intent behind these changes?

The `InvalidAssumptionError` exception is not an "unexpected situtation" and does not need an alert because we cannot immediately action it.

This creates noise in our exception monitoring: https://sentry.io/organizations/ministryofjustice/issues/2914226502/?project=5807819&referrer=slack

Removing the exception but keeping the telemetry will reduce noise.

## How?

`TelemetryService.reportInvalidAssumption(..., recoverable = false)` is used as a control flow; the exception is later caught again and used to branch how the data is fetched.

The change here removes the exception control flow, leading to

- No more sentry exceptions for this occurrence, while keeping the telemetry about it
- `CommunityAPIOffenderService.getResponsibleOfficer` can now return without an officer (also, 2 warnings fixed), indicating "no matching officer found"
- `getResponsibleProbationPractitioner` explicitly branches between `getContactableResponsibleOfficer` and `getContactableReferringOfficer` as a fallback
- added a new test to explicitly define what happens when the hmpps-auth call fails during `getContactableReferringOfficer` (we bubble up)

Amended test cases:

`getResponsibleProbationPractitioner`:
- uses responsible officer if they have an email
- uses the referring officer details if the community-api call fails
- uses the referring officer details if the responsible officer has no email
- uses the creator officer details if the responsible officer has no email and the referral is a draft
- aborts if it cannot retrieve responsible and referring officer details