### PR TITLE
end of service report is now only required if at least one delivery session is attended, rather than attempted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -15,4 +15,11 @@ interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
       "and appt.appointmentFeedbackSubmittedAt is not null"
   )
   fun countNumberOfAttemptedSessions(referralId: UUID): Int
+
+  @Query(
+    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
+      "where sesh.referral.id = :referralId and appt.attended in ('YES', 'LATE') " +
+      "and appt.appointmentFeedbackSubmittedAt is not null"
+  )
+  fun countNumberOfAttendedSessions(referralId: UUID): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -48,8 +48,8 @@ class ReferralConcluder(
     if (allSessionsAttempted)
       return true
 
-    val atLeastOneSessionAttempted = numberOfSessionsAttempted > 0
-    if (atLeastOneSessionAttempted && referral.endRequestedAt != null)
+    val deliveredFirstSubstantiveAppointment = numberOfSessionsAttempted > 0
+    if (deliveredFirstSubstantiveAppointment && referral.endRequestedAt != null)
       return true
 
     return false
@@ -85,13 +85,11 @@ class ReferralConcluder(
 
   private fun countSessionsAttempted(referral: Referral): Int {
     return referral.currentActionPlan?.let {
-      actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
+      return actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
     } ?: 0
   }
 
   private fun countSessionsAttended(referral: Referral): Int {
-    return referral.currentActionPlan?.let {
-      actionPlanRepository.countNumberOfAttendedSessions(referral.id)
-    } ?: 0
+    return actionPlanRepository.countNumberOfAttendedSessions(referral.id)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -60,7 +60,7 @@ class ReferralConcluder(
     val hasActionPlan = nonNull(referral.currentActionPlan)
 
     val numberOfAttendedSessions = countSessionsAttended(referral)
-    val hasAttemptedNoSessions = numberOfAttendedSessions == 0
+    val hasAttendedNoSessions = numberOfAttendedSessions == 0
 
     val totalNumberOfSessions = referral.currentActionPlan?.numberOfSessions ?: 0
     val hasAttemptedSomeSessions = totalNumberOfSessions > numberOfAttendedSessions
@@ -71,7 +71,7 @@ class ReferralConcluder(
     if (!hasActionPlan)
       return CANCELLED
 
-    if (hasAttemptedNoSessions)
+    if (hasAttendedNoSessions)
       return CANCELLED
 
     if (hasAttemptedSomeSessions && hasSubmittedEndOfServiceReport)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -59,12 +59,12 @@ class ReferralConcluder(
 
     val hasActionPlan = nonNull(referral.currentActionPlan)
 
-    val numberOfAttemptedSessions = countSessionsAttempted(referral)
-    val hasAttemptedNoSessions = numberOfAttemptedSessions == 0
+    val numberOfAttendedSessions = countSessionsAttended(referral)
+    val hasAttemptedNoSessions = numberOfAttendedSessions == 0
 
     val totalNumberOfSessions = referral.currentActionPlan?.numberOfSessions ?: 0
-    val hasAttemptedSomeSessions = totalNumberOfSessions > numberOfAttemptedSessions
-    val hasAttemptedAllSessions = totalNumberOfSessions == numberOfAttemptedSessions
+    val hasAttemptedSomeSessions = totalNumberOfSessions > numberOfAttendedSessions
+    val hasAttemptedAllSessions = totalNumberOfSessions == numberOfAttendedSessions
 
     val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -43,7 +43,7 @@ class ReferralConcluder(
     if (totalNumberOfSessions == 0)
       return false
 
-    val numberOfSessionsAttempted = countSessionsAttempted(referral)
+    val numberOfSessionsAttempted = countSessionsAttended(referral)
     val allSessionsAttempted = totalNumberOfSessions == numberOfSessionsAttempted
     if (allSessionsAttempted)
       return true
@@ -86,6 +86,12 @@ class ReferralConcluder(
   private fun countSessionsAttempted(referral: Referral): Int {
     return referral.currentActionPlan?.let {
       actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
+    } ?: 0
+  }
+
+  private fun countSessionsAttended(referral: Referral): Int {
+    return referral.currentActionPlan?.let {
+      actionPlanRepository.countNumberOfAttendedSessions(referral.id)
     } ?: 0
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
@@ -23,7 +24,7 @@ class ActionPlanRepositoryTest @Autowired constructor(
   private val referralFactory = ReferralFactory(entityManager)
 
   @Test
-  fun `count number of attended appointments`() {
+  fun `count number of attempted appointments`() {
     val referral1 = referralFactory.createSent()
     (1..4).forEach {
       deliverySessionFactory.createAttended(referral = referral1, sessionNumber = it)
@@ -33,6 +34,40 @@ class ActionPlanRepositoryTest @Autowired constructor(
 
     assertThat(actionPlanRepository.countNumberOfAttemptedSessions(referral1.id)).isEqualTo(4)
     assertThat(actionPlanRepository.countNumberOfAttemptedSessions(referral2.id)).isEqualTo(1)
+  }
+
+  @Test
+  fun `count number of attended sessions`() {
+    val referral1 = referralFactory.createSent()
+    (1..4).forEach {
+      deliverySessionFactory.createAttended(referral = referral1, sessionNumber = it)
+    }
+    val referral2 = referralFactory.createSent()
+    deliverySessionFactory.createAttended(referral = referral2)
+
+    assertThat(actionPlanRepository.countNumberOfAttendedSessions(referral1.id)).isEqualTo(4)
+    assertThat(actionPlanRepository.countNumberOfAttendedSessions(referral2.id)).isEqualTo(1)
+  }
+
+  @Test
+  fun `only sessions that were attended as yes or late are included in attended count`() {
+    val referral1 = referralFactory.createSent()
+
+    deliverySessionFactory.createAttended(referral = referral1, attended = Attended.YES, sessionNumber = 1)
+    deliverySessionFactory.createAttended(referral = referral1, attended = Attended.LATE, sessionNumber = 2)
+    deliverySessionFactory.createAttended(referral = referral1, attended = Attended.NO, sessionNumber = 3)
+
+    assertThat(actionPlanRepository.countNumberOfAttendedSessions(referral1.id)).isEqualTo(2)
+  }
+
+  @Test
+  fun `scheduled sessions that are not yet attended are not included in attended count`() {
+    val referral1 = referralFactory.createSent()
+
+    deliverySessionFactory.createAttended(referral = referral1, attended = Attended.YES, sessionNumber = 1)
+    deliverySessionFactory.createScheduled(referral = referral1, sessionNumber = 2)
+
+    assertThat(actionPlanRepository.countNumberOfAttendedSessions(referral1.id)).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -65,7 +65,7 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -80,7 +80,7 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -94,7 +94,7 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -107,7 +107,7 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -119,7 +119,7 @@ internal class ReferralConcluderTest {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -131,7 +131,7 @@ internal class ReferralConcluderTest {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -144,7 +144,7 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val endOfServiceReport = endOfServiceReportFactory.create()
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = endOfServiceReport)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -153,11 +153,11 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `should flag end of service report as required if it doesn't exist and when all sessions have been attempted`() {
+  fun `should flag end of service report as required if it doesn't exist and when all sessions have been attended`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
     val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -166,11 +166,11 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `should flag end of service report as required if it doesn't exist and when at least one session has been attempted and end has been requested`() {
+  fun `should flag end of service report as required if it doesn't exist and when at least one session has been attended and end has been requested`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -190,11 +190,11 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `should not flag end of service report as required when no sessions have been attempted`() {
+  fun `should not flag end of service report as required when no sessions have been attended`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(actionPlan.id)).thenReturn(0)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
 
     val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 


### PR DESCRIPTION
## What does this pull request do?

Updates the response so that an end of service report (endOfServiceReportCreationRequired in dto) is only required if at least one delivery session has been attended. 

## What is the intent behind these changes?

The current logic is incorrect. Currently and end of service report is required if at least one session is attempted, regardless if it was attended or not.
