### PR TITLE
Email ro on referral completion deadline changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -54,7 +54,10 @@ class ReferralEventPublisher(
         mapOf(
           "newDetails" to ReferralDetailsDTO.from(newDetails),
           "previousDetails" to ReferralDetailsDTO.from(previousDetails),
-          "currentAssignee" to referral.currentAssignee?.let { AuthUserDTO.from(it) }
+          "currentAssignee" to referral.currentAssignee?.let { AuthUserDTO.from(it) },
+          "crn" to referral.serviceUserCRN,
+          "sentBy" to referral.sentBy,
+          "createdBy" to referral.createdBy
         )
       )
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -695,4 +695,15 @@ class ReferralService(
       userDetail.lastName
     )
   }
+
+  fun isUserTheResponsibleOfficer(responsibleOfficer: ResponsibleProbationPractitioner, user: AuthUser): Boolean {
+    return userTypeChecker.isProbationPractitionerUser(user) &&
+      (
+        (responsibleOfficer.authUser?.let { it == user } ?: false) ||
+          (
+            responsibleOfficer.deliusStaffId?.let { it == communityAPIOffenderService.getStaffIdentifier(user) }
+              ?: false // if the RO doesn't have a staff ID we cannot determine if they are the sender, so assume not
+            )
+        )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -42,8 +42,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification.ReferralSpecifications
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.SENDER
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -55,12 +53,7 @@ data class ResponsibleProbationPractitioner(
   val deliusStaffId: Long?,
   val authUser: AuthUser?,
   override val lastName: String,
-  var role: ProbationPractitionerRole = SENDER
 ) : ContactablePerson
-
-enum class ProbationPractitionerRole {
-  RESPONSIBLE_OFFICER, SENDER
-}
 
 @Service
 @Transactional
@@ -664,20 +657,6 @@ class ReferralService(
   fun getResponsibleProbationPractitioner(referral: Referral): ResponsibleProbationPractitioner {
     val sentBy = referral.sentBy?.let { it } ?: null
     return getResponsibleProbationPractitioner(referral.serviceUserCRN, sentBy, referral.createdBy)
-  }
-
-  fun getResponsibleProbationPractitioner(referral: Referral, user: AuthUser): ResponsibleProbationPractitioner {
-    val sentBy = referral.sentBy?.let { it } ?: null
-    return getResponsibleProbationPractitioner(referral.serviceUserCRN, sentBy, referral.createdBy, user)
-  }
-
-  fun getResponsibleProbationPractitioner(crn: String, sentBy: AuthUser?, createdBy: AuthUser, user: AuthUser): ResponsibleProbationPractitioner {
-    val responsibleProbationPractitioner = getResponsibleProbationPractitioner(crn, sentBy, createdBy)
-    val isUserResponsibleOfficer = isUserTheResponsibleOfficer(responsibleProbationPractitioner, user)
-    if (isUserResponsibleOfficer) {
-      responsibleProbationPractitioner.role = RESPONSIBLE_OFFICER
-    }
-    return responsibleProbationPractitioner
   }
 
   fun getResponsibleProbationPractitioner(crn: String, sentBy: AuthUser?, createdBy: AuthUser): ResponsibleProbationPractitioner {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -42,6 +42,8 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification.ReferralSpecifications
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.SENDER
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -53,7 +55,12 @@ data class ResponsibleProbationPractitioner(
   val deliusStaffId: Long?,
   val authUser: AuthUser?,
   override val lastName: String,
+  var role: ProbationPractitionerRole = SENDER
 ) : ContactablePerson
+
+enum class ProbationPractitionerRole {
+  RESPONSIBLE_OFFICER, SENDER
+}
 
 @Service
 @Transactional
@@ -657,6 +664,20 @@ class ReferralService(
   fun getResponsibleProbationPractitioner(referral: Referral): ResponsibleProbationPractitioner {
     val sentBy = referral.sentBy?.let { it } ?: null
     return getResponsibleProbationPractitioner(referral.serviceUserCRN, sentBy, referral.createdBy)
+  }
+
+  fun getResponsibleProbationPractitioner(referral: Referral, user: AuthUser): ResponsibleProbationPractitioner {
+    val sentBy = referral.sentBy?.let { it } ?: null
+    return getResponsibleProbationPractitioner(referral.serviceUserCRN, sentBy, referral.createdBy, user)
+  }
+
+  fun getResponsibleProbationPractitioner(crn: String, sentBy: AuthUser?, createdBy: AuthUser, user: AuthUser): ResponsibleProbationPractitioner {
+    val responsibleProbationPractitioner = getResponsibleProbationPractitioner(crn, sentBy, createdBy)
+    val isUserResponsibleOfficer = isUserTheResponsibleOfficer(responsibleProbationPractitioner, user)
+    if (isUserResponsibleOfficer) {
+      responsibleProbationPractitioner.role = RESPONSIBLE_OFFICER
+    }
+    return responsibleProbationPractitioner
   }
 
   fun getResponsibleProbationPractitioner(crn: String, sentBy: AuthUser?, createdBy: AuthUser): ResponsibleProbationPractitioner {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.CreateCaseN
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -40,10 +39,11 @@ class CaseNotesNotificationsService(
   }
 
   private fun emailResponsibleProbationPractitioner(referral: Referral, sender: AuthUser, caseNoteId: UUID) {
-    val responsibleOfficer = referralService.getResponsibleProbationPractitioner(referral, sender)
+    val responsibleOfficer = referralService.getResponsibleProbationPractitioner(referral)
+    val senderIsResponsibleOfficer = referralService.isUserTheResponsibleOfficer(responsibleOfficer, sender)
 
     // if the case note was sent by someone other than the RO, email the RO
-    if (responsibleOfficer.role != RESPONSIBLE_OFFICER) {
+    if (!senderIsResponsibleOfficer) {
       emailSender.sendEmail(
         sentTemplate,
         responsibleOfficer.email,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
@@ -40,15 +40,7 @@ class CaseNotesNotificationsService(
 
   private fun emailResponsibleProbationPractitioner(referral: Referral, sender: AuthUser, caseNoteId: UUID) {
     val responsibleOfficer = referralService.getResponsibleProbationPractitioner(referral)
-    val senderIsResponsibleOfficer =
-      userTypeChecker.isProbationPractitionerUser(sender) &&
-        (
-          (responsibleOfficer.authUser?.let { it == sender } ?: false) ||
-            (
-              responsibleOfficer.deliusStaffId?.let { it == communityAPIOffenderService.getStaffIdentifier(sender) }
-                ?: false // if the RO doesn't have a staff ID we cannot determine if they are the sender, so assume not
-              )
-          )
+    val senderIsResponsibleOfficer = referralService.isUserTheResponsibleOfficer(responsibleOfficer, sender)
 
     // if the case note was sent by someone other than the RO, email the RO
     if (!senderIsResponsibleOfficer) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.CreateCaseN
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
 import java.util.UUID
 import javax.transaction.Transactional
 
@@ -39,11 +40,10 @@ class CaseNotesNotificationsService(
   }
 
   private fun emailResponsibleProbationPractitioner(referral: Referral, sender: AuthUser, caseNoteId: UUID) {
-    val responsibleOfficer = referralService.getResponsibleProbationPractitioner(referral)
-    val senderIsResponsibleOfficer = referralService.isUserTheResponsibleOfficer(responsibleOfficer, sender)
+    val responsibleOfficer = referralService.getResponsibleProbationPractitioner(referral, sender)
 
     // if the case note was sent by someone other than the RO, email the RO
-    if (!senderIsResponsibleOfficer) {
+    if (responsibleOfficer.role != RESPONSIBLE_OFFICER) {
       emailSender.sendEmail(
         sentTemplate,
         responsibleOfficer.email,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUse
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.NotifyService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.UserDetail
 import java.net.URI
@@ -89,12 +90,11 @@ class ReferralNotificationService(
     val recipient = hmppsAuthService.getUserDetail(currentAssignee)
     val newDetailsCreatedAuthUser = authUserRepository.findByIdOrNull(newDetails.createdById)
     val updater = hmppsAuthService.getUserDetail(newDetailsCreatedAuthUser!!)
-    val responsibleProbationPractitioner = referralService.getResponsibleProbationPractitioner(crn, sentBy, createdBy)
-    val isUserTheResponsibleOfficer = referralService.isUserTheResponsibleOfficer(responsibleProbationPractitioner, newDetailsCreatedAuthUser)
+    val responsibleProbationPractitioner = referralService.getResponsibleProbationPractitioner(crn, sentBy, createdBy, newDetailsCreatedAuthUser)
     val frontendUrl = generateResourceUrl(interventionsUIBaseURL, spReferralDetailsLocation, event.referral.id)
 
     if (newDetails.completionDeadline != previousDetails.completionDeadline) {
-      sendEmail(
+      sendEmailForNotifyingCompletionDeadline(
         recipient.email,
         recipient.firstName,
         newDetails,
@@ -102,8 +102,8 @@ class ReferralNotificationService(
         updater,
         frontendUrl
       )
-      if (!isUserTheResponsibleOfficer) {
-        sendEmail(
+      if (responsibleProbationPractitioner.role != RESPONSIBLE_OFFICER) {
+        sendEmailForNotifyingCompletionDeadline(
           responsibleProbationPractitioner.email,
           recipient.firstName,
           newDetails,
@@ -128,7 +128,7 @@ class ReferralNotificationService(
     }
   }
 
-  private fun sendEmail(
+  private fun sendEmailForNotifyingCompletionDeadline(
     email: String,
     firstName: String,
     newDetails: ReferralDetailsDTO,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.EmailSen
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.CreateCaseNoteEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.CaseNoteFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -45,10 +46,9 @@ internal class CaseNotesNotificationsServiceTest {
   fun `both PPs (responsible officer) and SPs (assignee) get notifications for a sent case note as long as they didn't send it`() {
 
     whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
-    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val sender = authUserFactory.createSP(id = "sp_sender", userName = "sp_user_name")
     val referral = referralFactory.createAssigned()
@@ -88,10 +88,9 @@ internal class CaseNotesNotificationsServiceTest {
   @Test
   fun `PP (responsible officer) does not get notified if they sent the case note`() {
     whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", 123L, null, "last")
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any())).thenReturn(
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", 123L, null, "last", RESPONSIBLE_OFFICER)
     )
-    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
     whenever(communityAPIOffenderService.getStaffIdentifier(any())).thenReturn(123L)
 
     val sender = authUserFactory.createPP(id = "pp_sender")
@@ -127,10 +126,9 @@ internal class CaseNotesNotificationsServiceTest {
     val sender = authUserFactory.createPP(id = "pp_sender")
 
     whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
-      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, sender, "last")
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any())).thenReturn(
+      ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, sender, "last", RESPONSIBLE_OFFICER)
     )
-    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
 
     val referral = referralFactory.createAssigned()
     val caseNote = caseNoteFactory.create(referral = referral, sentBy = sender, subject = "from pp", body = "body")
@@ -162,10 +160,9 @@ internal class CaseNotesNotificationsServiceTest {
   @Test
   fun `SP (assignee) does not get notified if they sent the case note`() {
     whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
-    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val sender = authUserFactory.createSP(id = "sp_sender")
     val referral = referralFactory.createAssigned(assignments = listOf(ReferralAssignment(OffsetDateTime.now(), sender, sender)))
@@ -202,10 +199,9 @@ internal class CaseNotesNotificationsServiceTest {
   fun `SP (assignee) does not get notified as the assignee has the same user name as the sender`() {
     whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
     val responsiblePp = authUserFactory.createSP(id = "responsiblePp", userName = "sameUserName")
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, responsiblePp, "last")
     )
-    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val assignedToId = authUserFactory.createSP(id = "sp_assignedToId", userName = "sameUserName")
     val referral = referralFactory.createAssigned(assignments = listOf(ReferralAssignment(OffsetDateTime.now(), assignedToId, assignedToId)))
@@ -240,10 +236,9 @@ internal class CaseNotesNotificationsServiceTest {
   @Test
   fun `SP (assignee) does not get notified if the referral is unassigned`() {
     whenever(hmppsAuthService.getUserDetail(any<AuthUser>())).thenReturn(UserDetail("sp", "sp@provider.co.uk", "last"))
-    whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
+    whenever(referralService.getResponsibleProbationPractitioner(any(), any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
-    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val sender = authUserFactory.createPP(id = "sender")
     val caseNote = caseNoteFactory.create(sentBy = sender, subject = "from pp", body = "body")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
@@ -48,6 +48,7 @@ internal class CaseNotesNotificationsServiceTest {
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
+    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val sender = authUserFactory.createSP(id = "sp_sender", userName = "sp_user_name")
     val referral = referralFactory.createAssigned()
@@ -90,6 +91,7 @@ internal class CaseNotesNotificationsServiceTest {
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", 123L, null, "last")
     )
+    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
     whenever(communityAPIOffenderService.getStaffIdentifier(any())).thenReturn(123L)
 
     val sender = authUserFactory.createPP(id = "pp_sender")
@@ -128,6 +130,7 @@ internal class CaseNotesNotificationsServiceTest {
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, sender, "last")
     )
+    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
 
     val referral = referralFactory.createAssigned()
     val caseNote = caseNoteFactory.create(referral = referral, sentBy = sender, subject = "from pp", body = "body")
@@ -162,6 +165,7 @@ internal class CaseNotesNotificationsServiceTest {
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
+    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val sender = authUserFactory.createSP(id = "sp_sender")
     val referral = referralFactory.createAssigned(assignments = listOf(ReferralAssignment(OffsetDateTime.now(), sender, sender)))
@@ -201,6 +205,7 @@ internal class CaseNotesNotificationsServiceTest {
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, responsiblePp, "last")
     )
+    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val assignedToId = authUserFactory.createSP(id = "sp_assignedToId", userName = "sameUserName")
     val referral = referralFactory.createAssigned(assignments = listOf(ReferralAssignment(OffsetDateTime.now(), assignedToId, assignedToId)))
@@ -238,6 +243,7 @@ internal class CaseNotesNotificationsServiceTest {
     whenever(referralService.getResponsibleProbationPractitioner(any())).thenReturn(
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", null, null, "last")
     )
+    whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
     val sender = authUserFactory.createPP(id = "sender")
     val caseNote = caseNoteFactory.create(sentBy = sender, subject = "from pp", body = "body")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -173,7 +173,10 @@ class NotifyReferralServiceTest {
               maximumNumberOfEnforceableDays = 3
             )
           ),
-          "currentAssignee" to if (assigned) AuthUserDTO.from(referral.currentAssignee!!) else null
+          "currentAssignee" to if (assigned) AuthUserDTO.from(referral.currentAssignee!!) else null,
+          "crn" to referral.serviceUserCRN,
+          "sentBy" to referral.sentBy,
+          "createdBy" to referral.createdBy
         )
       )
     }
@@ -207,7 +210,7 @@ class NotifyReferralServiceTest {
       whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
       whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
-      notifyService().onApplicationEvent(makeReferralDetailsChangedEvent(true))
+      notifyService().onApplicationEvent(makeReferralDetailsCompletionDeadlineChangedEvent(true))
       val personalisationCaptor = argumentCaptor<Map<String, String>>()
       verify(emailSender).sendEmail(eq("completionDeadlineUpdatedTemplateID"), eq("tom@tom.tom"), personalisationCaptor.capture())
       verify(emailSender).sendEmail(eq("completionDeadlineUpdatedTemplateID"), eq("abc@abc.com"), personalisationCaptor.capture())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -21,6 +21,8 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.SENDER
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.notifications.ReferralNotificationService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralDetailsFactory
@@ -186,8 +188,7 @@ class NotifyReferralServiceTest {
       whenever(authUserRepository.findById(referral.createdBy.id)).thenReturn(Optional.of(referral.createdBy))
       whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(UserDetail("sally", "sally@tom.com", "smith"))
       whenever(hmppsAuthService.getUserDetail(AuthUserDTO.from(referral.currentAssignee!!))).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
-      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
-      whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
+      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def", RESPONSIBLE_OFFICER))
 
       notifyService().onApplicationEvent(makeReferralDetailsCompletionDeadlineChangedEvent(true))
       val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -207,8 +208,7 @@ class NotifyReferralServiceTest {
       whenever(authUserRepository.findById(referral.createdBy.id)).thenReturn(Optional.of(referral.createdBy))
       whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(UserDetail("sally", "sally@tom.com", "smith"))
       whenever(hmppsAuthService.getUserDetail(AuthUserDTO.from(referral.currentAssignee!!))).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
-      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
-      whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
+      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def", SENDER))
 
       notifyService().onApplicationEvent(makeReferralDetailsCompletionDeadlineChangedEvent(true))
       val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -21,8 +21,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.SENDER
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.notifications.ReferralNotificationService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralDetailsFactory
@@ -188,7 +186,8 @@ class NotifyReferralServiceTest {
       whenever(authUserRepository.findById(referral.createdBy.id)).thenReturn(Optional.of(referral.createdBy))
       whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(UserDetail("sally", "sally@tom.com", "smith"))
       whenever(hmppsAuthService.getUserDetail(AuthUserDTO.from(referral.currentAssignee!!))).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
-      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def", RESPONSIBLE_OFFICER))
+      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
+      whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
 
       notifyService().onApplicationEvent(makeReferralDetailsCompletionDeadlineChangedEvent(true))
       val personalisationCaptor = argumentCaptor<Map<String, String>>()
@@ -208,7 +207,8 @@ class NotifyReferralServiceTest {
       whenever(authUserRepository.findById(referral.createdBy.id)).thenReturn(Optional.of(referral.createdBy))
       whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(UserDetail("sally", "sally@tom.com", "smith"))
       whenever(hmppsAuthService.getUserDetail(AuthUserDTO.from(referral.currentAssignee!!))).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
-      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def", SENDER))
+      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
+      whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
 
       notifyService().onApplicationEvent(makeReferralDetailsCompletionDeadlineChangedEvent(true))
       val personalisationCaptor = argumentCaptor<Map<String, String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -34,6 +34,7 @@ class NotifyReferralServiceTest {
   private val emailSender = mock<EmailSender>()
   private val hmppsAuthService = mock<HMPPSAuthService>()
   private val authUserRepository = mock<AuthUserRepository>()
+  private val referralService = mock<ReferralService>()
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
 
@@ -69,6 +70,7 @@ class NotifyReferralServiceTest {
       emailSender,
       hmppsAuthService,
       authUserRepository,
+      referralService
     )
   }
 
@@ -141,7 +143,10 @@ class NotifyReferralServiceTest {
               completionDeadline = LocalDate.of(2022, 4, 13)
             )
           ),
-          "currentAssignee" to if (assigned) AuthUserDTO.from(referral.currentAssignee!!) else null
+          "currentAssignee" to if (assigned) AuthUserDTO.from(referral.currentAssignee!!) else null,
+          "crn" to referral.serviceUserCRN,
+          "sentBy" to referral.sentBy,
+          "createdBy" to referral.createdBy
         )
       )
     }
@@ -178,10 +183,34 @@ class NotifyReferralServiceTest {
       whenever(authUserRepository.findById(referral.createdBy.id)).thenReturn(Optional.of(referral.createdBy))
       whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(UserDetail("sally", "sally@tom.com", "smith"))
       whenever(hmppsAuthService.getUserDetail(AuthUserDTO.from(referral.currentAssignee!!))).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
+      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
+      whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
 
       notifyService().onApplicationEvent(makeReferralDetailsCompletionDeadlineChangedEvent(true))
       val personalisationCaptor = argumentCaptor<Map<String, String>>()
       verify(emailSender).sendEmail(eq("completionDeadlineUpdatedTemplateID"), eq("tom@tom.tom"), personalisationCaptor.capture())
+      assertThat(personalisationCaptor.firstValue["caseworkerFirstName"]).isEqualTo("tom")
+      assertThat(personalisationCaptor.firstValue["newCompletionDeadline"]).isEqualTo("6 June 2022")
+      assertThat(personalisationCaptor.firstValue["previousCompletionDeadline"]).isEqualTo("13 April 2022")
+      assertThat(personalisationCaptor.firstValue["changedByName"]).isEqualTo("sally smith")
+      assertThat(personalisationCaptor.firstValue["referralDetailsUrl"]).isEqualTo("http://example.com/referral/${referral.id}")
+
+      // reason for change contains sensitive information
+      assertThat(personalisationCaptor.firstValue["reasonForChange"]).isNull()
+    }
+
+    @Test
+    fun `referral details changed event sends email to responsible officer when completion deadline has changed`() {
+      whenever(authUserRepository.findById(referral.createdBy.id)).thenReturn(Optional.of(referral.createdBy))
+      whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(UserDetail("sally", "sally@tom.com", "smith"))
+      whenever(hmppsAuthService.getUserDetail(AuthUserDTO.from(referral.currentAssignee!!))).thenReturn(UserDetail("tom", "tom@tom.tom", "jones"))
+      whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
+      whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(false)
+
+      notifyService().onApplicationEvent(makeReferralDetailsChangedEvent(true))
+      val personalisationCaptor = argumentCaptor<Map<String, String>>()
+      verify(emailSender).sendEmail(eq("completionDeadlineUpdatedTemplateID"), eq("tom@tom.tom"), personalisationCaptor.capture())
+      verify(emailSender).sendEmail(eq("completionDeadlineUpdatedTemplateID"), eq("abc@abc.com"), personalisationCaptor.capture())
       assertThat(personalisationCaptor.firstValue["caseworkerFirstName"]).isEqualTo("tom")
       assertThat(personalisationCaptor.firstValue["newCompletionDeadline"]).isEqualTo("6 June 2022")
       assertThat(personalisationCaptor.firstValue["previousCompletionDeadline"]).isEqualTo("13 April 2022")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -50,8 +50,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.SENDER
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
@@ -1124,46 +1122,6 @@ class ReferralServiceTest @Autowired constructor(
     assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
     assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId)
     assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(1)
-  }
-
-  @Test
-  fun `check if responsible probation practitioner for the referral is returned with responsibe officer as its role`() {
-
-    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("abc", "abc@abc.com", 123456L, "def"))
-    val authUser = AuthUser("123457", "delius", "bernard.beaks")
-    val createByAuthUser = AuthUser("123458", "delius", "bernard.beaks")
-    whenever(communityAPIOffenderService.getStaffIdentifier(authUser)).thenReturn(123456L)
-    whenever(hmppsAuthService.getUserDetail(createByAuthUser)).thenReturn(UserDetail("bernard", "beaks", "bernard.beaks@gmail.com"))
-
-    val expectedResponsibleProbationPractitioner = ResponsibleProbationPractitioner("abc", "abc@abc.com", 123456L, null, "def", RESPONSIBLE_OFFICER)
-
-    val responsibleProbationPractitioner = referralService.getResponsibleProbationPractitioner(
-      crn = "D007516",
-      sentBy = null,
-      createdBy = createByAuthUser,
-      user = authUser
-    )
-    assertThat(responsibleProbationPractitioner).isEqualTo(expectedResponsibleProbationPractitioner)
-  }
-
-  @Test
-  fun `check if responsible probation practitioner for the referral is returned with sender as its role`() {
-
-    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("abc", "abc@abc.com", 123456L, "def"))
-    val authUser = AuthUser("123457", "delius", "bernard.beaks")
-    val createByAuthUser = AuthUser("123458", "delius", "bernard.beaks")
-    whenever(communityAPIOffenderService.getStaffIdentifier(authUser)).thenReturn(123458L)
-    whenever(hmppsAuthService.getUserDetail(createByAuthUser)).thenReturn(UserDetail("bernard", "beaks", "bernard.beaks@gmail.com"))
-
-    val expectedResponsibleProbationPractitioner = ResponsibleProbationPractitioner("abc", "abc@abc.com", 123456L, null, "def", SENDER)
-
-    val responsibleProbationPractitioner = referralService.getResponsibleProbationPractitioner(
-      crn = "D007516",
-      sentBy = null,
-      createdBy = createByAuthUser,
-      user = authUser
-    )
-    assertThat(responsibleProbationPractitioner).isEqualTo(expectedResponsibleProbationPractitioner)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -50,6 +50,8 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.RESPONSIBLE_OFFICER
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationPractitionerRole.SENDER
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
@@ -1122,6 +1124,46 @@ class ReferralServiceTest @Autowired constructor(
     assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
     assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId)
     assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(1)
+  }
+
+  @Test
+  fun `check if responsible probation practitioner for the referral is returned with responsibe officer as its role`() {
+
+    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("abc", "abc@abc.com", 123456L, "def"))
+    val authUser = AuthUser("123457", "delius", "bernard.beaks")
+    val createByAuthUser = AuthUser("123458", "delius", "bernard.beaks")
+    whenever(communityAPIOffenderService.getStaffIdentifier(authUser)).thenReturn(123456L)
+    whenever(hmppsAuthService.getUserDetail(createByAuthUser)).thenReturn(UserDetail("bernard", "beaks", "bernard.beaks@gmail.com"))
+
+    val expectedResponsibleProbationPractitioner = ResponsibleProbationPractitioner("abc", "abc@abc.com", 123456L, null, "def", RESPONSIBLE_OFFICER)
+
+    val responsibleProbationPractitioner = referralService.getResponsibleProbationPractitioner(
+      crn = "D007516",
+      sentBy = null,
+      createdBy = createByAuthUser,
+      user = authUser
+    )
+    assertThat(responsibleProbationPractitioner).isEqualTo(expectedResponsibleProbationPractitioner)
+  }
+
+  @Test
+  fun `check if responsible probation practitioner for the referral is returned with sender as its role`() {
+
+    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("abc", "abc@abc.com", 123456L, "def"))
+    val authUser = AuthUser("123457", "delius", "bernard.beaks")
+    val createByAuthUser = AuthUser("123458", "delius", "bernard.beaks")
+    whenever(communityAPIOffenderService.getStaffIdentifier(authUser)).thenReturn(123458L)
+    whenever(hmppsAuthService.getUserDetail(createByAuthUser)).thenReturn(UserDetail("bernard", "beaks", "bernard.beaks@gmail.com"))
+
+    val expectedResponsibleProbationPractitioner = ResponsibleProbationPractitioner("abc", "abc@abc.com", 123456L, null, "def", SENDER)
+
+    val responsibleProbationPractitioner = referralService.getResponsibleProbationPractitioner(
+      crn = "D007516",
+      sentBy = null,
+      createdBy = createByAuthUser,
+      user = authUser
+    )
+    assertThat(responsibleProbationPractitioner).isEqualTo(expectedResponsibleProbationPractitioner)
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

- Email the responsible officer if there is a change in deadline and only email if the responsible officer is different to the updater.

## What is the intent behind these changes?

Emailing the service provider if there is a change in deadline is already in production but we realised even the responsible officer also needs to be intimated. There is a reason behind this change
