### PR TITLE
Fix "dependency call times" graph

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1651827910531,
+  "iteration": 1653946635075,
   "links": [],
   "panels": [
     {
@@ -779,11 +779,12 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "quantile(0.99, 300*rate(http_client_requests_seconds_sum{namespace='$namespace'}[5m])) by (clientName)",
+          "expr": "quantile(0.99, 300*rate(http_client_requests_seconds_sum{namespace='$namespace'}[5m])) by (client_name)",
           "format": "time_series",
+          "instant": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{ clientName }}",
+          "legendFormat": "{{ client_name }}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION


## What does this pull request do?

Fix "dependency call times" graph

The tag name changed from `clientName` to `client_name`, probably due to some dependency update

## What is the intent behind these changes?

To make sure we can still tell which dependency is slower

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1526295/171061810-7d56881e-d421-4774-8b4e-b1a241dd996f.png) | ![image](https://user-images.githubusercontent.com/1526295/171061789-e2cccea7-ad57-4a7d-9e76-1537a3c0ea26.png) |