### PR TITLE
⚗️  Merge repeated and redirected metrics

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralMetricsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralMetricsListener.kt
@@ -34,16 +34,14 @@ class ReferralMetricsListener(
   }
 
   private fun timer(previous: Referral, current: Referral): Timer {
-    return if (current.intervention.id == previous.intervention.id) {
-      Timer.builder("intervention.referral.repeat_time")
-        .tag("crn", current.serviceUserCRN)
-        .tag("interventionId", current.intervention.id.toString())
-        .register(registry)
-    } else {
-      Timer.builder("intervention.referral.redirect_time")
-        .tag("crn", current.serviceUserCRN)
-        .register(registry)
-    }
+    val interventionKind =
+      if (current.intervention.id == previous.intervention.id) "same"
+      else "different"
+
+    return Timer.builder("intervention.referral.repeated_time")
+      .tag("crn", current.serviceUserCRN)
+      .tag("intervention", interventionKind)
+      .register(registry)
   }
 
   private fun findPreviousReferral(current: Referral): Referral? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralMetricsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralMetricsListenerTest.kt
@@ -58,11 +58,13 @@ internal class ReferralMetricsListenerTest @Autowired constructor(
       metricsListener.onApplicationEvent(createEvent(referral))
     }
 
-    registry.find("intervention.referral.repeat_time").timer().let {
+    registry.find("intervention.referral.repeated_time").tag("intervention", "same").timer().let {
       assertThat(it?.count()).isEqualTo(2)
       assertThat(it?.totalTime(TimeUnit.HOURS)).isEqualTo(2.0)
     }
-    assertThat(registry.find("intervention.referral.redirect_time").timer()).isNull()
+    assertThat(
+      registry.find("intervention.referral.repeated_time").tag("intervention", "different").timers()
+    ).isEmpty()
   }
 
   @Test
@@ -74,11 +76,13 @@ internal class ReferralMetricsListenerTest @Autowired constructor(
       metricsListener.onApplicationEvent(createEvent(referral))
     }
 
-    registry.find("intervention.referral.redirect_time").timer().let {
+    registry.find("intervention.referral.repeated_time").tag("intervention", "different").timer().let {
       assertThat(it?.count()).isEqualTo(2)
       assertThat(it?.totalTime(TimeUnit.HOURS)).isEqualTo(2.0)
     }
-    assertThat(registry.find("intervention.referral.repeat_time").timer()).isNull()
+    assertThat(
+      registry.find("intervention.referral.repeated_time").tag("intervention", "same").timers()
+    ).isEmpty()
   }
 
   @Test
@@ -92,7 +96,6 @@ internal class ReferralMetricsListenerTest @Autowired constructor(
 
     metricsListener.onApplicationEvent(createEvent(newReferral))
 
-    assertThat(registry.find("intervention.referral.repeat_time").timer()).isNull()
-    assertThat(registry.find("intervention.referral.redirect_time").timer()).isNull()
+    assertThat(registry.find("intervention.referral.repeated_time").timers()).isEmpty()
   }
 }


### PR DESCRIPTION


## What does this pull request do?

Merge (simplify) repeated and redirected metrics into one **new** metric

| Before | After |
| --- | --- |
| `intervention.referral.repeat_time` | `intervention.referral.repeated_time`<br/>with `intervention="same"` tag |
|  `intervention.referral.redirect_time` | `intervention.referral.repeated_time`<br/>with `intervention="different"` tag|

## What is the intent behind these changes?

In AppInsights, I am always selecting both metrics and even aggregate them as "either repeated or redirected"

This makes me think they are semantically the same and would be better to filter them based on a tag instead