### PR TITLE
allow service provider referral summaries to be filtered by a person on probation search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -122,10 +122,11 @@ class ReferralController(
     @Nullable @RequestParam(name = "cancelled", required = false) cancelled: Boolean?,
     @Nullable @RequestParam(name = "unassigned", required = false) unassigned: Boolean?,
     @Nullable @RequestParam(name = "assignedTo", required = false) assignedToUserId: String?,
+    @Nullable @RequestParam(name = "search", required = false) searchText: String?,
     @PageableDefault(page = 0, size = 50, sort = ["sentAt"]) page: Pageable,
   ): Page<SentReferralSummariesDTO> {
     val user = userMapper.fromToken(authentication)
-    return (referralService.getSentReferralSummaryForUser(user, concluded, cancelled, unassigned, assignedToUserId, page) as Page<SentReferralSummary>).map { SentReferralSummariesDTO.from(it) }.also {
+    return (referralService.getSentReferralSummaryForUser(user, concluded, cancelled, unassigned, assignedToUserId, page, searchText) as Page<SentReferralSummary>).map { SentReferralSummariesDTO.from(it) }.also {
       telemetryClient.trackEvent(
         "PagedDashboardRequest",
         null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Dynamic
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.criteria.JoinType
@@ -28,6 +29,15 @@ class ReferralSpecifications {
     fun <T> unassigned(): Specification<T> {
       return Specification<T> { root, query, cb ->
         cb.isEmpty(root.get<List<ReferralAssignment>>("assignments"))
+      }
+    }
+
+    fun <T> search(searchText: String): Specification<T> {
+      return Specification<T> { root, query, cb ->
+        val serviceUserDataJoin = root.join<T, ServiceUserData>("serviceUserData", JoinType.INNER)
+        val exp1 = cb.concat(cb.upper(serviceUserDataJoin.get("firstName")), " ")
+        val exp2 = cb.concat(exp1, cb.upper(serviceUserDataJoin.get("lastName")))
+        cb.equal(exp2, searchText.uppercase())
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -128,8 +128,8 @@ class ReferralService(
     return assignedReferral
   }
 
-  fun getSentReferralSummaryForUser(user: AuthUser, concluded: Boolean?, cancelled: Boolean?, unassigned: Boolean?, assignedToUserId: String?, page: Pageable): Iterable<SentReferralSummary> {
-    val findSentReferralsSpec: Specification<SentReferralSummary> = createSpecification(concluded, cancelled, unassigned, assignedToUserId)
+  fun getSentReferralSummaryForUser(user: AuthUser, concluded: Boolean?, cancelled: Boolean?, unassigned: Boolean?, assignedToUserId: String?, page: Pageable, searchText: String? = null): Iterable<SentReferralSummary> {
+    val findSentReferralsSpec: Specification<SentReferralSummary> = createSpecification(concluded, cancelled, unassigned, assignedToUserId, searchText)
 
     if (userTypeChecker.isServiceProviderUser(user)) {
       return getSentReferralSummaryForServiceProviderUser(user, findSentReferralsSpec, page)
@@ -175,7 +175,8 @@ class ReferralService(
     concluded: Boolean?,
     cancelled: Boolean?,
     unassigned: Boolean?,
-    assignedToUserId: String?
+    assignedToUserId: String?,
+    searchText: String?,
   ): Specification<T> {
     var findSentReferralsSpec = ReferralSpecifications.sent<T>()
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, concluded, ReferralSpecifications.concluded())
@@ -183,6 +184,9 @@ class ReferralService(
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, unassigned, ReferralSpecifications.unassigned())
     assignedToUserId?.let {
       findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, true, ReferralSpecifications.currentlyAssignedTo(it))
+    }
+    searchText?.let {
+      findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, true, ReferralSpecifications.search(searchText))
     }
     return findSentReferralsSpec
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -69,6 +69,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     assignments: List<ReferralAssignment> = emptyList(),
 
     supplierAssessment: SupplierAssessment? = null,
+    serviceUserData: ServiceUserData? = null,
   ): Referral {
     return create(
       id = id,
@@ -87,7 +88,8 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       supplementaryRiskId = supplementaryRiskId,
 
       assignments = assignments,
-      supplierAssessment = supplierAssessment
+      supplierAssessment = supplierAssessment,
+      serviceUserData = serviceUserData
     )
   }
 
@@ -112,6 +114,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     ),
 
     supplierAssessment: SupplierAssessment? = null,
+    serviceUserData: ServiceUserData? = null,
   ): Referral {
     return create(
       id = id,
@@ -130,7 +133,8 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       supplementaryRiskId = supplementaryRiskId,
 
       assignments = assignments,
-      supplierAssessment = supplierAssessment
+      supplierAssessment = supplierAssessment,
+      serviceUserData = serviceUserData
     )
   }
 


### PR DESCRIPTION
## What does this pull request do?

Allows the service provider summary search to be filtered based on a person on probation search term.

## What is the intent behind these changes?

Allow users to get more specific results for their dashboards.
