### PR TITLE
upgrading the uk.gov.justice.hmpps.gradle-spring-boot to 4.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.2.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.3.0"
   kotlin("plugin.spring") version "1.6.21"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.6.21"
   id("jacoco")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -112,6 +112,7 @@ class SNSReferralService(
         // This is a system generated event at present and as such the actor will represent this
         snsPublisher.publish(event.referral.id, AuthUser.interventionsServiceUser, snsEvent)
       }
+      else -> {}
     }
   }
 }
@@ -164,6 +165,7 @@ class SNSActionPlanAppointmentService(
 
         snsPublisher.publish(referral.id, event.deliverySession.sessionFeedback.submittedBy!!, snsEvent)
       }
+      else -> {}
     }
   }
 }
@@ -216,6 +218,7 @@ class SNSAppointmentService(
 
         snsPublisher.publish(referral.id, appointment.appointmentFeedbackSubmittedBy!!, snsEvent)
       }
+      else -> {}
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
@@ -160,6 +160,7 @@ class NotifyActionPlanAppointmentService(
             )
           )
         }
+        else -> {}
       }
     }
   }
@@ -228,6 +229,7 @@ class NotifyAppointmentService(
             )
           )
         }
+        else -> {}
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
@@ -75,6 +75,7 @@ class ReferralNotificationService(
       ReferralEventType.DETAILS_AMENDED -> {
         handleDetailsChangedEvent(event)
       }
+      else -> {}
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
@@ -37,6 +37,7 @@ class AppointmentValidator {
           validateAddress(appointmentDeliveryAddress, errors)
         }
       }
+      else -> {}
     }
 
     if (referralStartDate != null && updateAppointmentDTO.appointmentTime.isBefore(referralStartDate)) {


### PR DESCRIPTION
## What does this pull request do?

- upgrade uk.gov.justice.hmpps.gradle-spring-boot to 4.3.0
- Since kotlin 1.7 comes with the strict checking on the default behaviour of the ```when``` expression
- Link for the actual issue- https://youtrack.jetbrains.com/issue/KT-47709
- Link to the release notes - https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/4.3.0.md

## What is the intent behind these changes?

- upgrade uk.gov.justice.hmpps.gradle-spring-boot to 4.3.0
