### PR TITLE
include 'lastName' field in 'ContactiblePerson' interface and populate it from API responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -22,6 +22,7 @@ data class ResponsibleOfficer(
   val firstName: String?,
   val email: String?,
   val staffId: Long?,
+  val lastName: String?,
 )
 
 private data class UserAccessResponse(
@@ -117,7 +118,7 @@ class CommunityAPIOffenderService(
       .retrieve()
       .bodyToFlux(OffenderManagerResponse::class.java)
       .filter { it.isResponsibleOfficer == true }
-      .map { ResponsibleOfficer(it.staff?.forenames?.substringBefore(' '), it.staff?.email, it.staffId) }
+      .map { ResponsibleOfficer(it.staff?.forenames?.substringBefore(' '), it.staff?.email, it.staffId, it.staff?.surname) }
       .collectList()
       .block()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -50,6 +50,7 @@ data class ResponsibleProbationPractitioner(
   override val email: String,
   val deliusStaffId: Long?,
   val authUser: AuthUser?,
+  override val lastName: String,
 ) : ContactablePerson
 
 @Service
@@ -617,6 +618,7 @@ class ReferralService(
           responsibleOfficer.email,
           responsibleOfficer.staffId,
           null,
+          responsibleOfficer.lastName ?: "",
         )
       }
 
@@ -640,6 +642,7 @@ class ReferralService(
       userDetail.email,
       null,
       referringProbationPractitioner,
+      userDetail.lastName
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
@@ -31,6 +31,7 @@ interface NotifyService {
 interface ContactablePerson {
   val firstName: String
   val email: String
+  val lastName: String
 }
 
 @Service

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/PactTest.kt
@@ -55,8 +55,8 @@ class PactTest : IntegrationTestBase() {
     whenever(communityAPIOffenderService.checkIfAuthenticatedDeliusUserHasAccessToServiceUser(any(), any()))
       .thenReturn(ServiceUserAccessResult(true, emptyList()))
     // required for SP users
-    whenever(hmppsAuthService.getUserDetail(any<AuthUserDTO>())).thenReturn(UserDetail("tom", "tom@tom.tom"))
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("tom", "tom@tom.tom"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUserDTO>())).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
     whenever(serviceProviderAccessScopeMapper.fromUser(any())).thenReturn(
       ServiceProviderAccessScope(
         setOf(serviceProviderFactory.create()),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
@@ -44,9 +44,9 @@ internal class CaseNotesNotificationsServiceTest {
   @Test
   fun `both PPs (responsible officer) and SPs (assignee) get notifications for a sent case note as long as they didn't send it`() {
 
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null)
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
 
     val sender = authUserFactory.createSP(id = "sp_sender", userName = "sp_user_name")
@@ -86,9 +86,9 @@ internal class CaseNotesNotificationsServiceTest {
 
   @Test
   fun `PP (responsible officer) does not get notified if they sent the case note`() {
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", 123L, null)
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", 123L, null, "last")
     )
     whenever(communityAPIOffenderService.getStaffIdentifier(any())).thenReturn(123L)
 
@@ -124,9 +124,9 @@ internal class CaseNotesNotificationsServiceTest {
   fun `PP (referring officer) does not get notified if they sent the case note`() {
     val sender = authUserFactory.createPP(id = "pp_sender")
 
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, sender)
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, sender, "last")
     )
 
     val referral = referralFactory.createAssigned()
@@ -158,9 +158,9 @@ internal class CaseNotesNotificationsServiceTest {
 
   @Test
   fun `SP (assignee) does not get notified if they sent the case note`() {
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null)
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
 
     val sender = authUserFactory.createSP(id = "sp_sender")
@@ -196,10 +196,10 @@ internal class CaseNotesNotificationsServiceTest {
   // user
   @Test
   fun `SP (assignee) does not get notified as the assignee has the same user name as the sender`() {
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     val responsiblePp = authUserFactory.createSP(id = "responsiblePp", userName = "sameUserName")
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, responsiblePp)
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, responsiblePp, "last")
     )
 
     val assignedToId = authUserFactory.createSP(id = "sp_assignedToId", userName = "sameUserName")
@@ -234,9 +234,9 @@ internal class CaseNotesNotificationsServiceTest {
 
   @Test
   fun `SP (assignee) does not get notified if the referral is unassigned`() {
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null)
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
 
     val sender = authUserFactory.createPP(id = "sender")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -107,8 +107,15 @@ internal class CommunityAPIOffenderServiceTest {
 
   @Test
   fun `getResponsibleOfficer returns first when there are multiple responsible officers`() {
-    val offenderService = offenderServiceFactory(createMockedRestClient(MockedResponse(offenderManagersLocation, HttpStatus.OK, "[{\"isResponsibleOfficer\": true, \"staff\": {\"forenames\": \"tom\", \"email\": \"tom@tom.tom\"}, \"staffId\": 123}, {\"isResponsibleOfficer\": true}]")))
+    val offenderService = offenderServiceFactory(createMockedRestClient(MockedResponse(offenderManagersLocation, HttpStatus.OK, "[{\"isResponsibleOfficer\": true, \"staff\": {\"forenames\": \"tom\", \"email\": \"tom@tom.tom\", \"surname\": \"jones\"}, \"staffId\": 123}, {\"isResponsibleOfficer\": true}]")))
     val result = offenderService.getResponsibleOfficer("X123456")
-    assertThat(result).isEqualTo(ResponsibleOfficer("tom", "tom@tom.tom", 123))
+    assertThat(result).isEqualTo(ResponsibleOfficer("tom", "tom@tom.tom", 123, "jones"))
+  }
+
+  @Test
+  fun `getResponsibleOfficer can handle null values in staff fields - we don't make any assumptions about the quality of data in delius`() {
+    val offenderService = offenderServiceFactory(createMockedRestClient(MockedResponse(offenderManagersLocation, HttpStatus.OK, "[{\"isResponsibleOfficer\": true, \"staffId\": 123}, {\"isResponsibleOfficer\": true}]")))
+    val result = offenderService.getResponsibleOfficer("X123456")
+    assertThat(result).isEqualTo(ResponsibleOfficer(null, null, 123, null))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
@@ -81,7 +81,7 @@ class NotifyActionPlanAppointmentServiceTest {
 
   @Test
   fun `appointment attendance recorded event calls email client when attended is NO`() {
-    whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null))
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
     notifyService().onApplicationEvent(generateAppointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, false, Attended.NO))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -108,7 +108,7 @@ class NotifyActionPlanAppointmentServiceTest {
 
   @Test
   fun `appointment behaviour recorded event calls email client`() {
-    whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null))
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
     notifyService().onApplicationEvent(generateAppointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanServiceTest.kt
@@ -91,7 +91,7 @@ class NotifyActionPlanServiceTest {
     val event = actionPlanApprovedEvent
     val actionPlan = event.actionPlan
     whenever(hmppsAuthService.getUserDetail(actionPlan.submittedBy!!))
-      .thenReturn(UserDetail("tom", "tom@tom.tom"))
+      .thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
 
     notifyService().onApplicationEvent(actionPlanApprovedEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -104,7 +104,7 @@ class NotifyActionPlanServiceTest {
   @Test
   fun `action plan submitted event generates valid url and sends an email`() {
     whenever(referralService.getResponsibleProbationPractitioner(any()))
-      .thenReturn(ResponsibleProbationPractitioner("tom", "tom@tom.tom", null, null))
+      .thenReturn(ResponsibleProbationPractitioner("tom", "tom@tom.tom", null, null, "jones"))
 
     notifyService().onApplicationEvent(actionPlanSubmittedEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyAppointmentServiceTest.kt
@@ -65,7 +65,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment attendance recorded event calls email client`() {
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
     notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.ATTENDANCE_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -92,7 +92,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment behaviour recorded event calls email client`() {
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
     notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.BEHAVIOUR_RECORDED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -110,7 +110,7 @@ class NotifyAppointmentServiceTest {
 
   @Test
   fun `appointment scheduled event sends email to pp`() {
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null))
+    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
     notifyService().onApplicationEvent(appointmentEvent(AppointmentEventType.SCHEDULED, true))
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyEndOfServiceReportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyEndOfServiceReportTest.kt
@@ -52,7 +52,7 @@ class NotifyEndOfServiceReportTest {
   @Test
   fun `end of service report submitted event generates valid url and sends an email`() {
     whenever(referralService.getResponsibleProbationPractitioner(any()))
-      .thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.abc", null, null))
+      .thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.abc", null, null, "def"))
 
     notifyService().onApplicationEvent(endOfServiceReportSubmittedEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -91,7 +91,7 @@ class NotifyReferralServiceTest {
 
   @Test
   fun `referral assigned event generates valid url and sends an email`() {
-    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("tom", "tom@tom.tom"))
+    whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
 
     notifyService().onApplicationEvent(referralAssignedEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -757,7 +757,7 @@ class ReferralServiceUnitTest {
 
   @Test
   fun `getResponsibleProbationPractitioner uses responsible officer`() {
-    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", "tom@tom.tom", 123))
+    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", "tom@tom.tom", 123, "jones"))
     val pp = referralService.getResponsibleProbationPractitioner(referralFactory.createSent())
     assertThat(pp.firstName).isEqualTo("tom")
     assertThat(pp.email).isEqualTo("tom@tom.tom")
@@ -767,7 +767,7 @@ class ReferralServiceUnitTest {
   fun `getResponsibleProbationPractitioner uses sender if there is an unexpected error`() {
     val sender = authUserFactory.create("sender")
     whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenThrow(ReadTimeoutException.INSTANCE)
-    whenever(hmppsAuthService.getUserDetail(sender)).thenReturn(UserDetail("andrew", "andrew@tom.tom"))
+    whenever(hmppsAuthService.getUserDetail(sender)).thenReturn(UserDetail("andrew", "andrew@tom.tom", "marr"))
     val pp = referralService.getResponsibleProbationPractitioner(referralFactory.createSent(sentBy = sender))
     assertThat(pp.firstName).isEqualTo("andrew")
     assertThat(pp.email).isEqualTo("andrew@tom.tom")
@@ -776,8 +776,8 @@ class ReferralServiceUnitTest {
   @Test
   fun `getResponsibleProbationPractitioner uses sender if there is no responsible officer email address`() {
     val sender = authUserFactory.create("sender")
-    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", null, 123))
-    whenever(hmppsAuthService.getUserDetail(sender)).thenReturn(UserDetail("andrew", "andrew@tom.tom"))
+    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", null, 123, "jones"))
+    whenever(hmppsAuthService.getUserDetail(sender)).thenReturn(UserDetail("andrew", "andrew@tom.tom", "marr"))
     val pp = referralService.getResponsibleProbationPractitioner(referralFactory.createSent(sentBy = sender))
     assertThat(pp.firstName).isEqualTo("andrew")
     assertThat(pp.email).isEqualTo("andrew@tom.tom")
@@ -786,8 +786,8 @@ class ReferralServiceUnitTest {
   @Test
   fun `getResponsibleProbationPractitioner uses creator if there is no responsible officer email address`() {
     val creator = authUserFactory.create("creator")
-    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", null, 123))
-    whenever(hmppsAuthService.getUserDetail(creator)).thenReturn(UserDetail("dan", "dan@tom.tom"))
+    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", null, 123, "jones"))
+    whenever(hmppsAuthService.getUserDetail(creator)).thenReturn(UserDetail("dan", "dan@tom.tom", "walker"))
     val pp = referralService.getResponsibleProbationPractitioner(referralFactory.createDraft(createdBy = creator))
     assertThat(pp.firstName).isEqualTo("dan")
     assertThat(pp.email).isEqualTo("dan@tom.tom")


### PR DESCRIPTION

## What does this pull request do?

include 'lastName' field in 'ContactiblePerson' interface and populate it from API responses

## What is the intent behind these changes?

we require the PP lastname for emails about changes to the referral.
