### PR TITLE
backfill referral_details table with existing referral details (which don't already have data in the new table)

### DIFF
--- a/src/main/resources/db/migration/V1_95_4__referral_details_backfill_with_existing_referrals.sql
+++ b/src/main/resources/db/migration/V1_95_4__referral_details_backfill_with_existing_referrals.sql
@@ -1,0 +1,26 @@
+insert into referral_details (
+    id,
+    superseded_by_id,
+    created_at,
+    created_by,
+    reason_for_change,
+    referral_id,
+    completion_deadline,
+    further_information,
+    maximum_enforceable_days
+)
+select
+    gen_random_uuid(),
+    null,
+    ref.created_at,
+    ref.created_by_id,
+    'initial referral details (populated from existing referral)',
+    ref.id,
+    ref.completion_deadline,
+    ref.further_information,
+    ref.maximum_enforceable_days
+from
+    referral ref
+        left join referral_details rd on ref.id = rd.referral_id
+where rd is null
+;


### PR DESCRIPTION


## What does this pull request do?

backfill referral_details table with existing referral details (which don't already have data in the new table)

## What is the intent behind these changes?

ensure that the new table is fully up to date with data from all existing and in progress referrals. this corresponds to step 2 in this plan https://github.com/ministryofjustice/hmpps-interventions-service/discussions/898
