### PR TITLE
Support multiplatform builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: main
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.14
+  hmpps: ministryofjustice/hmpps@5.1
   gradle: circleci/gradle@2.2.0
   mem: circleci/rememborb@0.0.1
 
@@ -252,10 +252,8 @@ workflows:
       - validate_helm:
           context:
             - hmpps-interventions-dev-deploy
-      - hmpps/build_docker:
+      - hmpps/build_multiplatform_docker:
           name: build_and_publish_docker
-          publish: true
-          persist_container_image: true
           filters:
             branches:
               only: [main]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,9 @@ _db_docker_config_postgres10: &db_docker_config_postgres10
 
 jobs:
   validate:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17.0"
     docker: *db_docker_config
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=true -Dkotlin.compiler.execution.strategy=in-process
@@ -52,7 +54,9 @@ jobs:
           path: build/reports/jacoco/test
 
   validate_db:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17.0"
     docker: *db_docker_config
     steps:
       - checkout
@@ -86,7 +90,9 @@ jobs:
             PGPASSWORD="$POSTGRES_PASSWORD" script/validate-metadata.sh
 
   validate_postgres10:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17.0"
     docker: *db_docker_config_postgres10
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=true -Dkotlin.compiler.execution.strategy=in-process
@@ -105,7 +111,9 @@ jobs:
           path: build/reports/jacoco/test
 
   validate_db_postgres10:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17.0"
     docker: *db_docker_config_postgres10
     steps:
       - checkout
@@ -139,7 +147,9 @@ jobs:
             PGPASSWORD="$POSTGRES_PASSWORD" script/validate-metadata.sh
 
   publish_data:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17.0"
     docker: *db_docker_config
     steps:
       - checkout
@@ -179,7 +189,9 @@ jobs:
       PACTBROKER_HOST: "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACTBROKER_AUTH_USERNAME: "interventions"
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17.0"
     docker: *db_docker_config
     steps:
       - checkout
@@ -216,7 +228,9 @@ jobs:
               --broker-base-url="$PACT_BROKER_BASE_URL" --broker-username="$PACT_BROKER_USERNAME" --broker-password="$PACT_BROKER_PASSWORD"
 
   validate_helm:
-    executor: hmpps/default_small
+    executor:
+      name: hmpps/default_small
+      tag: "3.10"
     steps:
       - checkout
       - hmpps/k8s_setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim AS builder
+FROM eclipse-temurin:17-jre-alpine AS builder
 
 WORKDIR /app
 
@@ -23,7 +23,7 @@ RUN ./gradlew assemble
 
 
 # ---
-FROM alpine:3.16 AS final
+FROM eclipse-temurin:17-jre-alpine AS final
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 # force a rebuild of `apk upgrade` below by invalidating the BUILD_NUMBER env variable on every commit
@@ -33,7 +33,6 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 RUN apk upgrade --no-cache && \
      apk add --no-cache \
        curl \
-       openjdk17-jdk \
        tzdata
 
 ENV TZ=Europe/London

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jre-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What does this pull request do?

Support x86_64 and arm64 builds out of the box.

Use `BUILDPLATFORM` which is [automatically defined][args].

🚫 Blocked until #1090 is merged (same line change)


## What is the intent behind these changes?

Taken from the ["Faster Multi-Platform Builds" guide][guide].

Picked from https://github.com/ministryofjustice/hmpps-template-kotlin/commit/70b9ff6ed5060d00639f135b7339e84ba290f62e

[guide]: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
[args]: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope