### PR TITLE
create a new appointment when rescheduling to store the historic appo…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -280,7 +280,7 @@ class AppointmentService(
   }
 
   private fun updateAppointment(
-    oldAppointment: Appointment,
+    appointment: Appointment,
     durationInMinutes: Int,
     appointmentTime: OffsetDateTime,
     deliusAppointmentId: Long?,
@@ -295,26 +295,13 @@ class AppointmentService(
     behaviourDescription: String?,
     appointmentType: AppointmentType,
   ): Appointment {
-    oldAppointment.durationInMinutes = durationInMinutes
-    oldAppointment.appointmentTime = appointmentTime
-    oldAppointment.deliusAppointmentId = deliusAppointmentId
-    val appointment = Appointment(
-      id = UUID.randomUUID(),
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = deliusAppointmentId,
-      createdBy = authUserRepository.save(createdByUser),
-      createdAt = OffsetDateTime.now(),
-      referral = oldAppointment.referral,
-      appointmentDelivery = oldAppointment.appointmentDelivery,
-      appointmentFeedbackSubmittedAt = oldAppointment.appointmentFeedbackSubmittedAt,
-      attendanceSubmittedAt = oldAppointment.attendanceSubmittedAt,
-      attendanceBehaviourSubmittedAt = oldAppointment.attendanceBehaviourSubmittedAt
-    )
+    appointment.durationInMinutes = durationInMinutes
+    appointment.appointmentTime = appointmentTime
+    appointment.deliusAppointmentId = deliusAppointmentId
     setAttendanceAndBehaviourIfHistoricAppointment(appointment, appointmentTime, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser, appointmentType)
-    val newAppointment = appointmentRepository.save(appointment)
-    createOrUpdateAppointmentDeliveryDetails(newAppointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
-    return newAppointment
+    val appointment = appointmentRepository.save(appointment)
+    createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
+    return appointment
   }
 
   private fun createOrUpdateAppointmentDeliveryAddress(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -280,7 +280,7 @@ class AppointmentService(
   }
 
   private fun updateAppointment(
-    appointment: Appointment,
+    oldAppointment: Appointment,
     durationInMinutes: Int,
     appointmentTime: OffsetDateTime,
     deliusAppointmentId: Long?,
@@ -295,13 +295,26 @@ class AppointmentService(
     behaviourDescription: String?,
     appointmentType: AppointmentType,
   ): Appointment {
-    appointment.durationInMinutes = durationInMinutes
-    appointment.appointmentTime = appointmentTime
-    appointment.deliusAppointmentId = deliusAppointmentId
+    oldAppointment.durationInMinutes = durationInMinutes
+    oldAppointment.appointmentTime = appointmentTime
+    oldAppointment.deliusAppointmentId = deliusAppointmentId
+    val appointment = Appointment(
+      id = UUID.randomUUID(),
+      appointmentTime = appointmentTime,
+      durationInMinutes = durationInMinutes,
+      deliusAppointmentId = deliusAppointmentId,
+      createdBy = authUserRepository.save(createdByUser),
+      createdAt = OffsetDateTime.now(),
+      referral = oldAppointment.referral,
+      appointmentDelivery = oldAppointment.appointmentDelivery,
+      appointmentFeedbackSubmittedAt = oldAppointment.appointmentFeedbackSubmittedAt,
+      attendanceSubmittedAt = oldAppointment.attendanceSubmittedAt,
+      attendanceBehaviourSubmittedAt = oldAppointment.attendanceBehaviourSubmittedAt
+    )
     setAttendanceAndBehaviourIfHistoricAppointment(appointment, appointmentTime, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser, appointmentType)
-    val appointment = appointmentRepository.save(appointment)
-    createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
-    return appointment
+    val newAppointment = appointmentRepository.save(appointment)
+    createOrUpdateAppointmentDeliveryDetails(newAppointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
+    return newAppointment
   }
 
   private fun createOrUpdateAppointmentDeliveryAddress(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -196,10 +196,21 @@ class DeliverySessionService(
       notifyProbationPractitioner,
     )
 
-    val appointment = existingAppointment?.apply {
-      this.appointmentTime = appointmentTime
-      this.durationInMinutes = durationInMinutes
-      this.deliusAppointmentId = deliusAppointmentId
+    // creating a new appointment from the existing appointment
+    val appointment = existingAppointment?.let {
+      Appointment(
+        id = UUID.randomUUID(),
+        appointmentTime = appointmentTime,
+        durationInMinutes = durationInMinutes,
+        deliusAppointmentId = deliusAppointmentId,
+        createdBy = it.createdBy,
+        createdAt = OffsetDateTime.now(),
+        referral = it.referral,
+        appointmentDelivery = it.appointmentDelivery,
+        appointmentFeedbackSubmittedAt = it.appointmentFeedbackSubmittedAt,
+        attendanceSubmittedAt = it.attendanceSubmittedAt,
+        attendanceBehaviourSubmittedAt = it.attendanceBehaviourSubmittedAt
+      )
     } ?: Appointment(
       id = UUID.randomUUID(),
       createdBy = authUserRepository.save(updatedBy),
@@ -207,8 +218,9 @@ class DeliverySessionService(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
-      referral = session.referral,
+      referral = session.referral
     )
+
     appointmentRepository.saveAndFlush(appointment)
     appointmentService.createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
     session.appointments.add(appointment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -272,6 +272,7 @@ internal class DeliverySessionsServiceTest {
   @Test
   fun `makes a booking when a session is updated`() {
     val session = deliverySessionFactory.createScheduled()
+    val appointment = session.currentAppointment
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = session.sessionNumber
     val referral = session.referral
@@ -282,7 +283,7 @@ internal class DeliverySessionsServiceTest {
     whenever(
       communityAPIBookingService.book(
         referral,
-        session.currentAppointment,
+        appointment,
         appointmentTime,
         durationInMinutes,
         SERVICE_DELIVERY,
@@ -308,7 +309,7 @@ internal class DeliverySessionsServiceTest {
     verify(appointmentService, times(1)).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.PHONE_CALL), eq(AppointmentSessionType.ONE_TO_ONE), isNull(), isNull())
     verify(communityAPIBookingService).book(
       referral,
-      session.currentAppointment,
+      appointment,
       appointmentTime,
       durationInMinutes,
       SERVICE_DELIVERY,
@@ -648,6 +649,7 @@ internal class DeliverySessionsServiceTest {
   @Test
   fun `makes a booking with delius office location`() {
     val session = deliverySessionFactory.createScheduled()
+    val appointment = session.currentAppointment
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = session.sessionNumber
     val referral = session.referral
@@ -659,7 +661,7 @@ internal class DeliverySessionsServiceTest {
     whenever(
       communityAPIBookingService.book(
         referral,
-        session.currentAppointment,
+        appointment,
         appointmentTime,
         durationInMinutes,
         SERVICE_DELIVERY,
@@ -688,7 +690,7 @@ internal class DeliverySessionsServiceTest {
     verify(appointmentService, times(1)).createOrUpdateAppointmentDeliveryDetails(any(), eq(AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE), eq(AppointmentSessionType.ONE_TO_ONE), isNull(), eq(npsOfficeCode))
     verify(communityAPIBookingService).book(
       referral,
-      session.currentAppointment,
+      appointment,
       appointmentTime,
       durationInMinutes,
       SERVICE_DELIVERY,


### PR DESCRIPTION
…intment details

## What does this pull request do?

- creates a new appointment instead of updating the existing appointment
- By doing that way, we store the historic changes of the appointment

## What is the intent behind these changes?

- We realised that when a reschedule of appointment happens, we are not storing the appointment history which seems to be mandatory. So, in the view of storing the appointment history, when a reschedule appointments is requested, we created a new appointment instead of updating the existing one
