### PR TITLE
🐛 Build with full version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN ./gradlew classes --exclude-task=generateGitProperties
 COPY src/main/ src/main/
 RUN ./gradlew classes --exclude-task=generateGitProperties
 
-# assemble extracts information from .git, this layer changes for all commits
+# assemble extracts information from .git and BUILD_NUMBER env var, these layers change for all commits
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 COPY . .
 RUN ./gradlew assemble
 


### PR DESCRIPTION


## What does this pull request do?

🐛 Build with full version number

Fixes "losing" the git SHA from the application version:
![image](https://user-images.githubusercontent.com/1526295/161770822-954583b9-84c4-46e1-bdfc-eb09a97e890a.png)


## What is the intent behind these changes?

2c7d77a34e94932f64126094759ca2e07c06aafa introduced a regression in the
application version -- the built version is `YYYY-MM-DD` now instead of
`YYYY-MM-DD.buildNumber.gitSHA`

This is because `ARG BUILD_NUMBER` was removed, which is used by the
gradle task `bootBuildInfo` to pass it in
