### PR TITLE
creating a new delius appointment when PoP did not attend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -201,7 +201,7 @@ class DeliverySessionService(
     // TODO: Some code duplication here with AppointmentService.kt
     val deliusAppointmentId = communityAPIBookingService.book(
       session.referral,
-      existingAppointment,
+      if (attended != Attended.NO) existingAppointment else null,
       appointmentTime,
       durationInMinutes,
       SERVICE_DELIVERY,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -570,7 +570,7 @@ class DeliverySessionServiceTest @Autowired constructor(
         null
       )
 
-      verify(communityAPIBookingService).book(eq(session.referral), any(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
+      verify(communityAPIBookingService).book(eq(session.referral), isNull(), eq(defaultAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull())
 
       assertThat(updatedSession.appointments.size).isEqualTo(2)
       val appointment = updatedSession.currentAppointment!!


### PR DESCRIPTION
## What does this pull request do?

- Creates a new nDelius appointment when the PoP did not attend

## What is the intent behind these changes?

- Recently a change was made to create a new appointment when rescheduling a PoP did not attend the session. Though it creates new appointment in R & R system, it tries to update the existing appointment in nDelius system. This was not working and now we will have to create a new appointment in nDelius.
