### PR TITLE
delete all referral details entities in between pact test runs to avoid foreign key constraint errors when deleting referrals

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Dyn
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.NPSRegionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceProviderRepository
@@ -53,6 +54,7 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var appointmentDeliveryRepository: AppointmentDeliveryRepository
   @Autowired protected lateinit var appointmentDeliveryAddressRepository: AppointmentDeliveryAddressRepository
   @Autowired protected lateinit var caseNoteRepository: CaseNoteRepository
+  @Autowired protected lateinit var referralDetailsRepository: ReferralDetailsRepository
   protected lateinit var setupAssistant: SetupAssistant
 
   @BeforeEach
@@ -76,6 +78,7 @@ abstract class IntegrationTestBase {
       appointmentDeliveryRepository,
       appointmentDeliveryAddressRepository,
       caseNoteRepository,
+      referralDetailsRepository,
     )
     setupAssistant.cleanAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -40,6 +40,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Dyn
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.NPSRegionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceProviderRepository
@@ -84,6 +85,7 @@ class SetupAssistant(
   private val appointmentDeliveryRepository: AppointmentDeliveryRepository,
   private val appointmentDeliveryAddressRepository: AppointmentDeliveryAddressRepository,
   private val caseNoteRepository: CaseNoteRepository,
+  private val referralDetailsRepository: ReferralDetailsRepository,
 ) {
   private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
   private val interventionFactory = InterventionFactory()
@@ -114,6 +116,7 @@ class SetupAssistant(
     appointmentDeliveryRepository.deleteAll()
     appointmentRepository.deleteAll()
 
+    referralDetailsRepository.deleteAll()
     referralRepository.deleteAll()
     interventionRepository.deleteAll()
     dynamicFrameworkContractRepository.deleteAll()


### PR DESCRIPTION

## What does this pull request do?

delete all referral details entities in between pact test runs to avoid foreign key constraint errors when delete referrals

## What is the intent behind these changes?

fix the failing pact tests in the `main` branch pipeline
