### PR TITLE
Migrate to generally available CronJob version

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: data-extractor-analytics

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: generate-ndmis-performance-report

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -19,7 +19,7 @@ data:
 
     rm -v /tmp/db.dump ~/.pgpass
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: db-refresh-job

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-team-kpis.yaml
@@ -9,7 +9,7 @@ data:
 {{ (.Files.Glob "reports/team_kpi*.sql").AsConfig | indent 2 }}
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: team-kpis


### PR DESCRIPTION


## What does this pull request do?

Migrate to generally available CronJob version

https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/

## What is the intent behind these changes?

Our cluster version is 1.21 which now supports CronJobs out of beta
🙌
