### PR TITLE
Book new appointment on did not attend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -66,7 +66,7 @@ data class DeliverySessionDTO(
   val appointmentTime: OffsetDateTime?,
   val durationInMinutes: Int?,
   val appointmentDeliveryType: AppointmentDeliveryType?,
-  val oldAppointments: MutableSet<Appointment>,
+  val oldAppointments: MutableSet<AppointmentDTO> = mutableSetOf(),
   val sessionType: AppointmentSessionType?,
   val npsOfficeCode: String?,
   val appointmentDeliveryAddress: AddressDTO?,
@@ -96,7 +96,9 @@ data class DeliverySessionDTO(
         appointmentDeliveryType = session.currentAppointment?.appointmentDelivery?.appointmentDeliveryType,
         sessionType = session.currentAppointment?.appointmentDelivery?.appointmentSessionType,
         appointmentDeliveryAddress = address,
-        oldAppointments = session.appointments.filterNot { it == session.currentAppointment }.toMutableSet(),
+        oldAppointments = session.appointments
+          .filterNot { it == session.currentAppointment }
+          .mapTo(HashSet()) { AppointmentDTO.from(it) },
         npsOfficeCode = session.currentAppointment?.appointmentDelivery?.npsOfficeCode,
         sessionFeedback = SessionFeedbackDTO.from(session.currentAppointment),
         deliusAppointmentId = session.currentAppointment?.deliusAppointmentId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -66,6 +66,7 @@ data class DeliverySessionDTO(
   val appointmentTime: OffsetDateTime?,
   val durationInMinutes: Int?,
   val appointmentDeliveryType: AppointmentDeliveryType?,
+  val oldAppointments: MutableSet<Appointment>,
   val sessionType: AppointmentSessionType?,
   val npsOfficeCode: String?,
   val appointmentDeliveryAddress: AddressDTO?,
@@ -95,6 +96,7 @@ data class DeliverySessionDTO(
         appointmentDeliveryType = session.currentAppointment?.appointmentDelivery?.appointmentDeliveryType,
         sessionType = session.currentAppointment?.appointmentDelivery?.appointmentSessionType,
         appointmentDeliveryAddress = address,
+        oldAppointments = session.appointments.filterNot { it == session.currentAppointment }.toMutableSet(),
         npsOfficeCode = session.currentAppointment?.appointmentDelivery?.npsOfficeCode,
         sessionFeedback = SessionFeedbackDTO.from(session.currentAppointment),
         deliusAppointmentId = session.currentAppointment?.deliusAppointmentId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -196,25 +196,15 @@ class DeliverySessionService(
       notifyProbationPractitioner,
     )
 
-    // creating a new appointment from the existing appointment
-    val appointment = existingAppointment?.let {
-      Appointment(
-        id = UUID.randomUUID(),
-        appointmentTime = appointmentTime,
-        durationInMinutes = durationInMinutes,
-        deliusAppointmentId = deliusAppointmentId,
-        createdBy = it.createdBy,
-        createdAt = OffsetDateTime.now(),
-        referral = it.referral
-      )
-    } ?: Appointment(
+    // creating a new appointment from the existing appointment or else create a new appointment
+    val appointment = Appointment(
       id = UUID.randomUUID(),
-      createdBy = authUserRepository.save(updatedBy),
-      createdAt = OffsetDateTime.now(),
-      appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
+      appointmentTime = appointmentTime,
       deliusAppointmentId = deliusAppointmentId,
-      referral = session.referral
+      createdAt = OffsetDateTime.now(),
+      createdBy = existingAppointment?.createdBy ?: authUserRepository.save(updatedBy),
+      referral = existingAppointment?.referral ?: session.referral
     )
 
     appointmentRepository.saveAndFlush(appointment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -205,11 +205,7 @@ class DeliverySessionService(
         deliusAppointmentId = deliusAppointmentId,
         createdBy = it.createdBy,
         createdAt = OffsetDateTime.now(),
-        referral = it.referral,
-        appointmentDelivery = it.appointmentDelivery,
-        appointmentFeedbackSubmittedAt = it.appointmentFeedbackSubmittedAt,
-        attendanceSubmittedAt = it.attendanceSubmittedAt,
-        attendanceBehaviourSubmittedAt = it.attendanceBehaviourSubmittedAt
+        referral = it.referral
       )
     } ?: Appointment(
       id = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
@@ -15,9 +15,11 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DeliverySessio
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.RecordAppointmentBehaviourDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentAttendanceDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateAppointmentDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentSessionType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.NO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended.YES
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
@@ -110,6 +112,50 @@ internal class DeliverySessionControllerTest {
           null,
           null,
           YES,
+          "attended",
+          false,
+          "behaviour"
+        )
+      ).thenReturn(deliverySession)
+
+      val sessionResponse = sessionsController.updateSessionAppointment(actionPlanId, sessionNumber, updateAppointmentDTO, userToken)
+
+      assertThat(sessionResponse).isEqualTo(DeliverySessionDTO.from(deliverySession))
+    }
+
+    @Test
+    fun `updates a session with new appointment when a PoP did not attend`() {
+      val user = authUserFactory.create()
+      val userToken = jwtTokenFactory.create(user)
+      val deliverySession = deliverySessionFactory.createScheduled(createdBy = user)
+      val actionPlanId = UUID.randomUUID()
+      val sessionNumber = deliverySession.sessionNumber
+
+      val attendanceDTO = UpdateAppointmentAttendanceDTO(NO, "attended")
+      val behaviourDTO = RecordAppointmentBehaviourDTO("behaviour", false)
+      val updateAppointmentDTO = UpdateAppointmentDTO(OffsetDateTime.now(), 10, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, attendanceDTO, behaviourDTO)
+      val newAppointment = Appointment(
+        id = UUID.randomUUID(),
+        createdBy = user,
+        createdAt = OffsetDateTime.now(),
+        appointmentTime = updateAppointmentDTO.appointmentTime,
+        durationInMinutes = updateAppointmentDTO.durationInMinutes,
+        deliusAppointmentId = 123L,
+        referral = deliverySession.referral,
+      )
+      deliverySession.appointments.add(newAppointment)
+      whenever(
+        sessionsService.updateSessionAppointment(
+          actionPlanId,
+          sessionNumber,
+          updateAppointmentDTO.appointmentTime,
+          updateAppointmentDTO.durationInMinutes,
+          user,
+          AppointmentDeliveryType.PHONE_CALL,
+          AppointmentSessionType.ONE_TO_ONE,
+          null,
+          null,
+          NO,
           "attended",
           false,
           "behaviour"


### PR DESCRIPTION
## What does this pull request do?

- Creating a convenience field of old appointments for a session in the DTO which will aid the front end to display that data.
- Fixing the small issue while creating the new Appointment for the update Appointment

## What is the intent behind these changes?

- There is a requirement to show appointment histories when a PoP did not attend a particular appointment and the appointment being rescheduled. So , to show the appointment histories we are creating a convenience field.
