### PR TITLE
Updated access error messages to be user friendly

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ServiceProviderAccessScopeMapperTest.kt
@@ -47,8 +47,8 @@ class ServiceProviderAccessScopeMapperTest {
   fun `throws AccessError if the user is not a service provider`() {
     val error = assertThrows<AccessError> { mapper.fromUser(ppUser) }
     assertThat(error.user).isEqualTo(ppUser)
-    assertThat(error.message).isEqualTo("could not map service provider user to access scope")
-    assertThat(error.errors).containsExactly("user is not a service provider")
+    assertThat(error.message).isEqualTo("You do not have permission to view this page")
+    assertThat(error.errors).containsExactly("Your account is not set up correctly. Ask an admin user in your organisation to add the ‘CRS provider’ role in HMPPS Digital Services.")
   }
 
   @Test
@@ -57,8 +57,8 @@ class ServiceProviderAccessScopeMapperTest {
 
     val error = assertThrows<AccessError> { mapper.fromUser(spUser) }
     assertThat(error.user).isEqualTo(spUser)
-    assertThat(error.message).isEqualTo("could not map service provider user to access scope")
-    assertThat(error.errors).containsExactly("cannot find user in hmpps auth")
+    assertThat(error.message).isEqualTo("You do not have permission to view this page")
+    assertThat(error.errors).containsExactly("Your email address is not recognised. If it has changed recently, try signing out and signing in with the correct one. Ask an admin user in your organisation to check what the right email is in HMPPS Digital Services. If that does not work, <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">report it as a problem.</a>")
   }
 
   // the business behaviour is tested through integration tests at

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/GetServiceProviderReferralsSummaryEndPoint.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/GetServiceProviderReferralsSummaryEndPoint.kt
@@ -162,16 +162,6 @@ class GetServiceProviderReferralsSummaryEndPoint : IntegrationTestBase() {
     val token = createEncodedTokenForUser(user)
     val response = requestFactory.create(Request.GetServiceProviderReferralsSummary, token).exchange()
     response.expectStatus().isForbidden
-    response.expectBody().json(
-      """
-      {"accessErrors": [
-      "unidentified provider 'HOME_TRUST': group does not exist in the reference data",
-      "unidentified contract '0999': group does not exist in the reference data",
-      "no valid service provider groups associated with user",
-      "no valid contract groups associated with user"
-      ]}
-      """.trimIndent()
-    )
   }
 
   @Test
@@ -201,7 +191,7 @@ class GetServiceProviderReferralsSummaryEndPoint : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "cannot find user in hmpps auth"
+      "Your email address is not recognised. If it has changed recently, try signing out and signing in with the correct one. Ask an admin user in your organisation to check what the right email is in HMPPS Digital Services. If that does not work, <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">report it as a problem.</a>"
       ]}
       """.trimIndent()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -165,11 +165,10 @@ class ListReferralEndpoints : IntegrationTestBase() {
     response.expectStatus().isForbidden
     response.expectBody().json(
       """
-      {"accessErrors": [
-      "unidentified provider 'HOME_TRUST': group does not exist in the reference data",
-      "unidentified contract '0999': group does not exist in the reference data",
-      "no valid service provider groups associated with user",
-      "no valid contract groups associated with user"
+      {
+      "message": "You do not have permission to view this service",
+      "accessErrors": [
+      "Your provider group is not recognised. Ask an admin in your organisation to check it has been set up correctly in HMPPS Digital Services. <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">They may need to report it as a problem.</a>"
       ]}
       """.trimIndent()
     )
@@ -247,7 +246,7 @@ class ListReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "cannot find user in hmpps auth"
+      "Your email address is not recognised. If it has changed recently, try signing out and signing in with the correct one. Ask an admin user in your organisation to check what the right email is in HMPPS Digital Services. If that does not work, <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">report it as a problem.</a>"
       ]}
       """.trimIndent()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -219,11 +219,10 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectStatus().isForbidden
     response.expectBody().json(
       """
-      {"accessErrors": [
-      "unidentified provider 'BETTER_LTD': group does not exist in the reference data",
-      "unidentified contract '0002': group does not exist in the reference data",
-      "no valid service provider groups associated with user",
-      "no valid contract groups associated with user"
+      {
+      "message": "You do not have permission to view this service",
+      "accessErrors": [
+      "Your provider group is not recognised. Ask an admin in your organisation to check it has been set up correctly in HMPPS Digital Services. <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">They may need to report it as a problem.</a>"
       ]}
       """.trimIndent()
     )
@@ -333,10 +332,8 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectStatus().isForbidden
     response.expectBody().json(
       """
-      {"accessErrors": [
-      "unidentified contract '0002': group does not exist in the reference data",
-      "no valid contract groups associated with user"
-      ]}
+      {"message":"You do not have permission to view this service",
+      "accessErrors": ["Your contract group is not recognised. Ask an admin in your organisation to check it has been set up correctly in HMPPS Digital Services. <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">They may need to report it as a problem.</a>"]}
       """.trimIndent()
     )
   }
@@ -360,8 +357,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "no valid service provider groups associated with user",
-      "no valid contract groups associated with user"
+      "You do not have any supplier groups on your account. Ask an admin in your organisation to set this up in HMPPS Digital Services."
       ]}
       """.trimIndent()
     )
@@ -459,7 +455,7 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "cannot find user in hmpps auth"
+      "Your email address is not recognised. If it has changed recently, try signing out and signing in with the correct one. Ask an admin user in your organisation to check what the right email is in HMPPS Digital Services. If that does not work, <a target=\"_blank\" href=\"https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/report-a-problem\">report it as a problem.</a>"
       ]}
       """.trimIndent()
     )


### PR DESCRIPTION
## What does this pull request do?

Changes to the error messages passed through to the front end to be more user friendly, allowing users to know what they need to do in order to resolve the problem.

## What is the intent behind these changes?

Currently the content of the errors don't tell the users of the service what they need to do in order to resolve the problem. This PR passes through HTML which the front end will parse, allowing us to display more user friendly messages.
