### PR TITLE
Handle all dashboard requests from dashboard pods

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
             backend:
               serviceName: default-http-backend
               servicePort: 80
-          - path: /sent-referrals/summary/service-provider
+          - path: /sent-referrals
             backend:
               serviceName: api-suspect
               servicePort: http


### PR DESCRIPTION
## What does this pull request do?

Currently, paginated requests are handled by the "normal API" pods and unpaginated provider requests are handled by the "dashboard" pods.

Handle all dashboard requests (provider-facing, probation-facing, paginated, unpaginated) from dashboard pods

This path will prefix match to:

- `/sent-referrals`
- `/sent-referrals/summary/service-provider`
- `/sent-referrals/paged`


## What is the intent behind these changes?

This is to separate 'business as usual' load from 'dashboard' load (which is exclusively read-only and costly)

This PR reopens #882, which was closed in favour of #950.
#950 then was reverted by #962, so this change is still valid.