### PR TITLE
Serve all referral list endpoints from dashboard pods

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
     - host: {{ .host }}
       http:
         paths:
-          - path: /sent-referrals/summary/service-provider
+          - path: /sent-referrals
             backend:
               serviceName: api-suspect
               servicePort: http


### PR DESCRIPTION
## What does this pull request do?

Serve all referral list endpoints from dashboard pods

## Context

1. performance issues with SP dashboards
2. separated them to api-suspect pods
3. then we fixed the performance
4. TBC finish


## What is the intent behind these changes?

This is to separate 'business as usual' load from 'dashboard' load (which is exlusively read-only and costly).

We used to serve provider endpoints from this pod -- it should now include all of them so we can see the impact on overall performance more easily.
