### PR TITLE
Increase JVM heap through command line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ COPY --chown=appuser:appgroup applicationinsights.json /app
 
 USER 2000
 
-ENTRYPOINT ["java", "-XX:+AlwaysActAsServerClassMachine", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/dumps", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-XX:MaxHeapSize=786432000", "-XX:+AlwaysActAsServerClassMachine", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/dumps", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -12,9 +12,6 @@ env:
     value: "{{ $value }}"
   {{ end }}
 
-  - name: JAVA_OPTS
-    value: "-Xmx750m"
-
   - name: APPLICATIONINSIGHTS_CONNECTION_STRING
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION


## What does this pull request do?

Increase JVM heap through command line

## What is the intent behind these changes?

Some time along the line, JAVA_OPTS seems to have stopped working.
We noticed as the ndmis-report cronjob started failing; during
investigation we noticed it's configured with 256MB maximum heap size:

    /app $ jcmd 1 GC.heap_info
    1:
     garbage-first heap   total 256000K, used 251511K [0x00000000f0600000, 0x0000000100000000)
      region size 1024K, 1 young (1024K), 0 survivors (0K)
     Metaspace       used 148017K, committed 148736K, reserved 1179648K
      class space    used 18580K, committed 18944K, reserved 1048576K

and printing `jcmd 1 VM.flags` printed `-XX:MaxHeapSize=262144000`.

This change removes `JAVA_OPTS` and passes down `-XX:MaxHeapSize` (long
version of `-Xmx`) directly, which works.
