### PR TITLE
Fix "Previous deployment not found" message in the deployment notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,6 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
-          show_changelog: true
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
           requires: [deploy_dev]
@@ -317,7 +316,6 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_prod
           env: "prod"
-          show_changelog: true
           slack_notification: true
           slack_channel_name: "interventions"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,7 @@ workflows:
           env: "dev"
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
+          k8s_deployment_name: hmpps-interventions-service-api
           filters:
             branches:
               only:
@@ -300,6 +301,7 @@ workflows:
           env: "preprod"
           slack_notification: true
           slack_channel_name: "interventions-dev-notifications"
+          k8s_deployment_name: hmpps-interventions-service-api
           requires: [deploy_dev]
           context:
             - hmpps-common-vars
@@ -318,6 +320,7 @@ workflows:
           env: "prod"
           slack_notification: true
           slack_channel_name: "interventions"
+          k8s_deployment_name: hmpps-interventions-service-api
           requires:
             - approve_prod
           context:


### PR DESCRIPTION
## What does this pull request do?

🐛 This fixes the "Previous deployment not found, showing current commit only." messages during deployment.

<img width="695" alt="image" src="https://user-images.githubusercontent.com/1526295/171433256-4dd3c4ef-4878-4212-823a-5a9ac5b4191f.png">

https://mojdt.slack.com/archives/CLA97UR7D/p1654094487087869

## What is the intent behind these changes?

The changelog makes the assumption that there is a resource in Kubernetes called `deployment/PROJECT_NAME`

Since 4ca388769c5721fa2b514679d42370853a2df0d7, there is no `deployment/hmpps-interventions-service`; the closest replacement is the `deployment/hmpps-interventions-service-api`.