### PR TITLE
Switch to weekly dependency updates (from daily)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,8 @@ updates:
 - package-ecosystem: gradle
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "software.amazon.awssdk:*"
-      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## What does this pull request do?

Switch to weekly dependency updates (from daily)

## What is the intent behind these changes?

Reduce "update noise".

Since 9029184653cafc6ab46bfac7da1a686462b26cf9 we have automatic merging of dependencies, so we can "bulk" update them without pain.

This change intends to avoid non-security updates "piling up", eg.

```
efc4a6ef PR #932 :dependabot:gradle/com.vladmihalcea-hibernate-types-52-2.15.2 (6 hours ago)
921fc9b6 PR #928 :dependabot:gradle/com.vladmihalcea-hibernate-types-52-2.15.1 (3 days ago)
7849b114 PR #924 :dependabot:gradle/com.vladmihalcea-hibernate-types-52-2.15.0 (4 days ago)
```

`software.amazon.awssdk` will now also be updated once a week, aligning with the intent.

🔐 Security updates will still be applied whenever they are opened.