### PR TITLE
Expose the service in the developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: hmpps-interventions
+  title: HMPPS Refer and monitor an intervention
+  description: Refer and monitor an intervention for people on probation or in custody
+spec:
+  owner: group:hmpps-interventions-dev
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: hmpps-interventions-service
+  title: Intervention service (REST API)
+  description: Domain API for tracking the lifecycle of CRS (Commissioned Rehabilitative Services) interventions and services
+  tags:
+    - kotlin
+    - spring-boot
+spec:
+  type: service
+  owner: group:hmpps-interventions-dev
+  system: system:hmpps-interventions
+  lifecycle: production
+  providesApis:
+    - api:hmpps-interventions-service
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: hmpps-interventions-service
+  title: Intervention service (REST API)
+  description: Domain API for tracking the lifecycle of CRS (Commissioned Rehabilitative Services) interventions and services
+spec:
+  type: openapi
+  lifecycle: production
+  owner: group:hmpps-interventions-dev
+  system: system:hmpps-interventions
+  definition:
+    $json: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/v3/api-docs


### PR DESCRIPTION
## What does this pull request do?

This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Developer Portal - Ministry of Justice software catalog](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/).

This portal scrapes all ministryofjustice repos for `catalog-info.yaml` [every hour](https://github.com/ministryofjustice/developer-portal/blob/d0f3debd8f05aac4d47c6aae162a6d732b9fde4e/packages/backend/src/plugins/catalog.ts#L20-L22)

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).



## What is the intent behind these changes?

To encourage self-definition of dependencies and discoverability of all Ministry of Justice applications.

If this works, we can open pull requests on these repos to add them to the 'collective'
- https://github.com/ministryofjustice/hmpps-interventions-ui
- https://github.com/ministryofjustice/hmpps-delius-interventions-event-listener
- https://github.com/ministryofjustice/hmpps-interventions-ops
- https://github.com/ministryofjustice/hmpps-interventions-docs

## Notes

📝 All the teams in GitHub are automatically imported to the portal, so we can reference our github teams as `group:hmpps-interventions-dev`