### PR TITLE
Add heap tools to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN ./gradlew assemble
 
 
 # ---
-FROM alpine:3.15 AS final
+FROM alpine:3.16 AS final
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 # force a rebuild of `apk upgrade` below by invalidating the BUILD_NUMBER env variable on every commit
@@ -33,7 +33,7 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 RUN apk upgrade --no-cache && \
      apk add --no-cache \
        curl \
-       openjdk17-jre-headless \
+       openjdk17-jdk \
        tzdata
 
 ENV TZ=Europe/London

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
@@ -14,4 +14,10 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: Always
               args: ["--jobName=ndmisPerformanceReportJob"]
+              volumeMounts:
+                - name: heap-dumps
+                  mountPath: /dumps
   {{- include "deployment.envs" . | nindent 14 }}
+          volumes:
+            - name: heap-dumps
+              emptyDir: {}


### PR DESCRIPTION
## What does this pull request do?

Add/enable JVM heap-related tools to the production Docker image.

## What is the intent behind these changes?

### Using jhsdb and jmap

Our images run as non-root on the hosting environment, so adding tooling on the fly is not possible.

We are having out-of-memory errors on one instance (ndmis-performane-report containers) so let's include tooling to
investigate the heap (part of JDK).

### Enable saving heap dumps on out-of-memory

All applications run with `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps`, but this folder is not writeable for the NDMIS cronjob, resulting in

    Unable to create /dumps: Permission denied