### PR TITLE
creating a new delius appointment when PoP did not attend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -201,7 +201,7 @@ class DeliverySessionService(
     // TODO: Some code duplication here with AppointmentService.kt
     val deliusAppointmentId = communityAPIBookingService.book(
       session.referral,
-      if (attended != Attended.NO) existingAppointment else null,
+      if (existingAppointment != null && existingAppointment.attended != Attended.NO) existingAppointment else null,
       appointmentTime,
       durationInMinutes,
       SERVICE_DELIVERY,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -201,7 +201,7 @@ class DeliverySessionService(
     // TODO: Some code duplication here with AppointmentService.kt
     val deliusAppointmentId = communityAPIBookingService.book(
       session.referral,
-      if (existingAppointment != null && existingAppointment.attended != Attended.NO) existingAppointment else null,
+      if (existingAppointment?.attended != Attended.NO) existingAppointment else null,
       appointmentTime,
       durationInMinutes,
       SERVICE_DELIVERY,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -547,7 +547,7 @@ class DeliverySessionServiceTest @Autowired constructor(
     @Test
     fun `can create new delivery session appointment for an appointment did not attend`() {
       val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 1)
-      val session = deliverySessionFactory.createScheduled(referral = actionPlan.referral)
+      val session = deliverySessionFactory.createScheduled(referral = actionPlan.referral, attended = Attended.NO)
 
       whenever(actionPlanAppointmentEventPublisher.sessionFeedbackRecordedEvent(any())).doAnswer {
         val session = it.getArgument<DeliverySession>(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/DeliverySessionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/DeliverySessionFactory.kt
@@ -38,6 +38,7 @@ class DeliverySessionFactory(em: TestEntityManager? = null) : EntityFactory(em) 
     appointmentTime: OffsetDateTime = OffsetDateTime.now().plusMonths(1),
     durationInMinutes: Int = 120,
     deliusAppointmentId: Long? = null,
+    attended: Attended? = null
   ): DeliverySession {
     val appointment = appointmentFactory.create(
       createdBy = createdBy,
@@ -46,6 +47,7 @@ class DeliverySessionFactory(em: TestEntityManager? = null) : EntityFactory(em) 
       durationInMinutes = durationInMinutes,
       appointmentFeedbackSubmittedBy = createdBy,
       deliusAppointmentId = deliusAppointmentId,
+      attended = attended
     )
 
     return save(


### PR DESCRIPTION
## What does this pull request do?

-Creates a new nDelius appointment when the PoP did not attend

## What is the intent behind these changes?

- Recently a change was made to create a new appointment when rescheduling a PoP did not attend the session. Though it creates new appointment in R & R system, it tries to update the existing appointment in nDelius system. This was not working and now we will have to create a new appointment in nDelius.
