### PR TITLE
Dashboard: mark repository graph Y axis as "time (seconds)"

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1647470012854,
+  "iteration": 1648808383727,
   "links": [],
   "panels": [
     {
@@ -701,7 +701,7 @@
         {
           "$$hashKey": "object:691",
           "decimals": null,
-          "format": "none",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1493,5 +1493,5 @@
   "timezone": "browser",
   "title": "HMPPS Refer and monitor an intervention",
   "uid": "PyQ91ARnk",
-  "version": 2
+  "version": 1
 }


### PR DESCRIPTION
## What does this pull request do?

Sets the Y axis unit for "Spring repository invocations" graph to "seconds".

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/1526295/161253813-c2a86e0a-9277-45ff-a2ff-25df58fa7b67.png">

## What is the intent behind these changes?

Good graph always have units.