### PR TITLE
Mark all older assignments superseded

### DIFF
--- a/src/main/resources/db/migration/V1_96__mark_older_assignments_superseded.sql
+++ b/src/main/resources/db/migration/V1_96__mark_older_assignments_superseded.sql
@@ -1,0 +1,23 @@
+-- We should have an invariant for assignments that all older assignments have been superseded
+-- In other words: there is only ZERO or ONE assignment with "superseded = FALSE"
+
+-- This query fixes the old data not conforming to this rule:
+-- |referral_id                         |assigned_at                      |superseded|
+-- {snip}
+-- |e4ad07b5-7535-4836-9ab8-000000000000|2021-07-28 11:56:36.844071 +00:00|false     |
+-- |e4ad07b5-7535-4836-9ab8-000000000000|2021-07-29 14:21:01.560241 +00:00|false     |
+-- |e4ad07b5-7535-4836-9ab8-000000000000|2021-08-05 14:41:47.612426 +00:00|false     |
+
+UPDATE referral_assignments oa
+SET superseded = TRUE
+FROM referral_assignments na
+WHERE oa.referral_id = na.referral_id
+  AND oa.assigned_at < na.assigned_at
+  AND oa.superseded = FALSE;
+
+-- Result:
+-- |referral_id                         |assigned_at                      |superseded|
+-- {snip}
+-- |e4ad07b5-7535-4836-9ab8-000000000000|2021-07-28 11:56:36.844071 +00:00|true      |
+-- |e4ad07b5-7535-4836-9ab8-000000000000|2021-07-29 14:21:01.560241 +00:00|true      |
+-- |e4ad07b5-7535-4836-9ab8-000000000000|2021-08-05 14:41:47.612426 +00:00|false     |


### PR DESCRIPTION

## What does this pull request do?

Mark all older assignments superseded

## What is the intent behind these changes?

The code makes sure newer assignments get correctly superseded, but I forgot to finish this data migration

We should have an invariant for assignments that all older assignments have been superseded
In other words: there is only **zero or one** assignment with `superseded = FALSE`

This invariant will simplify querying for the typical "latest assignment"

Finishes migration started in f1f884b7d1c23da8d367d452971573550b2061c1