### PR TITLE
Cancelled referrals shown in service provider

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
@@ -15,7 +15,7 @@ class ReferralAccessFilter(
 
   fun <T> serviceProviderReferrals(referralSpec: Specification<T>, user: AuthUser): Specification<T> {
     val userScope = serviceProviderAccessScopeMapper.fromUser(user)
-    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts))
+    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts)).and(ReferralSpecifications.attendanceNotSubmitted<T>())
   }
 
   fun serviceProviderReferralSummaries(referrals: List<ServiceProviderSentReferralSummary>, user: AuthUser): List<ServiceProviderSentReferralSummary> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
@@ -12,15 +12,16 @@ import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.Index
+import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.NamedAttributeNode
 import javax.persistence.NamedEntityGraph
 import javax.persistence.NamedSubgraph
+import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
-
 @NamedEntityGraph(
   name = "entity-referral-graph",
   attributeNodes =
@@ -28,7 +29,8 @@ import javax.validation.constraints.NotNull
     NamedAttributeNode("sentBy"),
     NamedAttributeNode(value = "serviceUserData", subgraph = "serviceUserData"),
     NamedAttributeNode(value = "intervention", subgraph = "interventions"),
-    NamedAttributeNode(value = "endOfServiceReport", subgraph = "endOfServiceReport")
+    NamedAttributeNode(value = "endOfServiceReport", subgraph = "endOfServiceReport"),
+    NamedAttributeNode(value = "supplierAssessment", subgraph = "supplierAssessmentData")
   ],
   subgraphs = [
     NamedSubgraph(
@@ -49,7 +51,14 @@ import javax.validation.constraints.NotNull
       name = "serviceUserData",
       attributeNodes = [
         NamedAttributeNode("disabilities"),
+        NamedAttributeNode("referral")
+      ]
+    ),
+    NamedSubgraph(
+      name = "supplierAssessmentData",
+      attributeNodes = [
         NamedAttributeNode("referral"),
+        NamedAttributeNode("appointments")
       ]
     )
   ]
@@ -71,7 +80,9 @@ class SentReferralSummary(
   var endRequestedAt: OffsetDateTime? = null,
   @NotNull @ManyToOne(fetch = FetchType.LAZY) val intervention: Intervention,
   @NotNull val serviceUserCRN: String,
-  @OneToOne(mappedBy = "referral") @Fetch(FetchMode.JOIN) var endOfServiceReport: EndOfServiceReport? = null
+  @OneToOne(mappedBy = "referral") @Fetch(FetchMode.JOIN) var endOfServiceReport: EndOfServiceReport? = null,
+  @OneToOne(mappedBy = "referral") @Fetch(FetchMode.JOIN) var supplierAssessment: SupplierAssessment? = null,
+  @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "referral_id") var actionPlans: MutableList<ActionPlan>? = null,
 ) {
   private val currentAssignment: ReferralAssignment?
     get() = assignments.maxByOrNull { it.assignedAt }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
 
 import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import java.time.OffsetDateTime
 import javax.persistence.criteria.JoinType
 
@@ -53,6 +56,25 @@ class ReferralSpecifications {
           cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
           cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
           root.join<T, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
+        )
+      }
+    }
+
+    fun <T> attendanceNotSubmitted(): Specification<T> {
+      return Specification<T> { root, _, cb ->
+        val supplierAssessmentJoin = root.join<T, SupplierAssessment>("supplierAssessment", JoinType.LEFT)
+        val appointmentJoin = supplierAssessmentJoin.join<SupplierAssessment, Appointment>("appointments", JoinType.LEFT)
+        val actionPlanJoin = root.join<T, ActionPlan>("actionPlans", JoinType.LEFT)
+        cb.not(
+          cb.and(
+            cb.and(
+              cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
+              cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
+              root.join<T, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
+            ),
+            cb.isNull(appointmentJoin.get<OffsetDateTime>("attendanceSubmittedAt")),
+            cb.isNull(actionPlanJoin.get<OffsetDateTime>("submittedAt")),
+          )
         )
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -178,7 +178,8 @@ class ReferralService(
     assignedToUserId: String?,
     searchText: String?,
   ): Specification<T> {
-    var findSentReferralsSpec = ReferralSpecifications.sent<T>()
+    var findSentReferralsSpec = ReferralSpecifications.sent<T>().and(ReferralSpecifications.attendanceNotSubmitted<T>())
+
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, concluded, ReferralSpecifications.concluded())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, cancelled, ReferralSpecifications.cancelled())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, unassigned, ReferralSpecifications.unassigned())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -178,7 +178,7 @@ class ReferralService(
     assignedToUserId: String?,
     searchText: String?,
   ): Specification<T> {
-    var findSentReferralsSpec = ReferralSpecifications.sent<T>().and(ReferralSpecifications.attendanceNotSubmitted<T>())
+    var findSentReferralsSpec = ReferralSpecifications.sent<T>()
 
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, concluded, ReferralSpecifications.concluded())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, cancelled, ReferralSpecifications.cancelled())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
@@ -103,7 +103,6 @@ class ReferralSpecificationsTest @Autowired constructor(
       val cancelledReferralSummary = referralSumariesFactory.getReferralSummary(cancelled)
       val completedReferralSummary = referralSumariesFactory.getReferralSummary(completed, endOfServiceReport)
       val result = sentReferralSummariesRepository.findAll(ReferralSpecifications.concluded())
-
       assertThat(result)
         .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
         .containsExactlyInAnyOrder(completedReferralSummary, cancelledReferralSummary)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -514,10 +514,12 @@ class ReferralServiceTest @Autowired constructor(
   @DisplayName("get sent referrals with a probation practitioner user")
   inner class GetSentReferralsPPUser {
     private val truncateSeconds: Comparator<OffsetDateTime> = Comparator { a, exp ->
-      if (a
-        .truncatedTo(ChronoUnit.SECONDS)
-        .isEqual(exp.truncatedTo(ChronoUnit.SECONDS))
-      ) 0 else 1
+      if (exp != null && a != null) {
+        if (a
+          .truncatedTo(ChronoUnit.SECONDS)
+          .isEqual(exp.truncatedTo(ChronoUnit.SECONDS))
+        ) 0 else 1
+      } else { 0 }
     }
 
     private val recursiveComparisonConfiguration: RecursiveComparisonConfiguration = recursiveComparisonConfigurationBuilder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -60,7 +60,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     intervention: Intervention = interventionFactory.create(),
     selectedServiceCategories: MutableSet<ServiceCategory>? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
-    actionPlans: MutableList<ActionPlan>? = null,
+    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
     referenceNumber: String? = "JS18726AC",
@@ -102,7 +102,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     intervention: Intervention = interventionFactory.create(),
     selectedServiceCategories: MutableSet<ServiceCategory>? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
-    actionPlans: MutableList<ActionPlan>? = null,
+    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
 
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
@@ -150,7 +150,8 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     referenceNumber: String? = "JS18726AC",
     relevantSentenceId: Long? = 123456L,
     supplementaryRiskId: UUID = UUID.randomUUID(),
-    actionPlans: MutableList<ActionPlan>? = null,
+    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
+    supplierAssessment: SupplierAssessment? = null,
 
     assignments: List<ReferralAssignment> = emptyList(),
 
@@ -171,6 +172,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       intervention = intervention,
       selectedServiceCategories = selectedServiceCategories,
       actionPlans = actionPlans,
+      supplierAssessment = supplierAssessment,
 
       sentAt = sentAt,
       sentBy = sentBy,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/SentReferralSummariesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/SentReferralSummariesFactory.kt
@@ -29,7 +29,7 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
     intervention: Intervention = interventionFactory.create(),
     selectedServiceCategories: MutableSet<ServiceCategory>? = null,
     desiredOutcomes: List<DesiredOutcome> = emptyList(),
-    actionPlans: MutableList<ActionPlan>? = null,
+    actionPlans: MutableList<ActionPlan>? = mutableListOf(),
 
     sentAt: OffsetDateTime = OffsetDateTime.now(),
     sentBy: AuthUser = authUserFactory.create(),
@@ -51,12 +51,10 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       selectedServiceCategories = selectedServiceCategories,
       desiredOutcomes = desiredOutcomes,
       actionPlans = actionPlans,
-
       sentAt = sentAt,
       sentBy = sentBy,
       referenceNumber = referenceNumber,
       supplementaryRiskId = supplementaryRiskId,
-
       assignments = assignments,
       concludedAt = concludedAt,
       supplierAssessment = supplierAssessment,
@@ -73,7 +71,9 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       referenceNumber = referenceNumber,
       concludedAt = concludedAt,
       assignments = assignments.toMutableList(),
-      serviceUserData = serviceUserData
+      serviceUserData = serviceUserData,
+      actionPlans = actionPlans,
+      supplierAssessment = supplierAssessment
     )
   }
 
@@ -93,7 +93,9 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       assignments = referral.assignments,
       endRequestedAt = referral.endRequestedAt,
       endOfServiceReport = referral.endOfServiceReport ?: endOfServiceReport,
-      serviceUserData = referral.serviceUserData
+      serviceUserData = referral.serviceUserData,
+      actionPlans = referral.actionPlans,
+      supplierAssessment = referral.supplierAssessment
     )
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Show the unattended and cancelled referrals only in the PP side and hide it in the SP side

## What is the intent behind these changes?

Probation practitioner needs to see the unattended and cancelled referrals but can be hidden for the SP's
