### PR TITLE
Set consumed APIs for the developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -31,6 +31,10 @@ spec:
   lifecycle: production
   providesApis:
     - api:hmpps-interventions
+  consumesApis:
+    - api:hmpps-risks-and-needs
+    - api:hmpps-community
+    - api:hmpps-auth
 
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
## What does this pull request do?

Set consumed APIs for the developer portal.

This will show up on [this graph on the developer-portal](https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog-graph?rootEntityRefs%5B%5D=system%3Adefault%2Fhmpps-interventions&maxDepth=%E2%88%9E&selectedKinds%5B%5D=api&selectedKinds%5B%5D=component&selectedKinds%5B%5D=location&selectedKinds%5B%5D=resource&unidirectional=false&mergeRelations=true&direction=BT&showFilters=true) ("Interventions Service" would connect to all the others as well.)

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/1526295/177296735-5a5c0393-5165-433f-8532-90cb563e9a04.png">

## What is the intent behind these changes?

So that the dependency chain is visible if someone is wondering what impact an outage/data refresh would have.