### PR TITLE
Add garbage collection time metric to Grafana

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1648808383727,
+  "iteration": 1650876944575,
   "links": [],
   "panels": [
     {
@@ -94,7 +94,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod }}",
+          "legendFormat": "{{ container }}",
           "refId": "A"
         },
         {
@@ -796,7 +796,8 @@
     },
     {
       "aliasColors": {
-        "Limit": "#bf1b00"
+        "Limit": "#bf1b00",
+        "Requested (soft limit)": "#f2c96d"
       },
       "bars": false,
       "dashLength": 10,
@@ -804,13 +805,11 @@
       "datasource": "Prometheus",
       "decimals": null,
       "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
-      "fillGradient": 0,
+      "fillGradient": 2,
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -818,18 +817,18 @@
         "y": 33
       },
       "hiddenSeries": false,
-      "id": 14,
+      "id": 28,
       "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
         "min": false,
         "rightSide": false,
         "show": true,
-        "sideWidth": 300,
+        "sideWidth": 450,
         "total": false,
-        "values": true
+        "values": false
       },
       "lines": true,
       "linewidth": 1,
@@ -849,25 +848,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace='$namespace'}[5m]))))",
+          "exemplar": true,
+          "expr": "avg by (container)(300*rate(jvm_gc_pause_seconds_sum{namespace='$namespace'}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Recv",
+          "legendFormat": "{{ container }}",
           "refId": "A"
-        },
-        {
-          "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_transmit_bytes_total{namespace='$namespace'}[5m]))))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Sent",
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Network",
+      "title": "Garbage collection time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -884,9 +878,9 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:423",
+          "$$hashKey": "object:691",
           "decimals": null,
-          "format": "bytes",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -894,7 +888,7 @@
           "show": true
         },
         {
-          "$$hashKey": "object:424",
+          "$$hashKey": "object:692",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1021,15 +1015,17 @@
       }
     },
     {
-      "aliasColors": {},
+      "aliasColors": {
+        "Limit": "#bf1b00"
+      },
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "",
+      "decimals": null,
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "links": []
         },
         "overrides": []
       },
@@ -1042,18 +1038,20 @@
         "y": 41
       },
       "hiddenSeries": false,
-      "id": 23,
+      "id": 14,
       "legend": {
-        "avg": false,
-        "current": false,
-        "hideZero": true,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": false,
         "show": true,
+        "sideWidth": 300,
         "total": false,
-        "values": false
+        "values": true
       },
-      "lines": false,
+      "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
@@ -1062,8 +1060,8 @@
       },
       "percentage": false,
       "pluginVersion": "7.5.9",
-      "pointradius": 2,
-      "points": true,
+      "pointradius": 5,
+      "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -1071,31 +1069,30 @@
       "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
-          "expr": "avg(rate(nginx_ingress_controller_requests{status=~\"5..\",exported_namespace=\"$namespace\"}[1m])*60) by(exported_service,status)",
+          "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace='$namespace'}[5m]))))",
           "format": "time_series",
-          "interval": "60s",
-          "intervalFactor": 1,
-          "legendFormat": "{{exported_service}}@{{ status }}",
+          "intervalFactor": 2,
+          "legendFormat": "Recv",
           "refId": "A"
+        },
+        {
+          "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_transmit_bytes_total{namespace='$namespace'}[5m]))))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Sent",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "5xx responses",
+      "title": "Network",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
-      "transformations": [
-        {
-          "id": "filterByRefId",
-          "options": {}
-        }
-      ],
       "transparent": true,
       "type": "graph",
       "xaxis": {
@@ -1107,16 +1104,17 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:102",
-          "format": "short",
+          "$$hashKey": "object:423",
+          "decimals": null,
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0.00001",
+          "min": "0",
           "show": true
         },
         {
-          "$$hashKey": "object:103",
+          "$$hashKey": "object:424",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1264,7 +1262,7 @@
         "y": 49
       },
       "hiddenSeries": false,
-      "id": 24,
+      "id": 23,
       "legend": {
         "avg": false,
         "current": false,
@@ -1294,7 +1292,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(rate(nginx_ingress_controller_requests{status=~\"2..|3..\",exported_namespace=\"$namespace\"}[1m])*60) by(exported_service,status)",
+          "expr": "avg(rate(nginx_ingress_controller_requests{status=~\"5..\",exported_namespace=\"$namespace\"}[1m])*60) by(exported_service,status)",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1306,7 +1304,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "2xx, 3xx responses",
+      "title": "5xx responses",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1421,6 +1419,116 @@
       "yBucketBound": "auto",
       "yBucketNumber": null,
       "yBucketSize": null
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.9",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(rate(nginx_ingress_controller_requests{status=~\"2..|3..\",exported_namespace=\"$namespace\"}[1m])*60) by(exported_service,status)",
+          "format": "time_series",
+          "interval": "60s",
+          "intervalFactor": 1,
+          "legendFormat": "{{exported_service}}@{{ status }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "2xx, 3xx responses",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [
+        {
+          "id": "filterByRefId",
+          "options": {}
+        }
+      ],
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:102",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0.00001",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:103",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,


### PR DESCRIPTION
## What does this pull request do?

Introduce garbage collection times to [our Grafana dashboard](https://grafana.live.cloud-platform.service.justice.gov.uk/d/PyQ91ARnk/hmpps-refer-and-monitor-an-intervention?orgId=1&from=now-6h&to=now&var-namespace=hmpps-interventions-prod)

Adds the bottom graph as a new panel:

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/1526295/165125650-1ac59810-b74e-4f13-85e3-2db0c4d9c017.png">

## What is the intent behind these changes?

Get more contextual information to identify root causes in outages.