### PR TITLE
Allow end of service report to be submitted with only 1 attended/late appointment (instead of all)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -11,6 +11,13 @@ interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
 
   @Query(
     "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
+      "where sesh.referral.id = :referralId and appt.attended is not null " +
+      "and appt.appointmentFeedbackSubmittedAt is not null"
+  )
+  fun countNumberOfAttemptedSessions(referralId: UUID): Int
+
+  @Query(
+    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
       "where sesh.referral.id = :referralId and appt.attended in ('YES', 'LATE') " +
       "and appt.appointmentFeedbackSubmittedAt is not null"
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -43,53 +43,50 @@ class ReferralConcluder(
     if (totalNumberOfSessions == 0)
       return false
 
-    val numberOfSessionsAttempted = countSessionsAttended(referral)
-    val allSessionsAttempted = totalNumberOfSessions == numberOfSessionsAttempted
-    if (allSessionsAttempted)
+    val endRequested = referral.endRequestedAt != null
+    if (deliveredFirstSubstantiveAppointment(referral) && endRequested)
       return true
 
-    val deliveredFirstSubstantiveAppointment = numberOfSessionsAttempted > 0
-    if (deliveredFirstSubstantiveAppointment && referral.endRequestedAt != null)
+    val numberOfAttemptedSessions = countSessionsAttempted(referral)
+    val allSessionsHaveAttendance = totalNumberOfSessions == numberOfAttemptedSessions
+    if (allSessionsHaveAttendance)
       return true
 
     return false
   }
 
   private fun getConcludedEventType(referral: Referral): ReferralEventType? {
-
     val hasActionPlan = nonNull(referral.currentActionPlan)
-
-    val numberOfAttendedSessions = countSessionsAttended(referral)
-    val hasAttendedNoSessions = numberOfAttendedSessions == 0
-
-    val totalNumberOfSessions = referral.currentActionPlan?.numberOfSessions ?: 0
-    val hasAttemptedSomeSessions = totalNumberOfSessions > numberOfAttendedSessions
-    val hasAttemptedAllSessions = totalNumberOfSessions == numberOfAttendedSessions
-
-    val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
-
     if (!hasActionPlan)
       return CANCELLED
 
-    if (hasAttendedNoSessions)
+    if (!deliveredFirstSubstantiveAppointment(referral))
       return CANCELLED
 
-    if (hasAttemptedSomeSessions && hasSubmittedEndOfServiceReport)
+    val numberOfAttemptedSessions = countSessionsAttempted(referral)
+    val totalNumberOfSessions = referral.currentActionPlan?.numberOfSessions ?: 0
+    val someSessionsHaveNoAttendance = totalNumberOfSessions > numberOfAttemptedSessions
+    val allSessionsHaveAttendance = totalNumberOfSessions == numberOfAttemptedSessions
+    val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
+
+    if (someSessionsHaveNoAttendance && hasSubmittedEndOfServiceReport)
       return PREMATURELY_ENDED
 
-    if (hasAttemptedAllSessions && hasSubmittedEndOfServiceReport)
+    if (allSessionsHaveAttendance && hasSubmittedEndOfServiceReport)
       return COMPLETED
 
     return null
   }
 
   private fun countSessionsAttempted(referral: Referral): Int {
-    return referral.currentActionPlan?.let {
-      return actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
-    } ?: 0
+    return actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
   }
 
   private fun countSessionsAttended(referral: Referral): Int {
     return actionPlanRepository.countNumberOfAttendedSessions(referral.id)
+  }
+
+  private fun deliveredFirstSubstantiveAppointment(referral: Referral): Boolean {
+    return countSessionsAttended(referral) > 0
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -43,12 +43,12 @@ class ReferralConcluder(
     if (totalNumberOfSessions == 0)
       return false
 
-    val numberOfSessionsAttended = countSessionsAttended(referral)
-    val allSessionsAttended = totalNumberOfSessions == numberOfSessionsAttended
-    if (allSessionsAttended)
+    val numberOfSessionsAttempted = countSessionsAttended(referral)
+    val allSessionsAttempted = totalNumberOfSessions == numberOfSessionsAttempted
+    if (allSessionsAttempted)
       return true
 
-    val deliveredFirstSubstantiveAppointment = numberOfSessionsAttended > 0
+    val deliveredFirstSubstantiveAppointment = numberOfSessionsAttempted > 0
     if (deliveredFirstSubstantiveAppointment && referral.endRequestedAt != null)
       return true
 
@@ -63,8 +63,8 @@ class ReferralConcluder(
     val hasAttendedNoSessions = numberOfAttendedSessions == 0
 
     val totalNumberOfSessions = referral.currentActionPlan?.numberOfSessions ?: 0
-    val hasAttendedSomeSessions = totalNumberOfSessions > numberOfAttendedSessions
-    val hasAttendedAllSessions = totalNumberOfSessions == numberOfAttendedSessions
+    val hasAttemptedSomeSessions = totalNumberOfSessions > numberOfAttendedSessions
+    val hasAttemptedAllSessions = totalNumberOfSessions == numberOfAttendedSessions
 
     val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
 
@@ -74,13 +74,19 @@ class ReferralConcluder(
     if (hasAttendedNoSessions)
       return CANCELLED
 
-    if (hasAttendedSomeSessions && hasSubmittedEndOfServiceReport)
+    if (hasAttemptedSomeSessions && hasSubmittedEndOfServiceReport)
       return PREMATURELY_ENDED
 
-    if (hasAttendedAllSessions && hasSubmittedEndOfServiceReport)
+    if (hasAttemptedAllSessions && hasSubmittedEndOfServiceReport)
       return COMPLETED
 
     return null
+  }
+
+  private fun countSessionsAttempted(referral: Referral): Int {
+    return referral.currentActionPlan?.let {
+      return actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
+    } ?: 0
   }
 
   private fun countSessionsAttended(referral: Referral): Int {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
@@ -24,6 +24,19 @@ class ActionPlanRepositoryTest @Autowired constructor(
   private val referralFactory = ReferralFactory(entityManager)
 
   @Test
+  fun `count number of attempted appointments`() {
+    val referral1 = referralFactory.createSent()
+    (1..4).forEach {
+      deliverySessionFactory.createAttended(referral = referral1, sessionNumber = it)
+    }
+    val referral2 = referralFactory.createSent()
+    deliverySessionFactory.createAttended(referral = referral2)
+
+    assertThat(actionPlanRepository.countNumberOfAttemptedSessions(referral1.id)).isEqualTo(4)
+    assertThat(actionPlanRepository.countNumberOfAttemptedSessions(referral2.id)).isEqualTo(1)
+  }
+
+  @Test
   fun `count number of attended sessions`() {
     val referral1 = referralFactory.createSent()
     (1..4).forEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -33,9 +33,19 @@ internal class ReferralConcluderTest {
     referralRepository, actionPlanRepository, referralEventPublisher
   )
 
+  private fun createReferralWithSessions(totalSessions: Int, attendedOrLate: Int, didNotAttend: Int): Referral {
+    assertThat(attendedOrLate + didNotAttend).isLessThanOrEqualTo(totalSessions)
+      .withFailMessage("test setup error: the sum of attended and did not attend sessions must not be greater than the total sessions")
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = totalSessions)
+    val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referral.id)).thenReturn(attendedOrLate)
+    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referral.id)).thenReturn(attendedOrLate + didNotAttend)
+    return referral
+  }
+
   @Test
   fun `concludes referral as cancelled when ending a referral with no action plan`() {
-
     val timeAtStart = OffsetDateTime.now()
     val referralWithNoActionPlan = referralFactory.createSent()
 
@@ -48,9 +58,8 @@ internal class ReferralConcluderTest {
   @Test
   fun `concludes referral as cancelled when ending a referral with no sessions attempted`() {
     val timeAtStart = OffsetDateTime.now()
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndNoAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndNoAttemptedSessions.id)).thenReturn(0)
+    val referralWithActionPlanAndNoAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 0, didNotAttend = 0)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttemptedSessions)
 
@@ -59,13 +68,23 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `concludes referral as prematurely ended when ending a referral with some sessions attempted and an end of service report submitted`() {
-
+  fun `concludes referral as cancelled when ending a referral without a substantive appointment (only not attended sessions)`() {
     val timeAtStart = OffsetDateTime.now()
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndNoAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 0, didNotAttend = 2)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttemptedSessions)
+
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoAttemptedSessions, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndNoAttemptedSessions, ReferralEventType.CANCELLED)
+  }
+
+  @Test
+  fun `concludes referral as prematurely ended when ending a referral with a substantive appointment and an end of service report submitted`() {
+    val timeAtStart = OffsetDateTime.now()
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -74,13 +93,24 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `concludes referral as completed when ending a referral with all sessions attempted and an end of service report submitted`() {
-
+  fun `concludes referral as completed when ending a referral when all sessions have some kind of attendance and has an end service report submitted`() {
     val timeAtStart = OffsetDateTime.now()
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttemptedSessions, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeAttemptedSessions, ReferralEventType.COMPLETED)
+  }
+
+  @Test
+  fun `concludes referral as completed when ending a referral when all sessions have been attended and has an end service report submitted`() {
+    val timeAtStart = OffsetDateTime.now()
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 2, didNotAttend = 0)
+    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -90,11 +120,9 @@ internal class ReferralConcluderTest {
 
   @Test
   fun `does not conclude a referral when ending a referral with some sessions attempted and an end of service report has not been submitted`() {
-
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -103,11 +131,9 @@ internal class ReferralConcluderTest {
 
   @Test
   fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report has not been submitted`() {
-
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
     referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -116,10 +142,8 @@ internal class ReferralConcluderTest {
 
   @Test
   fun `does not conclude a referral when ending a referral with some sessions attempted and an end of service report does not exist`() {
-
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -127,11 +151,9 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report does not exit`() {
-
-    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+  fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report does not exist`() {
+    val referralWithActionPlanAndSomeAttemptedSessions =
+      createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
 
     referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
@@ -179,7 +201,7 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `should not flag end of service report as required when action plan exists`() {
+  fun `should not flag end of service report as required when action plan is missing`() {
 
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = null)
 
@@ -195,6 +217,20 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
+
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+
+    assertThat(endOfServiceReportCreationRequired).isFalse
+    verifyNoInteractions(referralRepository, referralEventPublisher)
+  }
+
+  @Test
+  fun `should not flag end of service report as required when having only non-attended sessions`() {
+
+    val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
+    whenever(actionPlanRepository.countNumberOfAttemptedSessions(actionPlan.id)).thenReturn(1)
 
     val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -46,94 +46,94 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `concludes referral as cancelled when ending a referral with no sessions attended`() {
+  fun `concludes referral as cancelled when ending a referral with no sessions attempted`() {
     val timeAtStart = OffsetDateTime.now()
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndNoAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndNoAttendedSessions.id)).thenReturn(0)
+    val referralWithActionPlanAndNoAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referralWithActionPlanAndNoAttemptedSessions.id)).thenReturn(0)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttemptedSessions)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoAttendedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndNoAttendedSessions, ReferralEventType.CANCELLED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoAttemptedSessions, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndNoAttemptedSessions, ReferralEventType.CANCELLED)
   }
 
   @Test
-  fun `concludes referral as prematurely ended when ending a referral with some sessions attended and an end of service report submitted`() {
+  fun `concludes referral as prematurely ended when ending a referral with some sessions attempted and an end of service report submitted`() {
 
     val timeAtStart = OffsetDateTime.now()
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    referralWithActionPlanAndSomeAttendedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttendedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndSomeAttendedSessions, ReferralEventType.PREMATURELY_ENDED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttemptedSessions, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeAttemptedSessions, ReferralEventType.PREMATURELY_ENDED)
   }
 
   @Test
-  fun `concludes referral as completed when ending a referral with all sessions attended and an end of service report submitted`() {
+  fun `concludes referral as completed when ending a referral with all sessions attempted and an end of service report submitted`() {
 
     val timeAtStart = OffsetDateTime.now()
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    referralWithActionPlanAndSomeAttendedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(2)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttendedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndSomeAttendedSessions, ReferralEventType.COMPLETED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttemptedSessions, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeAttemptedSessions, ReferralEventType.COMPLETED)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with some sessions attended and an end of service report has not been submitted`() {
+  fun `does not conclude a referral when ending a referral with some sessions attempted and an end of service report has not been submitted`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    referralWithActionPlanAndSomeAttendedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with all sessions attended and an end of service report has not been submitted`() {
+  fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report has not been submitted`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    referralWithActionPlanAndSomeAttendedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(2)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with some sessions attended and an end of service report does not exist`() {
+  fun `does not conclude a referral when ending a referral with some sessions attempted and an end of service report does not exist`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with all sessions attended and an end of service report does not exit`() {
+  fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report does not exit`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(2)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttendedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
@@ -143,10 +143,10 @@ internal class ReferralConcluderTest {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val endOfServiceReport = endOfServiceReportFactory.create()
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = endOfServiceReport)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = endOfServiceReport)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttendedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -156,10 +156,10 @@ internal class ReferralConcluderTest {
   fun `should flag end of service report as required if it doesn't exist and when all sessions have been attended`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(2)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttendedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
     assertThat(endOfServiceReportCreationRequired).isTrue
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -169,10 +169,10 @@ internal class ReferralConcluderTest {
   fun `should flag end of service report as required if it doesn't exist and when at least one session has been attended and end has been requested`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttendedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttendedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
     assertThat(endOfServiceReportCreationRequired).isTrue
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -181,9 +181,9 @@ internal class ReferralConcluderTest {
   @Test
   fun `should not flag end of service report as required when action plan exists`() {
 
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = null)
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = null)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttendedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(actionPlanRepository, referralRepository, referralEventPublisher)
@@ -193,10 +193,10 @@ internal class ReferralConcluderTest {
   fun `should not flag end of service report as required when no sessions have been attended`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttendedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttendedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(referralRepository, referralEventPublisher)


### PR DESCRIPTION
## What does this pull request do?

Allow end of service report to be submitted with only 1 substantive appointment if all the sessions have some kind of attendance

## What is the intent behind these changes?

The previous changes were misunderstood by me.

The rules are:

- cancel a referral if there are no substantive delivery appointments
- require an end of service report (EoSR) when there is **at least one** attended/late delivery appointment **and** all sessions have some kind of attendance

The current rules were checking that _all_ delivery sessions are attended or late.
