### PR TITLE
Remove old deprecated views and tables

### DIFF
--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -143,12 +143,6 @@ COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_hostel_setting IS 'O
 COMMENT ON COLUMN draft_oasys_risk_information.risk_to_self_vulnerability IS 'OASYS Risk to Self - vulnerability';
 COMMENT ON COLUMN draft_oasys_risk_information.additional_information IS 'OASYS Additional risk information';
 
-COMMENT ON TABLE deprecated_action_plan_appointment IS '**deprecated**; use `appointment`';
-COMMENT ON TABLE deprecated_action_plan_session IS '**deprecated**; use `delivery_session`';
-COMMENT ON TABLE deprecated_action_plan_session_appointment IS '**deprecated**; use `delivery_session_appointment`';
-COMMENT ON VIEW delivery_session_deprecated IS '**deprecated** view in favour of new table `delivery_session`';
-COMMENT ON VIEW delivery_session_appointment_deprecated IS '**deprecated** view in favour of new table `delivery_session_appointment`';
-
 COMMENT ON TABLE action_plan_session_appointment_pre_v1_78 IS '**backup** no longer in use; for up-to-date session appointment links, see `delivery_session_appointment`';
 COMMENT ON TABLE delivery_session IS 'session details for a referral';
 COMMENT ON TABLE delivery_session_appointment IS 'links between sessions and appointments for a referral';

--- a/src/main/resources/db/migration/V1_97__remove_deprecated_views_and_tables.sql
+++ b/src/main/resources/db/migration/V1_97__remove_deprecated_views_and_tables.sql
@@ -1,0 +1,12 @@
+-- found by going to the https://hmpps-interventions-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk/meta/schema/ page and filtering for "deprecated"
+DROP VIEW delivery_session_appointment_deprecated;
+DROP VIEW delivery_session_deprecated;
+DROP TABLE deprecated_action_plan_appointment;
+DROP TABLE deprecated_action_plan_session_appointment;
+DROP TABLE deprecated_action_plan_session;
+
+DELETE
+FROM metadata
+WHERE table_name IN ('deprecated_action_plan_appointment',
+                     'deprecated_action_plan_session_appointment',
+                     'deprecated_action_plan_session');


### PR DESCRIPTION
## What does this pull request do?

Remove old deprecated views and tables.

## What is the intent behind these changes?

These views and tables were a stepping stone in extensive migrations and a safety net in case we needed to roll back.

They are no longer referenced or needed.