### PR TITLE
Revert "hide withdrawn referrals"

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
@@ -12,16 +12,15 @@ import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.Index
-import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.NamedAttributeNode
 import javax.persistence.NamedEntityGraph
 import javax.persistence.NamedSubgraph
-import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
+
 @NamedEntityGraph(
   name = "entity-referral-graph",
   attributeNodes =
@@ -29,8 +28,7 @@ import javax.validation.constraints.NotNull
     NamedAttributeNode("sentBy"),
     NamedAttributeNode(value = "serviceUserData", subgraph = "serviceUserData"),
     NamedAttributeNode(value = "intervention", subgraph = "interventions"),
-    NamedAttributeNode(value = "endOfServiceReport", subgraph = "endOfServiceReport"),
-    NamedAttributeNode(value = "supplierAssessment", subgraph = "supplierAssessmentData")
+    NamedAttributeNode(value = "endOfServiceReport", subgraph = "endOfServiceReport")
   ],
   subgraphs = [
     NamedSubgraph(
@@ -51,14 +49,7 @@ import javax.validation.constraints.NotNull
       name = "serviceUserData",
       attributeNodes = [
         NamedAttributeNode("disabilities"),
-        NamedAttributeNode("referral")
-      ]
-    ),
-    NamedSubgraph(
-      name = "supplierAssessmentData",
-      attributeNodes = [
         NamedAttributeNode("referral"),
-        NamedAttributeNode("appointments")
       ]
     )
   ]
@@ -80,9 +71,7 @@ class SentReferralSummary(
   var endRequestedAt: OffsetDateTime? = null,
   @NotNull @ManyToOne(fetch = FetchType.LAZY) val intervention: Intervention,
   @NotNull val serviceUserCRN: String,
-  @OneToOne(mappedBy = "referral") @Fetch(FetchMode.JOIN) var endOfServiceReport: EndOfServiceReport? = null,
-  @OneToOne(mappedBy = "referral") @Fetch(FetchMode.JOIN) var supplierAssessment: SupplierAssessment? = null,
-  @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "referral_id") var actionPlans: MutableList<ActionPlan>? = null,
+  @OneToOne(mappedBy = "referral") @Fetch(FetchMode.JOIN) var endOfServiceReport: EndOfServiceReport? = null
 ) {
   private val currentAssignment: ReferralAssignment?
     get() = assignments.maxByOrNull { it.assignedAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -1,15 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
 
 import org.springframework.data.jpa.domain.Specification
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import java.time.OffsetDateTime
 import javax.persistence.criteria.JoinType
 
@@ -56,25 +53,6 @@ class ReferralSpecifications {
           cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
           cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
           root.join<T, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
-        )
-      }
-    }
-
-    fun <T> attendanceNotSubmitted(): Specification<T> {
-      return Specification<T> { root, _, cb ->
-        val supplierAssessmentJoin = root.join<T, SupplierAssessment>("supplierAssessment", JoinType.LEFT)
-        val appointmentJoin = supplierAssessmentJoin.join<SupplierAssessment, Appointment>("appointments", JoinType.LEFT)
-        val actionPlanJoin = root.join<T, ActionPlan>("actionPlans", JoinType.LEFT)
-        cb.not(
-          cb.and(
-            cb.and(
-              cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
-              cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
-              root.join<T, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
-            ),
-            cb.isNull(appointmentJoin.get<OffsetDateTime>("attendanceSubmittedAt")),
-            cb.isNull(actionPlanJoin.get<OffsetDateTime>("submittedAt")),
-          )
         )
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -178,8 +178,7 @@ class ReferralService(
     assignedToUserId: String?,
     searchText: String?,
   ): Specification<T> {
-    var findSentReferralsSpec = ReferralSpecifications.sent<T>().and(ReferralSpecifications.attendanceNotSubmitted<T>())
-
+    var findSentReferralsSpec = ReferralSpecifications.sent<T>()
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, concluded, ReferralSpecifications.concluded())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, cancelled, ReferralSpecifications.cancelled())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, unassigned, ReferralSpecifications.unassigned())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
@@ -103,6 +103,7 @@ class ReferralSpecificationsTest @Autowired constructor(
       val cancelledReferralSummary = referralSumariesFactory.getReferralSummary(cancelled)
       val completedReferralSummary = referralSumariesFactory.getReferralSummary(completed, endOfServiceReport)
       val result = sentReferralSummariesRepository.findAll(ReferralSpecifications.concluded())
+
       assertThat(result)
         .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
         .containsExactlyInAnyOrder(completedReferralSummary, cancelledReferralSummary)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -892,9 +892,9 @@ class ReferralServiceTest @Autowired constructor(
     fun `only referrals that have a person on probation matching the search text should be returned`() {
       val result = referralService.getSentReferralSummaryForUser(user, null, null, null, null, pageRequest, "john smith")
 
-      assertThat(result).hasSize(2)
-        .extracting("id")
-        .contains(referral.id, referral2.id)
+      assertThat(result).size().isEqualTo(2)
+      assertThat(result.first().id).isEqualTo(referral.id)
+      assertThat(result.last().id).isEqualTo(referral2.id)
     }
 
     @Test
@@ -945,14 +945,11 @@ class ReferralServiceTest @Autowired constructor(
     lateinit var selfAssignedSentReferralSummary: SentReferralSummary
     lateinit var otherAssignedSentReferralSummary: SentReferralSummary
     lateinit var pageRequest: PageRequest
-
     private val truncateSeconds: Comparator<OffsetDateTime> = Comparator { a, exp ->
-      if (exp != null && a != null) {
-        if (a
-          .truncatedTo(ChronoUnit.SECONDS)
-          .isEqual(exp.truncatedTo(ChronoUnit.SECONDS))
-        ) 0 else 1
-      } else { 0 }
+      if (a
+        .truncatedTo(ChronoUnit.SECONDS)
+        .isEqual(exp.truncatedTo(ChronoUnit.SECONDS))
+      ) 0 else 1
     }
 
     private val recursiveComparisonConfiguration: RecursiveComparisonConfiguration = recursiveComparisonConfigurationBuilder
@@ -989,7 +986,6 @@ class ReferralServiceTest @Autowired constructor(
         endRequestedAt = OffsetDateTime.now(),
         concludedAt = OffsetDateTime.now(),
         endOfServiceReport = null,
-        actionPlans = mutableListOf(actionPlanFactory.createSubmitted())
       )
 
       cancelledSentReferralSummary = sentReferralSummariesFactory.getReferralSummary(cancelledReferral)
@@ -1034,34 +1030,6 @@ class ReferralServiceTest @Autowired constructor(
         )
     }
 
-    @Test
-    fun `to check for cancelled referral were pop did not attend appointment should not return`() {
-      val result = referralService.getSentReferralSummaryForUser(user, null, null, null, null, pageRequest)
-      val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
-      val cancelledReferral = referralFactory.createEnded(
-        intervention = intervention,
-        endRequestedReason = cancellationReasonFactory.create("ANY"),
-        endRequestedAt = OffsetDateTime.now(),
-        concludedAt = OffsetDateTime.now(),
-        endOfServiceReport = null,
-        actionPlans = mutableListOf(actionPlanFactory.create(submittedAt = null))
-      )
-      val appointment =
-        appointmentFactory.create(referral = cancelledReferral, attendanceSubmittedAt = null)
-      val supplierAssessmentAppointment =
-        supplierAssessmentFactory.create(appointment = appointment, referral = cancelledReferral)
-      cancelledReferral.supplierAssessment = supplierAssessmentAppointment
-      entityManager.refresh(cancelledReferral)
-      assertThat(result)
-        .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
-        .containsExactlyInAnyOrder(
-          completedSentReferralSummary,
-          liveSentReferralSummary,
-          cancelledSentReferralSummary,
-          selfAssignedSentReferralSummary,
-          otherAssignedSentReferralSummary
-        )
-    }
     @Test
     fun `setting concluded returns only concluded referrals`() {
       val result = referralService.getSentReferralSummaryForUser(user, true, null, null, null, pageRequest)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -60,7 +60,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     intervention: Intervention = interventionFactory.create(),
     selectedServiceCategories: MutableSet<ServiceCategory>? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
-    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
+    actionPlans: MutableList<ActionPlan>? = null,
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
     referenceNumber: String? = "JS18726AC",
@@ -102,7 +102,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     intervention: Intervention = interventionFactory.create(),
     selectedServiceCategories: MutableSet<ServiceCategory>? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
-    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
+    actionPlans: MutableList<ActionPlan>? = null,
 
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
@@ -150,8 +150,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     referenceNumber: String? = "JS18726AC",
     relevantSentenceId: Long? = 123456L,
     supplementaryRiskId: UUID = UUID.randomUUID(),
-    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
-    supplierAssessment: SupplierAssessment? = null,
+    actionPlans: MutableList<ActionPlan>? = null,
 
     assignments: List<ReferralAssignment> = emptyList(),
 
@@ -172,7 +171,6 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       intervention = intervention,
       selectedServiceCategories = selectedServiceCategories,
       actionPlans = actionPlans,
-      supplierAssessment = supplierAssessment,
 
       sentAt = sentAt,
       sentBy = sentBy,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/SentReferralSummariesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/SentReferralSummariesFactory.kt
@@ -29,7 +29,7 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
     intervention: Intervention = interventionFactory.create(),
     selectedServiceCategories: MutableSet<ServiceCategory>? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
-    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
+    actionPlans: MutableList<ActionPlan>? = null,
 
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
@@ -51,10 +51,12 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       selectedServiceCategories = selectedServiceCategories,
       desiredOutcomes = desiredOutcomes,
       actionPlans = actionPlans,
+
       sentAt = sentAt,
       sentBy = sentBy,
       referenceNumber = referenceNumber,
       supplementaryRiskId = supplementaryRiskId,
+
       assignments = assignments,
       concludedAt = concludedAt,
       supplierAssessment = supplierAssessment,
@@ -71,9 +73,7 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       referenceNumber = referenceNumber,
       concludedAt = concludedAt,
       assignments = assignments.toMutableList(),
-      serviceUserData = serviceUserData,
-      actionPlans = actionPlans,
-      supplierAssessment = supplierAssessment
+      serviceUserData = serviceUserData
     )
   }
 
@@ -93,9 +93,7 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       assignments = referral.assignments,
       endRequestedAt = referral.endRequestedAt,
       endOfServiceReport = referral.endOfServiceReport ?: endOfServiceReport,
-      serviceUserData = referral.serviceUserData,
-      actionPlans = referral.actionPlans,
-      supplierAssessment = referral.supplierAssessment
+      serviceUserData = referral.serviceUserData
     )
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Reverts ministryofjustice/hmpps-interventions-service#1065

## What is the intent behind these changes?

Due to the same referral showing up multiple times in dashboards.
Issue thread on Slack: https://mojdt.slack.com/archives/CLA97UR7D/p1657530623108879