### PR TITLE
disabling the fix for showing the unattended cancelled referrals in t…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
@@ -15,7 +15,8 @@ class ReferralAccessFilter(
 
   fun <T> serviceProviderReferrals(referralSpec: Specification<T>, user: AuthUser): Specification<T> {
     val userScope = serviceProviderAccessScopeMapper.fromUser(user)
-    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts)).and(ReferralSpecifications.attendanceNotSubmitted<T>())
+    // TODO come back later and fix the bug for throwing error page
+    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts))
   }
 
   fun serviceProviderReferralSummaries(referrals: List<ServiceProviderSentReferralSummary>, user: AuthUser): List<ServiceProviderSentReferralSummary> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration
+import org.junit.Ignore
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -1067,6 +1068,8 @@ class ReferralServiceTest @Autowired constructor(
     }
 
     @Test
+    @Ignore
+    // TODO- come back once we solve the production issue
     fun `to check for cancelled referral were pop did not attend appointment should not return for SP User`() {
       val intervention = interventionFactory.create(contract = contractFactory.create(primeProvider = provider))
       val cancelledReferral = referralFactory.createEnded(


### PR DESCRIPTION
…he SP side alone.

## What does this pull request do?

- shows cancelled unattended referrals on both sides

## What is the intent behind these changes?

- This pull request was intended to disable the fix for not showing the cancelled unattended referrals on the sp side. This has caused an production issue. So, once we fix the issue, we will put the fix back
