### PR TITLE
Create new appointment for supplier assessment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SupplierAssessmentDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SupplierAssessmentDTO.kt
@@ -13,7 +13,7 @@ data class SupplierAssessmentDTO(
     fun from(supplierAssessment: SupplierAssessment): SupplierAssessmentDTO {
       return SupplierAssessmentDTO(
         id = supplierAssessment.id,
-        appointments = AppointmentDTO.from(supplierAssessment.appointments.filter { !it.superseded }.toMutableSet()),
+        appointments = AppointmentDTO.from(supplierAssessment.appointments.filterNot { it.superseded }.toMutableSet()),
         currentAppointmentId = supplierAssessment.currentAppointment?.id,
         referralId = supplierAssessment.referral.id
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SupplierAssessmentDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SupplierAssessmentDTO.kt
@@ -13,7 +13,7 @@ data class SupplierAssessmentDTO(
     fun from(supplierAssessment: SupplierAssessment): SupplierAssessmentDTO {
       return SupplierAssessmentDTO(
         id = supplierAssessment.id,
-        appointments = AppointmentDTO.from(supplierAssessment.appointments),
+        appointments = AppointmentDTO.from(supplierAssessment.appointments.filter { !it.superseded }.toMutableSet()),
         currentAppointmentId = supplierAssessment.currentAppointment?.id,
         referralId = supplierAssessment.referral.id
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Appointment.kt
@@ -48,6 +48,7 @@ data class Appointment(
   var appointmentDelivery: AppointmentDelivery? = null,
 
   @ManyToOne(fetch = FetchType.LAZY) var referral: Referral,
+  var superseded: Boolean = false,
   @Id val id: UUID,
 ) {
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/AppointmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/AppointmentRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import java.util.UUID
 
-interface AppointmentRepository : JpaRepository<Appointment, UUID>
+interface AppointmentRepository : JpaRepository<Appointment, UUID> {
+  fun findAllByReferralId(referralId: UUID): List<Appointment>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
@@ -25,7 +25,7 @@ class PerformanceReportProcessor(
     // note: all referrals here are 'sent', we can safely access fields like 'referenceNumber'
     val contract = referral.intervention.dynamicFrameworkContract
     val approvedActionPlan = referral.approvedActionPlan
-    //Supplier assessment will only have the latest appointments. Hence, retrieving from the appointments
+    // Supplier assessment will only have the latest appointments. Hence, retrieving from the appointments
     val appointments = appointmentRepository.findAllByReferralId(referral.id)
     val firstAppointment: Appointment? = appointments.minByOrNull { it.createdAt }
     val firstAppointmentWithNonAttendance: Appointment? = appointments.filter { it.attended == Attended.NO }.minByOrNull { it.appointmentTime }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
@@ -4,13 +4,16 @@ import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
 
 @Component
 class PerformanceReportProcessor(
   private val actionPlanService: ActionPlanService,
+  private val appointmentRepository: AppointmentRepository
 ) : ItemProcessor<Referral, PerformanceReportData> {
   companion object : KLogging()
 
@@ -22,7 +25,11 @@ class PerformanceReportProcessor(
     // note: all referrals here are 'sent', we can safely access fields like 'referenceNumber'
     val contract = referral.intervention.dynamicFrameworkContract
     val approvedActionPlan = referral.approvedActionPlan
-    val saa = referral.supplierAssessment
+    //Supplier assessment will only have the latest appointments. Hence, retrieving from the appointments
+    val appointments = appointmentRepository.findAllByReferralId(referral.id)
+    val firstAppointment: Appointment? = appointments.minByOrNull { it.createdAt }
+    val firstAppointmentWithNonAttendance: Appointment? = appointments.filter { it.attended == Attended.NO }.minByOrNull { it.appointmentTime }
+    val firstAttendedAppointment: Appointment? = appointments.filter { listOf(Attended.YES, Attended.LATE).contains(it.attended) }.minByOrNull { it.appointmentTime }
 
     return PerformanceReportData(
       referralReference = referral.referenceNumber!!,
@@ -32,11 +39,11 @@ class PerformanceReportProcessor(
       currentAssigneeEmail = referral.currentAssignee?.userName,
       serviceUserCRN = referral.serviceUserCRN,
       dateReferralReceived = referral.sentAt!!,
-      dateSupplierAssessmentFirstArranged = saa?.firstAppointment?.createdAt,
-      dateSupplierAssessmentFirstScheduledFor = saa?.firstAppointment?.appointmentTime,
-      dateSupplierAssessmentFirstNotAttended = saa?.firstAppointmentWithNonAttendance?.appointmentTime,
-      dateSupplierAssessmentFirstAttended = saa?.firstAttendedAppointment?.appointmentTime,
-      supplierAssessmentAttendedOnTime = saa?.firstAttendedAppointment?.attended?.let { it == Attended.YES },
+      dateSupplierAssessmentFirstArranged = firstAppointment?.createdAt,
+      dateSupplierAssessmentFirstScheduledFor = firstAppointment?.appointmentTime,
+      dateSupplierAssessmentFirstNotAttended = firstAppointmentWithNonAttendance?.appointmentTime,
+      dateSupplierAssessmentFirstAttended = firstAttendedAppointment?.appointmentTime,
+      supplierAssessmentAttendedOnTime = firstAttendedAppointment?.attended?.let { it == Attended.YES },
       firstActionPlanSubmittedAt = referral.actionPlans?.mapNotNull { it.submittedAt }?.minOrNull(),
       firstActionPlanApprovedAt = referral.actionPlans?.mapNotNull { it.approvedAt }?.minOrNull(),
       firstSessionAttendedAt = approvedActionPlan?.let { actionPlanService.getFirstAttendedAppointment(it)?.appointmentTime },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -80,6 +80,7 @@ class AppointmentService(
           communityAPIBookingService.book(referral, appointment, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode)
         updateAppointment(
           durationInMinutes,
+          appointment,
           appointmentTime,
           deliusAppointmentId,
           createdByUser,
@@ -281,6 +282,7 @@ class AppointmentService(
 
   private fun updateAppointment(
     durationInMinutes: Int,
+    oldAppointment: Appointment,
     appointmentTime: OffsetDateTime,
     deliusAppointmentId: Long?,
     createdByUser: AuthUser,
@@ -305,7 +307,9 @@ class AppointmentService(
       referral = referral,
     )
     setAttendanceAndBehaviourIfHistoricAppointment(appointment, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser, appointmentType)
-    appointmentRepository.saveAndFlush(appointment)
+    oldAppointment.superseded = true
+    appointmentRepository.saveAndFlush(oldAppointment)
+    appointmentRepository.save(appointment)
     createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
     return appointment
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -297,20 +297,24 @@ class AppointmentService(
     behaviourDescription: String?,
     appointmentType: AppointmentType,
   ): Appointment {
-    val appointment = Appointment(
-      id = UUID.randomUUID(),
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = deliusAppointmentId,
-      createdBy = authUserRepository.save(createdByUser),
-      createdAt = OffsetDateTime.now(),
-      referral = referral,
+    val appointment = createAppointment(
+      durationInMinutes,
+      appointmentTime,
+      deliusAppointmentId,
+      createdByUser,
+      appointmentDeliveryType,
+      appointmentSessionType,
+      appointmentDeliveryAddress,
+      referral,
+      npsOfficeCode,
+      attended,
+      additionalAttendanceInformation,
+      notifyProbationPractitioner,
+      behaviourDescription,
+      appointmentType
     )
-    setAttendanceAndBehaviourIfHistoricAppointment(appointment, attended, additionalAttendanceInformation, behaviourDescription, notifyProbationPractitioner, createdByUser, appointmentType)
     oldAppointment.superseded = true
-    appointmentRepository.saveAndFlush(oldAppointment)
-    appointmentRepository.save(appointment)
-    createOrUpdateAppointmentDeliveryDetails(appointment, appointmentDeliveryType, appointmentSessionType, appointmentDeliveryAddress, npsOfficeCode)
+    appointmentRepository.save(oldAppointment)
     return appointment
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -70,26 +70,9 @@ class SupplierAssessmentService(
       notifyProbationPractitioner,
       behaviourDescription
     )
-    handleSupplierAppointments(existingAppointment, supplierAssessment, appointment)
-    return appointment
-  }
-
-  private fun handleSupplierAppointments(
-    existingAppointment: Appointment?,
-    supplierAssessment: SupplierAssessment,
-    appointment: Appointment
-  ) {
-    when {
-      existingAppointment == null || existingAppointment.attended == Attended.NO -> {
-        supplierAssessment.appointments.add(appointment)
-      }
-      existingAppointment.attended == null -> {
-        // Replacing the existing appointment with the new appointment so that we can maintain both in the appointment repository
-        supplierAssessment.appointments.remove(existingAppointment)
-        supplierAssessment.appointments.add(appointment)
-      }
-    }
+    supplierAssessment.appointments.add(appointment)
     supplierAssessmentRepository.save(supplierAssessment)
+    return appointment
   }
 
   fun scheduleNewSupplierAssessmentAppointment(

--- a/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
+++ b/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
@@ -2,9 +2,10 @@
 ALTER TABLE appointment
     ADD COLUMN superseded bool NOT NULL DEFAULT false;
 
--- migrating the values to "true" will be done in when a new reschedule start to happen
--- • all the appointments can be false to start with
--- • reschedule appointments happens, new appointments will be created instead of overwriting and the old appointments will be set to true
+-- migrating the values to "true" will be done when rescheduling an appointment
+-- all the appointments can be false to start with
+-- reschedule appointments happens, new appointments will be created and instead of overwriting to the old appointments.
+-- the old appointments will be set to true
 
 -- inserting the metadata for the new column
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('appointment','superseded',FALSE, TRUE);

--- a/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
+++ b/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
@@ -1,10 +1,10 @@
--- to enable querying the single "live" entry via `AND superseded = false`
+-- to enable querying the single "live" appointments
 ALTER TABLE appointment
     ADD COLUMN superseded bool NOT NULL DEFAULT false;
 
--- migrating the values to "true" will be done in a subsequent deploy, to avoid race conditions where
--- • we migrate the data
--- • assignments happen with the old code not using `superseded`
--- • then new code takes over
+-- migrating the values to "true" will be done in when a new reschedule start to happen
+-- • all the appointments can be false to start with
+-- • reschedule appointments happens, new appointments will be created instead of overwriting and the old appointments will be set to true
 
--- instead, we'll deploy in one go, _then_ migrate all the old data once the new code is live and ensures consistency
+-- inserting the metadata for the new column
+INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('appointment','superseded',FALSE);

--- a/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
+++ b/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
@@ -1,0 +1,10 @@
+-- to enable querying the single "live" entry via `AND superseded = false`
+ALTER TABLE appointment
+    ADD COLUMN superseded bool NOT NULL DEFAULT false;
+
+-- migrating the values to "true" will be done in a subsequent deploy, to avoid race conditions where
+-- • we migrate the data
+-- • assignments happen with the old code not using `superseded`
+-- • then new code takes over
+
+-- instead, we'll deploy in one go, _then_ migrate all the old data once the new code is live and ensures consistency

--- a/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
+++ b/src/main/resources/db/migration/V1_98__superseded_flag_for_appointments.sql
@@ -7,4 +7,4 @@ ALTER TABLE appointment
 -- • reschedule appointments happens, new appointments will be created instead of overwriting and the old appointments will be set to true
 
 -- inserting the metadata for the new column
-INSERT INTO metadata (table_name, column_name, sensitive) VALUES ('appointment','superseded',FALSE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('appointment','superseded',FALSE, TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
@@ -1,16 +1,29 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider.performance.PerformanceReportProcessor
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.SupplierAssessmentFactory
 import java.lang.RuntimeException
+import java.time.OffsetDateTime
 
 internal class PerformanceReportDataProcessorTest {
   private val actionPlanService = mock<ActionPlanService>()
-  private val processor = PerformanceReportProcessor(actionPlanService)
+  private val appointmentFactory = AppointmentFactory()
+  private val supplierAssessmentFactory = SupplierAssessmentFactory()
+  private val appointmentRepository: AppointmentRepository = mock()
+  private val actionPlanFactory = ActionPlanFactory()
+
+  private val processor = PerformanceReportProcessor(actionPlanService, appointmentRepository)
 
   private val referralFactory = ReferralFactory()
 
@@ -19,5 +32,35 @@ internal class PerformanceReportDataProcessorTest {
     val referral = referralFactory.createDraft()
 
     assertThrows<RuntimeException> { processor.process(referral) }
+  }
+
+  @Test
+  fun `will process sent referrals`() {
+    val supplierAssessmentFirstAppointment = appointmentFactory.create(attended = Attended.NO, createdAt = OffsetDateTime.parse("2022-07-01T10:42:43+00:00"))
+    val supplierAssessmentNewAppointment = appointmentFactory.create(attended = Attended.YES, createdAt = OffsetDateTime.parse("2022-07-02T10:42:43+00:00"))
+    val approvedActionPlanAppointment = appointmentFactory.create()
+    val unApprovedAppointment = appointmentFactory.create()
+    val supplierAssessment = supplierAssessmentFactory.create(appointment = supplierAssessmentFirstAppointment)
+    supplierAssessment.appointments.add(supplierAssessmentNewAppointment)
+    val actionPlan = actionPlanFactory.createApproved()
+    val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan), supplierAssessment = supplierAssessment)
+
+    whenever(appointmentRepository.findAllByReferralId(referral.id)).thenReturn(listOf(supplierAssessmentFirstAppointment, supplierAssessmentNewAppointment))
+    whenever(actionPlanService.getFirstAttendedAppointment(actionPlan)).thenReturn(approvedActionPlanAppointment)
+    whenever(actionPlanService.getAllAttendedAppointments(actionPlan)).thenReturn(listOf(unApprovedAppointment, approvedActionPlanAppointment))
+
+    val performanceReportData = processor.process(referral)
+
+    assertThat(performanceReportData.referralId).isEqualTo(referral.id)
+    assertThat(performanceReportData.dateReferralReceived).isEqualTo(referral.sentAt)
+    assertThat(performanceReportData.dateReferralReceived).isEqualTo(referral.sentAt)
+    assertThat(performanceReportData.contractReference).isEqualTo(referral.intervention.dynamicFrameworkContract.contractReference)
+    assertThat(performanceReportData.dateSupplierAssessmentFirstArranged).isEqualTo(supplierAssessmentFirstAppointment.createdAt)
+    assertThat(performanceReportData.dateSupplierAssessmentFirstNotAttended).isEqualTo(supplierAssessmentFirstAppointment.appointmentTime)
+    assertThat(performanceReportData.dateSupplierAssessmentFirstScheduledFor).isEqualTo(supplierAssessmentFirstAppointment.appointmentTime)
+    assertThat(performanceReportData.dateSupplierAssessmentFirstAttended).isEqualTo(supplierAssessmentNewAppointment.appointmentTime)
+    assertThat(performanceReportData.firstSessionAttendedAt).isEqualTo(approvedActionPlanAppointment.appointmentTime)
+    assertThat(performanceReportData.numberOfSessionsAttended).isEqualTo(2)
+    assertThat(performanceReportData.supplierAssessmentAttendedOnTime).isEqualTo(true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
@@ -23,7 +23,7 @@ internal class PerformanceReportDataProcessorTest {
   private val appointmentRepository: AppointmentRepository = mock()
   private val actionPlanFactory = ActionPlanFactory()
 
-  private val processor = PerformanceReportProcessor(actionPlanService, appointmentRepository)
+  private val processor = PerformanceReportProcessor(actionPlanService)
 
   private val referralFactory = ReferralFactory()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -387,6 +387,7 @@ class AppointmentServiceTest {
       val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = newNpsCode)
 
       // Then
+      assertThat(existingAppointment.superseded).isTrue
       verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, newNpsCode)
       verifySavedAppointment(appointmentTime, durationInMinutes, rescheduledDeliusAppointmentId, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, newNpsCode)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -190,7 +190,7 @@ class AppointmentServiceTest {
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = rescheduledDeliusAppointmentId,
     )
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+    whenever(appointmentRepository.saveAndFlush(any())).thenReturn(savedAppointment)
 
     // When
     val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -198,6 +198,10 @@ class AppointmentServiceTest {
     // Then
     verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     verifySavedAppointment(appointmentTime, durationInMinutes, rescheduledDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    val argumentCaptor = argumentCaptor<Appointment>()
+    verify(appointmentRepository, atLeast(1)).save(argumentCaptor.capture())
+    val oldAppointmentArguments = argumentCaptor.lastValue
+    assertThat(oldAppointmentArguments.superseded).isTrue
     assertThat(updatedAppointment.attended).isNull()
     assertThat(updatedAppointment.additionalAttendanceInformation).isNull()
     assertThat(updatedAppointment.attendanceBehaviour).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -249,12 +249,12 @@ class AppointmentServiceTest {
   fun `future appointment can be updated with a past appointment containing feedback`() {
     // Given
     val durationInMinutes = 60
-    val appointmentTime = OffsetDateTime.parse("3000-12-04T10:42:43+00:00")
+    val pastAppointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = null)
     val referral = referralFactory.createSent()
     val rescheduledDeliusAppointmentId = 99L
 
-    whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
+    whenever(communityAPIBookingService.book(referral, existingAppointment, pastAppointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
       .thenReturn(rescheduledDeliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
@@ -268,7 +268,7 @@ class AppointmentServiceTest {
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
-    val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, OffsetDateTime.parse("2020-12-04T10:42:43+00:00"), SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
+    val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, pastAppointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
 
     // Then
     verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, OffsetDateTime.parse("2020-12-04T10:42:43+00:00"), durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -335,10 +335,7 @@ class AppointmentServiceTest {
   private fun verifyResponse(appointment: Appointment, originalId: UUID?, expectNewId: Boolean, deliusAppointmentId: Long, appointmentTime: OffsetDateTime?, durationInMinutes: Int, appointmentDeliveryType: AppointmentDeliveryType, appointmentSessionType: AppointmentSessionType, npsOfficeCode: String? = null) {
 
     // Verifying create or update route
-    if (expectNewId)
-      assertThat(appointment).isNotEqualTo(originalId)
-    else
-      assertThat(appointment).isNotEqualTo(originalId)
+    assertThat(appointment).isNotEqualTo(originalId)
 
     assertThat(appointment.deliusAppointmentId).isEqualTo(deliusAppointmentId)
     assertThat(appointment.appointmentTime).isEqualTo(appointmentTime)
@@ -375,7 +372,7 @@ class AppointmentServiceTest {
       val oldNpsCode = "CRS0001"
       val newNpsCode = "CRS0002"
 
-      whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
+      whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, newNpsCode))
         .thenReturn(rescheduledDeliusAppointmentId)
       val savedAppointment = appointmentFactory.create(
         appointmentTime = appointmentTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentServiceTest.kt
@@ -150,7 +150,7 @@ class SupplierAssessmentServiceTest {
       whenever(
         appointmentService.createOrUpdateAppointment(
           eq(supplierAssessment.referral),
-          isNull(),
+          eq(supplierAssessment.currentAppointment),
           eq(durationInMinutes),
           eq(appointmentTime),
           eq(SUPPLIER_ASSESSMENT),
@@ -173,7 +173,7 @@ class SupplierAssessmentServiceTest {
       verify(supplierAssessmentRepository, atLeastOnce()).save(argumentCaptor.capture())
       val arguments = argumentCaptor.firstValue
 
-      assertThat(arguments.appointments.size).isEqualTo(1)
+      assertThat(arguments.appointments.size).isEqualTo(2)
       assertThat(arguments.currentAppointment).isEqualTo(supplierAssessmentAppointment)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentFactory.kt
@@ -28,6 +28,7 @@ class AppointmentFactory(em: TestEntityManager? = null) : EntityFactory(em) {
     appointmentFeedbackSubmittedAt: OffsetDateTime? = null,
     appointmentFeedbackSubmittedBy: AuthUser? = null,
     deliusAppointmentId: Long? = null,
+    superseded: Boolean = false,
     referral: Referral = referralFactory.createSent()
   ): Appointment {
     return save(
@@ -47,6 +48,7 @@ class AppointmentFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         appointmentFeedbackSubmittedAt = appointmentFeedbackSubmittedAt,
         appointmentFeedbackSubmittedBy = appointmentFeedbackSubmittedBy,
         deliusAppointmentId = deliusAppointmentId,
+        superseded = superseded,
         referral = referral,
       )
     )


### PR DESCRIPTION
## What does this pull request do?

- When a supplier assessment appointment is rescheduled, a new appointment is created instead of updating the existing appointment
- When the new appointment is created, old appointments is replaced with the new appointment
- PerformanceReportProcessor now gets the appointment data directly from the database instead of supplier assessment

## What is the intent behind these changes?

- The supplier assessment was not storing the appointments story when a appointment gets rescheduled, these changes are done to resolve the issue.
