### PR TITLE
resolving the duplicate referrals returned from the query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -61,7 +61,8 @@ class ReferralSpecifications {
     }
 
     fun <T> attendanceNotSubmitted(): Specification<T> {
-      return Specification<T> { root, _, cb ->
+      return Specification<T> { root, query, cb ->
+        query.distinct(true)
         val supplierAssessmentJoin = root.join<T, SupplierAssessment>("supplierAssessment", JoinType.LEFT)
         val appointmentJoin = supplierAssessmentJoin.join<SupplierAssessment, Appointment>("appointments", JoinType.LEFT)
         val actionPlanJoin = root.join<T, ActionPlan>("actionPlans", JoinType.LEFT)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -539,7 +539,7 @@ class ReferralServiceTest @Autowired constructor(
     }
 
     @Test
-    fun `to check for cancelled referral were pop did not attend appointment should return for SP user`() {
+    fun `to check for cancelled referral were pop did not attend appointment should return for PP user`() {
       val user = userFactory.create("pp_user_1", "delius")
       val startedReferrals = (1..3).map { sentReferralSummariesFactory.createSent(createdBy = user) }
 
@@ -1068,7 +1068,6 @@ class ReferralServiceTest @Autowired constructor(
 
     @Test
     fun `to check for cancelled referral were pop did not attend appointment should not return for SP User`() {
-      val result = referralService.getSentReferralSummaryForUser(user, null, null, null, null, pageRequest)
       val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
       val cancelledReferral = referralFactory.createEnded(
         intervention = intervention,
@@ -1084,6 +1083,7 @@ class ReferralServiceTest @Autowired constructor(
         supplierAssessmentFactory.create(appointment = appointment, referral = cancelledReferral)
       cancelledReferral.supplierAssessment = supplierAssessmentAppointment
       entityManager.refresh(cancelledReferral)
+      val result = referralService.getSentReferralSummaryForUser(user, null, null, null, null, pageRequest)
       assertThat(result)
         .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
         .containsExactlyInAnyOrder(


### PR DESCRIPTION
## What does this pull request do?

This pull request returns distinct query results when the attendance not submitted query is run.

## What is the intent behind these changes?

resolve regression issues when exclude cancelled unattended referrals where duplicate referrals were shown in the dashboard
