### PR TITLE
Fixing the case worker sorting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
+import org.hibernate.annotations.Where
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.CascadeType
@@ -59,12 +60,13 @@ class SentReferralSummary(
   @Id val id: UUID,
   @ElementCollection
   @CollectionTable(name = "referral_assignments")
+  @Where(clause = "superseded = false")
   val assignments: MutableList<ReferralAssignment> = mutableListOf(),
   @ManyToOne @Fetch(FetchMode.JOIN) var sentBy: AuthUser,
   var sentAt: OffsetDateTime,
   var concludedAt: OffsetDateTime? = null,
   var referenceNumber: String,
-  @OneToOne(mappedBy = "referral", cascade = arrayOf(CascadeType.ALL)) @PrimaryKeyJoinColumn var serviceUserData: ServiceUserData?,
+  @OneToOne(mappedBy = "referral", cascade = [CascadeType.ALL]) @PrimaryKeyJoinColumn var serviceUserData: ServiceUserData?,
   @NotNull @ManyToOne @Fetch(FetchMode.JOIN) val createdBy: AuthUser,
   var endRequestedAt: OffsetDateTime? = null,
   @NotNull @ManyToOne(fetch = FetchType.LAZY) val intervention: Intervention,


### PR DESCRIPTION
## What does this pull request do?

Filters the superseded rows from the referral assignment to the latest so that we sort with the latest case worker.

## What is the intent behind these changes?

The caseworker sorting is not working properly as it is returning the duplicated rows of caseworker. The changes are intended to reduce the duplicated rows of caseworker by filtering only the latest assignment
