### PR TITLE
Bump plugin to 4.2.0 to import security fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.2.0"
   kotlin("plugin.spring") version "1.6.21"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.6.21"
   id("jacoco")


### PR DESCRIPTION
## What does this pull request do?

Bump plugin to 4.2.0 to import security fixes

## What is the intent behind these changes?

To unblock the vulnerability scanning

Release notes: https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/e2fe19925339c5bdb0936b5f93422a9213639956/release-notes/4.2.0.md

