### PR TITLE
Define API for developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,6 +12,9 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
+  annotations:
+    circleci.com/project-slug: github/ministryofjustice/hmpps-interventions-service
+    sentry.io/project-slug: interventions-service-prod
   name: hmpps-interventions-service
   title: Intervention service
   description: Domain API for tracking the lifecycle of CRS (Commissioned Rehabilitative Services) interventions and services

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,6 +18,9 @@ metadata:
   name: hmpps-interventions-service
   title: Intervention service
   description: Domain API for tracking the lifecycle of CRS (Commissioned Rehabilitative Services) interventions and services
+  links:
+    - url: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/meta/schema/
+      title: Data dictionary
   tags:
     - kotlin
     - spring-boot

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: hmpps-interventions-service
-  title: Intervention service (REST API)
+  title: Intervention service
   description: Domain API for tracking the lifecycle of CRS (Commissioned Rehabilitative Services) interventions and services
   tags:
     - kotlin
@@ -23,3 +23,20 @@ spec:
   owner: group:hmpps-interventions-dev
   system: system:hmpps-interventions
   lifecycle: production
+  providesApis:
+    - api:hmpps-interventions
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: hmpps-interventions
+  title: Intervention API
+  description: Domain API for tracking the lifecycle of CRS (Commissioned Rehabilitative Services) interventions and services
+spec:
+  type: openapi
+  lifecycle: production
+  owner: group:hmpps-interventions-dev
+  system: system:hmpps-interventions
+  definition:
+    $text: https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/v3/api-docs


### PR DESCRIPTION
## What does this pull request do?

- Define API for developer portal
- Define CircleCI and Sentry links for the developer portal
- Define the data dictionary link for everyone to see

## What is the intent behind these changes?

The developer portal now accepts OpenAPI definitions from default cloud-platform hostnames (it was blocked before)

This allows us to define the API exposed by this service and use `consumesApis`/`providersApis` in other components