### PR TITLE
fix for showing the unattended cancelled referrals in the SP side alone.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/ReferralAccessFilter.kt
@@ -15,8 +15,7 @@ class ReferralAccessFilter(
 
   fun <T> serviceProviderReferrals(referralSpec: Specification<T>, user: AuthUser): Specification<T> {
     val userScope = serviceProviderAccessScopeMapper.fromUser(user)
-    // TODO come back later and fix the bug for throwing error page
-    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts))
+    return referralSpec.and(ReferralSpecifications.withSPAccess(userScope.contracts)).and(ReferralSpecifications.attendanceNotSubmitted<T>())
   }
 
   fun serviceProviderReferralSummaries(referrals: List<ServiceProviderSentReferralSummary>, user: AuthUser): List<ServiceProviderSentReferralSummary> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
@@ -64,7 +64,7 @@ import javax.validation.constraints.NotNull
   ]
 )
 @Entity(name = "referral")
-@Table(name = "referral", indexes = arrayOf(Index(columnList = "created_by_id")))
+@Table(name = "referral", indexes = [Index(columnList = "created_by_id")])
 class SentReferralSummary(
   @Id val id: UUID,
   @ElementCollection

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSummariesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSummariesRepository.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
@@ -11,5 +13,5 @@ interface SentReferralSummariesRepository : JpaRepository<SentReferralSummary, U
   /** TODO- Projection with specification is not been implemented by Spring JPA yet.So have to come up with this approach of creating a repository for projecting the fields we wanted.
    * Will have to move to projection when that is ready. **/
   @EntityGraph(value = "entity-referral-graph")
-  override fun findAll(spec: Specification<SentReferralSummary>): List<SentReferralSummary>
+  override fun findAll(spec: Specification<SentReferralSummary>, page: Pageable): Page<SentReferralSummary>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -61,8 +61,7 @@ class ReferralSpecifications {
     }
 
     fun <T> attendanceNotSubmitted(): Specification<T> {
-      return Specification<T> { root, query, cb ->
-        query.distinct(true)
+      return Specification<T> { root, _, cb ->
         val supplierAssessmentJoin = root.join<T, SupplierAssessment>("supplierAssessment", JoinType.LEFT)
         val appointmentJoin = supplierAssessmentJoin.join<SupplierAssessment, Appointment>("appointments", JoinType.LEFT)
         val actionPlanJoin = root.join<T, ActionPlan>("actionPlans", JoinType.LEFT)
@@ -73,7 +72,10 @@ class ReferralSpecifications {
               cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
               root.join<T, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
             ),
-            cb.isNull(appointmentJoin.get<OffsetDateTime>("attendanceSubmittedAt")),
+            cb.and(
+              cb.isNull(appointmentJoin.get<OffsetDateTime>("attendanceSubmittedAt")),
+              cb.equal(appointmentJoin.get<Boolean>("superseded"), false)
+            ),
             cb.isNull(actionPlanJoin.get<OffsetDateTime>("submittedAt")),
           )
         )


### PR DESCRIPTION
## What does this pull request do?

- Fixes the issue where unattended cancelled referrals are shown in the SP side
- There was change in the query where we filter out the appointments which has superseded = false, in that way we avoid the duplication of referrals in the dashboard page

## What is the intent behind these changes?

-  Disabled the changes done in ```57449075995458b33b3bcfd76114c2bd71a6ae2c``` with this revision number ```2fbba750a548922c6100bf6b8df43baf07e4ee35``` due to a production bug where users reported the error page is been thrown
- When investigated we found that distinct and sort was not working well in tandem. so have to quickly disable the function that is causing it.
- We removed the distinct and resolved only by mapping the latest appointments
