### PR TITLE
Filter assignments by superseded flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -15,25 +15,25 @@ class ReferralSpecifications {
   companion object {
 
     fun <T> sent(): Specification<T> {
-      return Specification<T> { root, query, cb ->
+      return Specification<T> { root, _, cb ->
         cb.isNotNull(root.get<OffsetDateTime>("sentAt"))
       }
     }
 
     fun <T> concluded(): Specification<T> {
-      return Specification<T> { root, query, cb ->
+      return Specification<T> { root, _, cb ->
         cb.isNotNull(root.get<OffsetDateTime>("concludedAt"))
       }
     }
 
     fun <T> unassigned(): Specification<T> {
-      return Specification<T> { root, query, cb ->
+      return Specification<T> { root, _, cb ->
         cb.isEmpty(root.get<List<ReferralAssignment>>("assignments"))
       }
     }
 
     fun <T> search(searchText: String): Specification<T> {
-      return Specification<T> { root, query, cb ->
+      return Specification<T> { root, _, cb ->
         val serviceUserDataJoin = root.join<T, ServiceUserData>("serviceUserData", JoinType.INNER)
         val exp1 = cb.concat(cb.upper(serviceUserDataJoin.get("firstName")), " ")
         val exp2 = cb.concat(exp1, cb.upper(serviceUserDataJoin.get("lastName")))
@@ -49,7 +49,7 @@ class ReferralSpecifications {
      * ReferralConcluder.kt class.
      */
     fun <T> cancelled(): Specification<T> {
-      return Specification<T> { root, query, cb ->
+      return Specification<T> { root, _, cb ->
         cb.and(
           cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
           cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
@@ -59,7 +59,7 @@ class ReferralSpecifications {
     }
 
     fun <T> withSPAccess(contracts: Set<DynamicFrameworkContract>): Specification<T> {
-      return Specification<T> { root, query, cb ->
+      return Specification<T> { root, _, _ ->
         val interventionJoin = root.join<T, Intervention>("intervention", JoinType.INNER)
         val dynamicContractJoin = interventionJoin.join<Intervention, DynamicFrameworkContract>("dynamicFrameworkContract", JoinType.LEFT)
         dynamicContractJoin.`in`(contracts)
@@ -67,11 +67,11 @@ class ReferralSpecifications {
     }
 
     fun <T> createdBy(authUser: AuthUser): Specification<T> {
-      return Specification<T> { root, query, cb -> cb.equal(root.get<String>("createdBy"), authUser) }
+      return Specification<T> { root, _, cb -> cb.equal(root.get<String>("createdBy"), authUser) }
     }
 
     fun <T> matchingServiceUserReferrals(serviceUserCRNs: List<String>): Specification<T> {
-      return Specification<T> { root, query, cb -> root.get<String>("serviceUserCRN").`in`(serviceUserCRNs) }
+      return Specification<T> { root, _, _ -> root.get<String>("serviceUserCRN").`in`(serviceUserCRNs) }
     }
 
     /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
@@ -54,18 +54,22 @@ internal class ReferralTest {
       referral.assignments.clear()
       assertThatNoException().isThrownBy { referral.validateInvariants() }
 
-      val firstAssignment =
+      val initialAssignment =
         ReferralAssignment(OffsetDateTime.now().plusMinutes(1L), assignee, assignee, superseded = false)
-      referral.assignments.add(firstAssignment)
+      referral.assignments.add(initialAssignment)
       assertThatNoException().isThrownBy { referral.validateInvariants() }
 
-      val secondAssignment =
+      val latestAssignment =
         ReferralAssignment(OffsetDateTime.now().plusMinutes(5L), assignee, assignee, superseded = false)
-      referral.assignments.add(secondAssignment)
+      referral.assignments.add(latestAssignment)
       assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { referral.validateInvariants() }
 
-      firstAssignment.superseded = true
-      secondAssignment.superseded = false
+      initialAssignment.superseded = false
+      latestAssignment.superseded = true
+      assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { referral.validateInvariants() }
+
+      initialAssignment.superseded = true
+      latestAssignment.superseded = false
       assertThatNoException().isThrownBy { referral.validateInvariants() }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
@@ -42,6 +44,29 @@ internal class ReferralTest {
       )
 
       assertThat(referral.currentAssignee).isEqualTo(currentAssignee)
+    }
+
+    @Test
+    fun `all but the latest assignment needs to be superseded`() {
+      val referral = referralFactory.createSent()
+      val assignee = authUserFactory.createSP()
+
+      referral.assignments.clear()
+      assertThatNoException().isThrownBy { referral.validateInvariants() }
+
+      val firstAssignment =
+        ReferralAssignment(OffsetDateTime.now().plusMinutes(1L), assignee, assignee, superseded = false)
+      referral.assignments.add(firstAssignment)
+      assertThatNoException().isThrownBy { referral.validateInvariants() }
+
+      val secondAssignment =
+        ReferralAssignment(OffsetDateTime.now().plusMinutes(5L), assignee, assignee, superseded = false)
+      referral.assignments.add(secondAssignment)
+      assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { referral.validateInvariants() }
+
+      firstAssignment.superseded = true
+      secondAssignment.superseded = false
+      assertThatNoException().isThrownBy { referral.validateInvariants() }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
@@ -168,18 +168,14 @@ class ReferralSpecificationsTest @Autowired constructor(
       val someOtherUser = authUserFactory.create(id = "someOtherUser")
 
       val assignments: List<ReferralAssignment> = listOf(
-        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = user),
-        ReferralAssignment(OffsetDateTime.now().minusDays(1), assignedBy = someOtherUser, assignedTo = someOtherUser),
+        ReferralAssignment(OffsetDateTime.now().minusDays(1), assignedBy = someOtherUser, assignedTo = someOtherUser, superseded = true),
+        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = user, superseded = false),
       )
 
       val assignedReferral = referralFactory.createAssigned(assignments = assignments)
-      val assignedReferralSummary = referralSumariesFactory.getReferralSummary(assignedReferral)
-
       val result = sentReferralSummariesRepository.findAll(ReferralSpecifications.currentlyAssignedTo(user.id))
 
-      assertThat(result)
-        .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
-        .containsExactly(assignedReferralSummary)
+      assertThat(result.map { it.id }).containsExactly(assignedReferral.id)
     }
 
     @Test
@@ -188,8 +184,8 @@ class ReferralSpecificationsTest @Autowired constructor(
       val someOtherUser = authUserFactory.create(id = "someOtherUser")
 
       val assignments: List<ReferralAssignment> = listOf(
-        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = someOtherUser),
-        ReferralAssignment(OffsetDateTime.now().minusDays(1), assignedBy = someOtherUser, assignedTo = user),
+        ReferralAssignment(OffsetDateTime.now().minusDays(1), assignedBy = someOtherUser, assignedTo = user, superseded = true),
+        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = someOtherUser, superseded = false),
       )
 
       referralFactory.createAssigned(assignments = assignments)
@@ -203,7 +199,7 @@ class ReferralSpecificationsTest @Autowired constructor(
       val someOtherUser = authUserFactory.create(id = "someOtherUser")
 
       val assignments: List<ReferralAssignment> = listOf(
-        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = someOtherUser)
+        ReferralAssignment(OffsetDateTime.now(), assignedBy = someOtherUser, assignedTo = someOtherUser, superseded = false)
       )
 
       referralFactory.createAssigned(assignments = assignments)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AssignmentsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AssignmentsFactory.kt
@@ -15,7 +15,12 @@ class AssignmentsFactory(em: TestEntityManager? = null) : EntityFactory(em) {
         this.add(authUserFactory.create(randomAlphanumeric(6), randomAlphanumeric(5), randomAlphanumeric(12)))
       }
     }
-    return assignedUsers.mapIndexed { i, u ->
+    return createInOrder(*assignedUsers.toTypedArray())
+  }
+
+  fun createInOrder(vararg users: AuthUser): List<ReferralAssignment> {
+    val numberOfAssignments = users.size
+    return users.mapIndexed { i, u ->
       val latest = numberOfAssignments - 1
       ReferralAssignment(
         OffsetDateTime.now().minusHours(latest.toLong()).plusHours(i.toLong()),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AssignmentsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AssignmentsFactory.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
+
+import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
+import java.time.OffsetDateTime
+
+class AssignmentsFactory(em: TestEntityManager? = null) : EntityFactory(em) {
+  private val authUserFactory = AuthUserFactory(em)
+
+  fun create(numberOfAssignments: Int): List<ReferralAssignment> {
+    val assignedUsers = mutableListOf<AuthUser>().apply {
+      repeat(numberOfAssignments) {
+        this.add(authUserFactory.create(randomAlphanumeric(6), randomAlphanumeric(5), randomAlphanumeric(12)))
+      }
+    }
+    return assignedUsers.mapIndexed { i, u ->
+      val latest = numberOfAssignments - 1
+      ReferralAssignment(
+        OffsetDateTime.now().minusHours(latest.toLong()).plusHours(i.toLong()),
+        assignedBy = u,
+        assignedTo = u,
+        superseded = i != latest
+      )
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Simplifies filtering dashboards for an assigned person. Essentially changes

- from `where ra.assigned_at = (SELECT MAX(assigned_at) FROM referral_assignments WHERE referral_id = ra.referral_id)`
- to `where ra.superseded = false`

## Enabled by

The invariant is now tested on persistence.

I did this because I was struggling with invalid test states and wanted to ensure we could not accidentally test the wrong things.

## What is the intent behind these changes?

There is an invariant in the data model that guarantees that all assignments are superseded, except the latest one.

This allows us to remove query and code complexity.