### PR TITLE
Nullified time component from date validation fields to align with UI validation rules

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -87,7 +87,10 @@ class DeliverySessionService(
       if (it.appointmentTime.isAfter(appointmentTime)) {
         throw EntityExistsException("can't schedule new appointment for session; new appointment occurs before previously scheduled appointment for session [referralId=$referralId, sessionNumber=$sessionNumber]")
       }
-      if (it.appointmentTime.isBefore(getReferral(referralId).sentAt)) {
+
+      val sentAtAtStartOfDay = getReferral(referralId).sentAt?.withHour(0)?.withMinute(0)?.withSecond(1)
+
+      if (it.appointmentTime.isBefore(sentAtAtStartOfDay)) {
         throw ValidationError("can't schedule new appointment for session; new appointment occurs before referral creation date for session [referralId=$referralId, sessionNumber=$sessionNumber]", listOf())
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
@@ -39,7 +39,9 @@ class AppointmentValidator {
       }
     }
 
-    if (referralStartDate != null && updateAppointmentDTO.appointmentTime.isBefore(referralStartDate)) {
+    val referralStartDateStartOfDay = referralStartDate?.withHour(0)?.withMinute(0)?.withSecond(1)
+
+    if (referralStartDate != null && updateAppointmentDTO.appointmentTime.isBefore(referralStartDateStartOfDay)) {
       errors.add(FieldError(field = "appointmentTime", error = Code.APPOINTMENT_TIME_BEFORE_REFERRAL_START_DATE))
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidatorTest.kt
@@ -135,20 +135,21 @@ internal class AppointmentValidatorTest {
       @Test
       fun `appointment date before referral date throws validation error`() {
         val updateAppointmentDTO = UpdateAppointmentDTO(
-          appointmentTime = OffsetDateTime.now().minusMinutes(1), // will fail if the test runs just after midnight
+          appointmentTime = OffsetDateTime.now().minusDays(1),
           durationInMinutes = 1,
           appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE,
           sessionType = AppointmentSessionType.ONE_TO_ONE,
           npsOfficeCode = "CRSEXT",
           appointmentAttendance = null,
-          appointmentBehaviour = null
+          appointmentBehaviour = null,
+
         )
 
         var exception = assertThrows<ValidationError> {
           deliverySessionValidator.validateUpdateAppointment(updateAppointmentDTO, OffsetDateTime.now())
         }
 
-        assertThat(exception.errors).containsExactly(
+        assertThat(exception.errors).contains(
           FieldError("appointmentTime", Code.APPOINTMENT_TIME_BEFORE_REFERRAL_START_DATE),
         )
       }


### PR DESCRIPTION
## What does this pull request do?

Removes the time component from the date validation check to prevent issues where the user see's an error from the API
that isn't caught in the UI validation. We could potentially change this in the future if we want to make the validation stricter
and include the time the referral was sent

## What is the intent behind these changes?

Prevent the users (SP) from seeing an API error due to it being stricter than the front end validation.
