### PR TITLE
Statistics: report on the previous 7 days instead of "all time"

### DIFF
--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
@@ -10,15 +10,11 @@ WITH counts AS (SELECT COUNT(r.id)                                              
                        COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
                                                   r.end_requested_at IS NOT NULL AND
                                                   eosr.submitted_at IS NOT NULL )       AS count_of_early_end_referrals,
-                       COUNT(r.id) FILTER ( WHERE r.end_requested_reason_code = 'MIS' ) AS count_of_mistaken_referrals,
-                       COUNT(DISTINCT r.created_by_id)                                  AS count_of_pp_users_starting_referrals,
-                       COUNT(DISTINCT r.sent_by_id)                                     AS count_of_pp_users_sending_referrals
+                       COUNT(r.id) FILTER ( WHERE r.end_requested_reason_code = 'MIS' ) AS count_of_mistaken_referrals
                 FROM referral r
                          LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id),
 
-     times AS (SELECT AVG(sent_at - created_at)                                            AS avg_completion_time,
-                      PERCENTILE_CONT(0.50) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p50_completion_time,
-                      PERCENTILE_CONT(0.90) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p90_completion_time,
+     times AS (SELECT PERCENTILE_CONT(0.50) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p50_completion_time,
                       PERCENTILE_CONT(0.95) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p95_completion_time,
                       PERCENTILE_CONT(0.99) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p99_completion_time
                FROM referral
@@ -32,15 +28,7 @@ SELECT counts.count_of_started_referrals,
        counts.count_of_cancelled_referrals,
        counts.count_of_mistaken_referrals,
        counts.count_of_early_end_referrals,
-       counts.count_of_pp_users_starting_referrals,
-       counts.count_of_pp_users_sending_referrals,
-       CASE
-           WHEN counts.count_of_started_referrals = 0 THEN 0.0
-           ELSE 100.0 * counts.count_of_sent_referrals / counts.count_of_started_referrals
-           END AS completion_rate_percent,
-       times.avg_completion_time,
        times.p50_completion_time,
-       times.p90_completion_time,
        times.p95_completion_time,
        times.p99_completion_time
 

--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
@@ -1,16 +1,17 @@
-WITH counts AS (SELECT COUNT(r.id)                                                      AS count_of_started_referrals,
-                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NULL )                   AS count_of_draft_referrals,
-                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL )               AS count_of_sent_referrals,
-                       COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL )          AS count_of_concluded_referrals,
+WITH counts AS (SELECT COUNT(r.id)                                                AS count_of_started_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NULL )             AS count_of_draft_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL )         AS count_of_sent_referrals,
                        COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL AND
-                                                  r.concluded_at IS NULL )              AS count_of_live_referrals,
+                                                  r.concluded_at IS NULL )        AS count_of_live_referrals,
                        COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
                                                   r.end_requested_at IS NOT NULL AND
-                                                  eosr.submitted_at IS NULL )           AS count_of_cancelled_referrals,
+                                                  eosr.submitted_at IS NULL )     AS count_of_cancelled_referrals,
                        COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
                                                   r.end_requested_at IS NOT NULL AND
-                                                  eosr.submitted_at IS NOT NULL )       AS count_of_early_end_referrals,
-                       COUNT(r.id) FILTER ( WHERE r.end_requested_reason_code = 'MIS' ) AS count_of_mistaken_referrals
+                                                  eosr.submitted_at IS NOT NULL ) AS count_of_early_end_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
+                                                  r.end_requested_at IS NULL )    AS count_of_completed_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL )    AS count_of_concluded_referrals
                 FROM referral r
                          LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id),
 
@@ -23,11 +24,11 @@ WITH counts AS (SELECT COUNT(r.id)                                              
 SELECT counts.count_of_started_referrals,
        counts.count_of_draft_referrals,
        counts.count_of_sent_referrals,
-       counts.count_of_concluded_referrals,
        counts.count_of_live_referrals,
        counts.count_of_cancelled_referrals,
-       counts.count_of_mistaken_referrals,
        counts.count_of_early_end_referrals,
+       counts.count_of_completed_referrals,
+       counts.count_of_concluded_referrals,
        times.p50_completion_time,
        times.p95_completion_time,
        times.p99_completion_time

--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
@@ -1,4 +1,7 @@
-WITH counts AS (SELECT COUNT(r.id)                                                AS count_of_started_referrals,
+WITH dates AS (SELECT (DATE_TRUNC('day', NOW()) - '7 days'::interval) AS start_date,
+                      DATE_TRUNC('day', NOW())                        AS end_date),
+
+     counts AS (SELECT COUNT(r.id)                                                AS count_of_started_referrals,
                        COUNT(r.id) FILTER ( WHERE r.sent_at IS NULL )             AS count_of_draft_referrals,
                        COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL )         AS count_of_sent_referrals,
                        COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL AND
@@ -13,15 +16,21 @@ WITH counts AS (SELECT COUNT(r.id)                                              
                                                   r.end_requested_at IS NULL )    AS count_of_completed_referrals,
                        COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL )    AS count_of_concluded_referrals
                 FROM referral r
-                         LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id),
+                         LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id,
+                     dates d
+                WHERE COALESCE(r.concluded_at, r.end_requested_at, r.sent_at, r.created_at) BETWEEN d.start_date AND d.end_date),
 
      times AS (SELECT PERCENTILE_CONT(0.50) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p50_completion_time,
                       PERCENTILE_CONT(0.95) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p95_completion_time,
                       PERCENTILE_CONT(0.99) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p99_completion_time
-               FROM referral
-               WHERE sent_at IS NOT NULL)
+               FROM referral r,
+                    dates d
+               WHERE sent_at IS NOT NULL
+                 AND COALESCE(r.concluded_at, r.end_requested_at, r.sent_at, r.created_at) BETWEEN d.start_date AND d.end_date)
 
-SELECT counts.count_of_started_referrals,
+SELECT dates.start_date::date   AS start_date_inclusive,
+       dates.end_date::date - 1 AS end_date_inclusive,
+       counts.count_of_started_referrals,
        counts.count_of_draft_referrals,
        counts.count_of_sent_referrals,
        counts.count_of_live_referrals,
@@ -33,5 +42,6 @@ SELECT counts.count_of_started_referrals,
        times.p95_completion_time,
        times.p99_completion_time
 
-FROM counts,
+FROM dates,
+     counts,
      times;

--- a/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
+++ b/helm_deploy/hmpps-interventions-service/reports/team_kpi_report.sql
@@ -1,30 +1,28 @@
-WITH counts AS (
-    SELECT count(r.id)                                                      AS count_of_started_referrals,
-           count(r.id) FILTER ( WHERE r.sent_at IS NULL )                   AS count_of_draft_referrals,
-           count(r.id) FILTER ( WHERE r.sent_at IS NOT NULL )               AS count_of_sent_referrals,
-           count(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL )          AS count_of_concluded_referrals,
-           count(r.id) FILTER ( WHERE r.sent_at IS NOT NULL AND
-                                      r.concluded_at IS NULL )              AS count_of_live_referrals,
-           count(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
-                                      r.end_requested_at IS NOT NULL AND
-                                      eosr.submitted_at IS NULL )           AS count_of_cancelled_referrals,
-           count(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
-                                      r.end_requested_at IS NOT NULL AND
-                                      eosr.submitted_at IS NOT NULL )       AS count_of_early_end_referrals,
-           count(r.id) FILTER ( WHERE r.end_requested_reason_code = 'MIS' ) AS count_of_mistaken_referrals,
-           count(DISTINCT r.created_by_id)                                  AS count_of_pp_users_starting_referrals,
-           count(DISTINCT r.sent_by_id)                                     AS count_of_pp_users_sending_referrals
-    FROM referral r
-             LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id),
+WITH counts AS (SELECT COUNT(r.id)                                                      AS count_of_started_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NULL )                   AS count_of_draft_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL )               AS count_of_sent_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL )          AS count_of_concluded_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.sent_at IS NOT NULL AND
+                                                  r.concluded_at IS NULL )              AS count_of_live_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
+                                                  r.end_requested_at IS NOT NULL AND
+                                                  eosr.submitted_at IS NULL )           AS count_of_cancelled_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.concluded_at IS NOT NULL AND
+                                                  r.end_requested_at IS NOT NULL AND
+                                                  eosr.submitted_at IS NOT NULL )       AS count_of_early_end_referrals,
+                       COUNT(r.id) FILTER ( WHERE r.end_requested_reason_code = 'MIS' ) AS count_of_mistaken_referrals,
+                       COUNT(DISTINCT r.created_by_id)                                  AS count_of_pp_users_starting_referrals,
+                       COUNT(DISTINCT r.sent_by_id)                                     AS count_of_pp_users_sending_referrals
+                FROM referral r
+                         LEFT JOIN end_of_service_report eosr ON r.id = eosr.referral_id),
 
-     times AS (
-         SELECT avg(sent_at - created_at)                                            AS avg_completion_time,
-                percentile_cont(0.50) within group ( order by sent_at - created_at ) AS p50_completion_time,
-                percentile_cont(0.90) within group ( order by sent_at - created_at ) AS p90_completion_time,
-                percentile_cont(0.95) within group ( order by sent_at - created_at ) AS p95_completion_time,
-                percentile_cont(0.99) within group ( order by sent_at - created_at ) AS p99_completion_time
-         FROM referral
-         WHERE sent_at IS NOT NULL)
+     times AS (SELECT AVG(sent_at - created_at)                                            AS avg_completion_time,
+                      PERCENTILE_CONT(0.50) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p50_completion_time,
+                      PERCENTILE_CONT(0.90) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p90_completion_time,
+                      PERCENTILE_CONT(0.95) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p95_completion_time,
+                      PERCENTILE_CONT(0.99) WITHIN GROUP ( ORDER BY sent_at - created_at ) AS p99_completion_time
+               FROM referral
+               WHERE sent_at IS NOT NULL)
 
 SELECT counts.count_of_started_referrals,
        counts.count_of_draft_referrals,
@@ -36,10 +34,10 @@ SELECT counts.count_of_started_referrals,
        counts.count_of_early_end_referrals,
        counts.count_of_pp_users_starting_referrals,
        counts.count_of_pp_users_sending_referrals,
-       case
-           when counts.count_of_started_referrals = 0 then 0.0
-           else 100.0 * counts.count_of_sent_referrals / counts.count_of_started_referrals
-           end AS completion_rate_percent,
+       CASE
+           WHEN counts.count_of_started_referrals = 0 THEN 0.0
+           ELSE 100.0 * counts.count_of_sent_referrals / counts.count_of_started_referrals
+           END AS completion_rate_percent,
        times.avg_completion_time,
        times.p50_completion_time,
        times.p90_completion_time,
@@ -47,4 +45,4 @@ SELECT counts.count_of_started_referrals,
        times.p99_completion_time
 
 FROM counts,
-     times
+     times;


### PR DESCRIPTION
## What does this pull request do?

Switches #interventions-statistics reports from "all time" to "last 7 days".

Also removes unnecessary metrics. (As assumed by me, as we have very little evidence.)

Removed:

- average completion time (averages are too skewed by outliers)
- 90th percentile completion time (95th/99th are useful)
- count of users starting and sending referrals (used to see the uptake of the service during day1, now meaningless)
- completion rate (meaningless as long as we have hanging referrals and re-referrals)
- mistaken referrals (referrals ended with the reason 'made my mistake', as they are not useful here; will be useful together with re-referral tracking)

Added:

- count of completed referrals (the ones that finished naturally, without the probation officer requesting an early end)

## Where should the reviewer start?

Please review commit-by-commit as the first one is a reformat.

## What is the intent behind these changes?

Provide better rolling statistics for the service.
Also creates the foundation for measuring rolling data, e.g. the number of amendments and re-referrals.