### PR TITLE
Amend desired outcomes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AmendReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AmendReferralController.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import mu.KLogging
+import org.springframework.http.HttpStatus.NO_CONTENT
+import org.springframework.http.ResponseEntity
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendComplexityLevelDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendDesiredOutcomesDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AmendReferralService
+import java.util.UUID
+
+@RestController
+class AmendReferralController(
+  private val amendReferralService: AmendReferralService
+) {
+  companion object : KLogging()
+
+  @PostMapping("/sent-referral/{referralId}/service-category/{serviceCategoryId}/amend-complexity-level")
+  fun updateComplexityLevel(
+    @PathVariable referralId: UUID,
+    @PathVariable serviceCategoryId: UUID,
+    @RequestBody complexityLevel: AmendComplexityLevelDTO,
+    authentication: JwtAuthenticationToken
+  ): ResponseEntity<Any> {
+    amendReferralService.updateComplexityLevel(referralId, complexityLevel, serviceCategoryId, authentication)
+    return ResponseEntity(NO_CONTENT)
+  }
+
+  @PostMapping("/sent-referral/{referralId}/service-category/{serviceCategoryId}/amend-desired-outcomes")
+  fun amendDesiredOutcomes(
+    authentication: JwtAuthenticationToken,
+    @PathVariable referralId: UUID,
+    @PathVariable serviceCategoryId: UUID,
+    @RequestBody request: AmendDesiredOutcomesDTO
+  ): ResponseEntity<Any> {
+    amendReferralService.updateReferralDesiredOutcomes(referralId, request, authentication, serviceCategoryId)
+    return ResponseEntity(NO_CONTENT)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AmendReferralChangesDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AmendReferralChangesDTO.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+data class AmendReferralChangesDTO(
+  var values: List<String>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AmendReferralsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AmendReferralsDTO.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AmendTopic
+import java.util.UUID
+
+data class AmendReferralsDTO(
+  val values: List<String>,
+  val reasonForChange: String? = null,
+  val amendTopic: AmendTopic
+) {
+  companion object {
+    fun from(changelog: Changelog): AmendReferralsDTO {
+      return AmendReferralsDTO(
+        values = changelog.newVal.values,
+        reasonForChange = changelog.reasonForChange,
+        amendTopic = changelog.topic
+      )
+    }
+  }
+}
+
+data class AmendComplexityLevelDTO(
+  val complexityLevelId: UUID,
+  val reasonForChange: String
+)
+
+data class AmendDesiredOutcomesDTO(
+  val desiredOutcomesIds: List<UUID>,
+  val reasonForChange: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
 
 enum class ReferralEventType {
-  SENT, ASSIGNED, CANCELLED, PREMATURELY_ENDED, COMPLETED, DETAILS_AMENDED
+  SENT, ASSIGNED, CANCELLED, PREMATURELY_ENDED, COMPLETED, DETAILS_AMENDED, COMPLEXITY_LEVEL_AMENDED, DESIRED_OUTCOMES_AMENDED
 }
 
 class ReferralEvent(
@@ -40,6 +40,14 @@ class ReferralEventPublisher(
 
   fun referralAssignedEvent(referral: Referral) {
     applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.ASSIGNED, referral, getSentReferralURL(referral)))
+  }
+
+  fun referralComplexityChangedEvent(referral: Referral) {
+    applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.COMPLEXITY_LEVEL_AMENDED, referral, getSentReferralURL(referral)))
+  }
+
+  fun referralDesiredOutcomesChangedEvent(referral: Referral) {
+    applicationEventPublisher.publishEvent(ReferralEvent(this, ReferralEventType.DESIRED_OUTCOMES_AMENDED, referral, getSentReferralURL(referral)))
   }
 
   fun referralConcludedEvent(referral: Referral, eventType: ReferralEventType) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Changelog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Changelog.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType
+import org.hibernate.annotations.Fetch
+import org.hibernate.annotations.FetchMode
+import org.hibernate.annotations.Type
+import org.hibernate.annotations.TypeDef
+import org.hibernate.annotations.TypeDefs
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AmendTopic
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.ManyToOne
+import javax.validation.constraints.NotNull
+
+@Entity
+@TypeDefs(
+  value = [
+    TypeDef(name = "jsonb", typeClass = JsonBinaryType::class),
+    TypeDef(name = "topic", typeClass = PostgreSQLEnumType::class)
+  ]
+)
+data class Changelog(
+  @Column(name = "referral_id") val referralId: UUID,
+
+  @Id
+  @Column(name = "changelog_id")
+  val id: UUID,
+
+  @Type(type = "topic") @Enumerated(EnumType.STRING)
+  var topic: AmendTopic,
+
+  @Type(type = "jsonb")
+  @Column(name = "old_value")
+  val oldVal: ReferralAmendmentDetails,
+
+  @Type(type = "jsonb")
+  @Column(name = "new_value")
+  val newVal: ReferralAmendmentDetails,
+
+  @Column(name = "reason_for_change")
+  var reasonForChange: String,
+
+  @Column(name = "changed_at")
+  val changedAt: OffsetDateTime,
+
+  @NotNull @ManyToOne @Fetch(FetchMode.JOIN)
+  val changedBy: AuthUser
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ChangelogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ChangelogRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
+import java.util.UUID
+
+interface ChangelogRepository : JpaRepository<Changelog, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -1,0 +1,139 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.server.ServerWebInputException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendComplexityLevelDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendDesiredOutcomesDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SelectedDesiredOutcomesMapping
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ChangelogRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.transaction.Transactional
+
+enum class AmendTopic {
+  COMPLEXITY_LEVEL,
+  DESIRED_OUTCOMES
+}
+
+@Service
+@Transactional
+class AmendReferralService(
+  private val referralEventPublisher: ReferralEventPublisher,
+  private val changelogRepository: ChangelogRepository,
+  private val referralRepository: ReferralRepository,
+  private val serviceCategoryRepository: ServiceCategoryRepository,
+  private val userMapper: UserMapper,
+  private val referralService: ReferralService
+) {
+
+  fun updateComplexityLevel(referralId: UUID, update: AmendComplexityLevelDTO, serviceCategoryId: UUID, authentication: JwtAuthenticationToken) {
+
+    val referral = getSentReferralForAuthenticatedUser(referralId, authentication)
+
+    if (referral.approvedActionPlan != null) {
+      throw ServerWebInputException("complexity level cannot be updated: the action plan is already approved")
+    }
+    val actor = userMapper.fromToken(authentication)
+    val complexityLevel = referral.complexityLevelIds?.get(serviceCategoryId)
+
+    referral.complexityLevelIds?.put(serviceCategoryId, update.complexityLevelId)
+
+    val oldValue = ReferralAmendmentDetails(listOf(complexityLevel!!.toString()))
+    val newValue = ReferralAmendmentDetails(listOf(update.complexityLevelId.toString()))
+
+    val changelog = Changelog(
+      referral.id,
+      UUID.randomUUID(),
+      AmendTopic.COMPLEXITY_LEVEL,
+      oldValue,
+      newValue,
+      update.reasonForChange,
+      OffsetDateTime.now(),
+      actor
+    )
+    changelogRepository.save(changelog)
+    referralRepository.save(referral)
+    referralEventPublisher.referralComplexityChangedEvent(referral)
+  }
+
+  fun updateReferralDesiredOutcomes(
+    referralId: UUID,
+    amendDesiredOutcomesDTO: AmendDesiredOutcomesDTO,
+    authentication: JwtAuthenticationToken,
+    serviceCategoryId: UUID
+  ) {
+
+    val referral = getSentReferralForAuthenticatedUser(referralId, authentication)
+
+    val desiredOutcomeIds = amendDesiredOutcomesDTO.desiredOutcomesIds
+
+    if (desiredOutcomeIds.isEmpty()) {
+      throw ServerWebInputException("desired outcomes cannot be empty")
+    }
+
+    if (referral.approvedActionPlan != null) {
+      throw ServerWebInputException("desired outcomes cannot be updated: the action plan is already approved")
+    }
+
+    if (referral.selectedServiceCategories.isNullOrEmpty()) {
+      throw ServerWebInputException("desired outcomes cannot be updated: no service categories selected for this referral")
+    }
+
+    if (!referral.selectedServiceCategories!!.map { it.id }.contains(serviceCategoryId)) {
+      throw ServerWebInputException("desired outcomes cannot be updated: specified service category not selected for this referral")
+    }
+
+    val validDesiredOutcomeIds = serviceCategoryRepository.findByIdOrNull(serviceCategoryId)?.desiredOutcomes?.map { it.id }
+      ?: throw ServerWebInputException("desired outcomes cannot be updated: specified service category not found")
+
+    if (!validDesiredOutcomeIds.containsAll(desiredOutcomeIds)) {
+      throw ServerWebInputException("desired outcomes cannot be updated: at least one desired outcome is not valid for this service category")
+    }
+
+    if (referral.selectedDesiredOutcomes == null) {
+      referral.selectedDesiredOutcomes = mutableListOf()
+    }
+
+    val actor = userMapper.fromToken(authentication)
+    val oldValue = ReferralAmendmentDetails(values = referral.selectedDesiredOutcomes!!.map { it.desiredOutcomeId.toString() }.toList())
+    val newValue = ReferralAmendmentDetails(values = desiredOutcomeIds.map { it.toString() }.toList())
+
+    referral.selectedDesiredOutcomes!!.removeIf { desiredOutcome -> desiredOutcome.serviceCategoryId == serviceCategoryId }
+    desiredOutcomeIds.forEach { desiredOutcomeId ->
+      referral.selectedDesiredOutcomes!!.add(
+        SelectedDesiredOutcomesMapping(serviceCategoryId, desiredOutcomeId)
+      )
+    }
+
+    val changelog = Changelog(
+      referral.id,
+      UUID.randomUUID(),
+      AmendTopic.DESIRED_OUTCOMES,
+      oldValue,
+      newValue,
+      amendDesiredOutcomesDTO.reasonForChange,
+      OffsetDateTime.now(),
+      actor
+    )
+    changelogRepository.save(changelog)
+    val savedReferral = referralRepository.save(referral)
+    referralEventPublisher.referralDesiredOutcomesChangedEvent(savedReferral)
+  }
+
+  fun getSentReferralForAuthenticatedUser(referralId: UUID, authentication: JwtAuthenticationToken): Referral {
+    val user = userMapper.fromToken(authentication)
+    return referralService.getSentReferralForUser(referralId, user)
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "sent referral not found [id=$referralId]")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
@@ -26,6 +26,8 @@ import javax.transaction.Transactional
 @Service
 @Transactional
 class ReferralNotificationService(
+  @Value("\${notify.templates.complexity-level-changed}") private val complexityLevelTemplateID: String,
+  @Value("\${notify.templates.desired-outcome-changed}") private val desiredOutcomesAmendTemplateID: String,
   @Value("\${notify.templates.referral-sent}") private val referralSentTemplateID: String,
   @Value("\${notify.templates.referral-assigned}") private val referralAssignedTemplateID: String,
   @Value("\${notify.templates.completion-deadline-updated}") private val completionDeadlineUpdatedTemplateID: String,
@@ -53,7 +55,7 @@ class ReferralNotificationService(
           mapOf(
             "organisationName" to serviceProvider.name,
             "referenceNumber" to event.referral.referenceNumber!!,
-            "referralUrl" to location.toString(),
+            "referralUrl" to location.toString()
           )
         )
       }
@@ -68,6 +70,34 @@ class ReferralNotificationService(
             "spFirstName" to userDetails.firstName,
             "referenceNumber" to event.referral.referenceNumber!!,
             "referralUrl" to location.toString(),
+          )
+        )
+      }
+
+      ReferralEventType.DESIRED_OUTCOMES_AMENDED -> {
+        val userDetails = hmppsAuthService.getUserDetail(event.referral.currentAssignee!!)
+        val location = generateResourceUrl(interventionsUIBaseURL, spReferralDetailsLocation, event.referral.id)
+        emailSender.sendEmail(
+          desiredOutcomesAmendTemplateID,
+          userDetails.email,
+          mapOf(
+            "sp_first_name" to userDetails.firstName,
+            "referral_number" to event.referral.referenceNumber!!,
+            "referral" to location.toString()
+          )
+        )
+      }
+
+      ReferralEventType.COMPLEXITY_LEVEL_AMENDED -> {
+        val userDetails = hmppsAuthService.getUserDetail(event.referral.currentAssignee!!)
+        val location = generateResourceUrl(interventionsUIBaseURL, spReferralDetailsLocation, event.referral.id)
+        emailSender.sendEmail(
+          complexityLevelTemplateID,
+          userDetails.email,
+          mapOf(
+            "sp_first_name" to userDetails.firstName,
+            "referral_number" to event.referral.referenceNumber!!,
+            "referral" to location.toString()
           )
         )
       }
@@ -123,7 +153,7 @@ class ReferralNotificationService(
           "newMaximumEnforceableDays" to newDetails.maximumEnforceableDays!!.toString(),
           "previousMaximumEnforceableDays" to previousDetails.maximumEnforceableDays!!.toString(),
           "changedByName" to "${updater.firstName} ${updater.lastName}",
-          "referralDetailsUrl" to frontendUrl.toString(),
+          "referralDetailsUrl" to frontendUrl.toString()
         )
       )
     }
@@ -144,7 +174,7 @@ class ReferralNotificationService(
         "newCompletionDeadline" to formatDate(newDetails.completionDeadline!!),
         "previousCompletionDeadline" to formatDate(previousDetails.completionDeadline!!),
         "changedByName" to "${updater.firstName} ${updater.lastName}",
-        "referralDetailsUrl" to frontendUrl.toString(),
+        "referralDetailsUrl" to frontendUrl.toString()
       )
     )
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,6 +114,8 @@ notify:
     case-note-sent: "83868039-3d42-4af6-86da-df14e9d4a8b7"
     completion-deadline-updated: "fb5c9bc1-3131-49aa-8aeb-6138208406d1"
     enforceable-days-updated: "eef5834f-3a33-46e1-a937-a8bf0e3320c0"
+    complexity-level-changed: "824900b1-7c06-4594-984d-310b1b46098a"
+    desired-outcome-changed: "817ce0e0-3efd-4bc9-a65d-e3e32e78c404"
 
 interventions-ui:
   locations:

--- a/src/main/resources/db/migration/V1_101_1__alter_changelog_table.sql
+++ b/src/main/resources/db/migration/V1_101_1__alter_changelog_table.sql
@@ -1,0 +1,3 @@
+CREATE TYPE amendTypes AS ENUM ('COMPLEXITY_LEVEL','DESIRED_OUTCOMES');
+
+alter table changelog alter column topic TYPE amendTypes using topic::amendTypes;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AmendReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/AmendReferralControllerTest.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.server.ServerWebInputException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendComplexityLevelDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendDesiredOutcomesDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AmendReferralService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ChangeLogFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import java.util.UUID
+
+internal class AmendReferralControllerTest {
+  private val amendReferralService = mock<AmendReferralService>()
+  private val amendReferralController = AmendReferralController(
+    amendReferralService
+  )
+  private val tokenFactory = JwtTokenFactory()
+  private val referralFactory = ReferralFactory()
+  private val authUserFactory = AuthUserFactory()
+
+  @Nested
+  inner class UpdateComplexityLevel {
+    private val referral = referralFactory.createSent()
+    private val user = authUserFactory.create()
+    private val token = tokenFactory.create(userID = user.id, userName = user.userName, authSource = user.authSource)
+    private val complexityUUID = UUID.randomUUID()
+    private val serviceCategoryUUID = UUID.randomUUID()
+
+    @Test
+    fun `updateComplexityLevel returns complexity level not updated if no referral exists`() {
+      val complexityLevel = AmendComplexityLevelDTO(complexityUUID, "A reason for change")
+      val serverWebInputException = ServerWebInputException("sent referral not found [id=${referral.id}]")
+      whenever(amendReferralService.updateComplexityLevel(any(), any(), any(), any()))
+        .thenThrow(serverWebInputException)
+      val exception = assertThrows<ResponseStatusException> {
+        amendReferralController.updateComplexityLevel(serviceCategoryUUID, referral.id, complexityLevel, token)
+      }
+      assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+      assertThat(exception.reason).isEqualTo("sent referral not found [id=${referral.id}]")
+    }
+
+    @Test
+    fun `updateComplexityLevel updates referral complexity level with valid referral and fields `() {
+      val complexityLevel = AmendComplexityLevelDTO(complexityUUID, "A reason for change")
+      doNothing().whenever(amendReferralService).updateComplexityLevel(eq(referral.id), eq(complexityLevel), eq(serviceCategoryUUID), eq(token))
+      val returnedValue = amendReferralController.updateComplexityLevel(referral.id, serviceCategoryUUID, complexityLevel, token)
+      assertThat(returnedValue.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+    }
+  }
+
+  @Nested
+  inner class AmendDesiredOutcomes {
+    private val referral = referralFactory.createSent()
+    private val user = authUserFactory.create()
+    private val token = tokenFactory.create(userID = user.id, userName = user.userName, authSource = user.authSource)
+    private val serviceCategoryUUID = UUID.randomUUID()
+    private val desiredOutcomesUUID = UUID.randomUUID()
+    private val newDesiredOutcomesUUID = UUID.randomUUID()
+    private val changeLogFactory = ChangeLogFactory()
+
+    @Test
+    fun `amendDesiredOutcomes do not update if no referral exists`() {
+      val amendDesiredOutcomesDTO = AmendDesiredOutcomesDTO(listOf(newDesiredOutcomesUUID), "A reason for change")
+      val serverWebInputException = ServerWebInputException("sent referral not found [id=${referral.id}]")
+      whenever(amendReferralService.updateReferralDesiredOutcomes(any(), any(), any(), any()))
+        .thenThrow(serverWebInputException)
+
+      val exception = assertThrows<ResponseStatusException> {
+        amendReferralController.amendDesiredOutcomes(token, referral.id, serviceCategoryUUID, amendDesiredOutcomesDTO)
+      }
+      assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+      assertThat(exception.reason).isEqualTo("sent referral not found [id=${referral.id}]")
+    }
+
+    @Test
+    fun `amendDesiredOutcomes updates referral desired outcomes for the service category`() {
+      val amendDesiredOutcomesDTO = AmendDesiredOutcomesDTO(listOf(newDesiredOutcomesUUID), "A reason for change")
+      doNothing().whenever(amendReferralService).updateReferralDesiredOutcomes(eq(referral.id), eq(amendDesiredOutcomesDTO), eq(token), eq(serviceCategoryUUID))
+      val returnedValue = amendReferralController.amendDesiredOutcomes(token, referral.id, serviceCategoryUUID, amendDesiredOutcomesDTO)
+      assertThat(returnedValue.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
@@ -1,0 +1,107 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendDesiredOutcomesDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ChangelogRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
+import java.util.UUID
+
+@RepositoryTest
+class AmendReferralServiceTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val referralRepository: ReferralRepository,
+  val authUserRepository: AuthUserRepository,
+  val interventionRepository: InterventionRepository,
+  val deliverySessionRepository: DeliverySessionRepository,
+  val actionPlanRepository: ActionPlanRepository,
+  val endOfServiceReportRepository: EndOfServiceReportRepository,
+  val serviceCategoryRepository: ServiceCategoryRepository,
+  val changelogRepository: ChangelogRepository
+) {
+
+  private val referralEventPublisher: ReferralEventPublisher = mock()
+  private val userFactory = AuthUserFactory(entityManager)
+  private val referralFactory = ReferralFactory(entityManager)
+  private val serviceCategoryFactory = ServiceCategoryFactory(entityManager)
+  private val referralService: ReferralService = mock()
+
+  private val userMapper: UserMapper = mock()
+  private val jwtAuthenticationToken = JwtAuthenticationToken(mock())
+  private val amendReferralService = AmendReferralService(
+    referralEventPublisher,
+    changelogRepository,
+    referralRepository,
+    serviceCategoryRepository,
+    userMapper,
+    referralService
+  )
+
+  @AfterEach
+  fun `clear referrals`() {
+    referralRepository.deleteAll()
+    changelogRepository.deleteAll()
+  }
+
+  @Test
+  fun `amend desired outcomes of a service category for a referral`() {
+    val someoneElse = userFactory.create("helper_pp_user", "delius")
+    val user = userFactory.create("pp_user_1", "delius")
+    val serviceCategoryId = UUID.randomUUID()
+    val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+    val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+
+    val serviceCategory = serviceCategoryFactory.create(
+      id = serviceCategoryId,
+      desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2)
+    )
+    val referral = referralFactory.createSent(
+      selectedServiceCategories = mutableSetOf(serviceCategory),
+      desiredOutcomes = mutableListOf(desiredOutcome1),
+      createdBy = someoneElse
+    )
+    whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(user)
+    whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+
+    amendReferralService.updateReferralDesiredOutcomes(
+      referral.id,
+      AmendDesiredOutcomesDTO(listOf(desiredOutcome2.id), "needs changing"),
+      jwtAuthenticationToken,
+      serviceCategory.id
+    )
+    val changelog = entityManager.entityManager.createQuery("FROM Changelog u WHERE u.referralId = :referralId")
+      .setParameter("referralId", referral.id)
+      .singleResult as Changelog
+
+    assertThat(changelog.newVal.values.size).isEqualTo(1)
+    assertThat(changelog.newVal.values).containsExactly(desiredOutcome2.id.toString())
+    assertThat(changelog.reasonForChange).isEqualTo("needs changing")
+
+    val newReferral = referralRepository.findById(referral.id).get()
+
+    assertThat(newReferral.selectedDesiredOutcomes!!.size).isEqualTo(1)
+    assertThat(newReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
+    assertThat(newReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome2.id)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceUnitTest.kt
@@ -1,0 +1,387 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.server.ServerWebInputException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendComplexityLevelDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AmendDesiredOutcomesDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ComplexityLevel
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ChangelogRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ChangeLogFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.JwtTokenFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
+import java.time.OffsetDateTime
+import java.util.Optional
+import java.util.UUID
+
+class AmendReferralServiceUnitTest {
+  private val referralRepository: ReferralRepository = mock()
+  private val referralService = mock<ReferralService>()
+  private val serviceCategoryRepository: ServiceCategoryRepository = mock()
+  private val changelogRepository: ChangelogRepository = mock()
+  private val referralEventPublisher: ReferralEventPublisher = mock()
+  private val jwtAuthenticationToken = JwtAuthenticationToken(mock())
+
+  private val userMapper: UserMapper = mock()
+
+  private val referralFactory = ReferralFactory()
+  private val serviceCategoryFactory = ServiceCategoryFactory()
+  private val tokenFactory = JwtTokenFactory()
+  private val changeLogFactory = ChangeLogFactory()
+  private val actionPlanFactory = ActionPlanFactory()
+
+  private val amendReferralService = AmendReferralService(
+    referralEventPublisher,
+    changelogRepository,
+    referralRepository,
+    serviceCategoryRepository,
+    userMapper,
+    referralService
+  )
+
+  @Nested
+  inner class UpdateDraftReferralDesiredOutcomes() {
+    val authUser = AuthUser("CRN123", "auth", "user")
+
+    @Test
+    fun `cant set desired outcomes to an empty list`() {
+      val referral = referralFactory.createSent()
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateReferralDesiredOutcomes(
+          referral.id,
+          AmendDesiredOutcomesDTO(listOf(), "wrong input"),
+          jwtAuthenticationToken,
+          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
+        )
+      }
+      assertThat(e.message.equals("desired outcomes cannot be empty"))
+    }
+
+    @Test
+    fun `cant set desired outcomes when no service categories have been selected`() {
+      val referral = referralFactory.createSent()
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateReferralDesiredOutcomes(
+          referral.id,
+          AmendDesiredOutcomesDTO(listOf(UUID.randomUUID()), "wrong input"),
+          jwtAuthenticationToken,
+          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be updated: no service categories selected for this referral"))
+    }
+
+    @Test
+    fun `cant set desired outcomes for an invalid service category`() {
+      val serviceCategory1 = serviceCategoryFactory.create()
+      val serviceCategory2 = serviceCategoryFactory.create()
+      val referral = referralFactory.createSent(selectedServiceCategories = mutableSetOf(serviceCategory1))
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateReferralDesiredOutcomes(
+          referral.id,
+          AmendDesiredOutcomesDTO(listOf(UUID.randomUUID()), "wrong input"),
+          jwtAuthenticationToken,
+          serviceCategory2.id
+        )
+      }
+      assertThat(e.message.equals("desired outcomes cannot be updated: specified service category not selected for this referral"))
+    }
+
+    @Test
+    fun `cant set desired outcome when service category is not found`() {
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.empty())
+      val serviceCategory = serviceCategoryFactory.create()
+      val referral = referralFactory.createSent(selectedServiceCategories = mutableSetOf(serviceCategory))
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateReferralDesiredOutcomes(
+          referral.id,
+          AmendDesiredOutcomesDTO(listOf(UUID.randomUUID()), "wrong input"),
+          jwtAuthenticationToken,
+          serviceCategory.id
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be updated: specified service category not found"))
+    }
+
+    @Test
+    fun `cant set desired outcome when the action plan is approved`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val serviceCategory = serviceCategoryFactory.create(
+        id = serviceCategoryId,
+        desiredOutcomes = listOf(desiredOutcome)
+      )
+      val referral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        desiredOutcomes = mutableListOf(desiredOutcome),
+        actionPlans = mutableListOf(actionPlanFactory.create(approvedAt = OffsetDateTime.now()))
+      )
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateReferralDesiredOutcomes(
+          referral.id,
+          AmendDesiredOutcomesDTO(listOf(desiredOutcome.id), "there is a reason"),
+          jwtAuthenticationToken,
+          serviceCategory.id
+        )
+      }
+      assertThat(e.reason).isEqualTo("desired outcomes cannot be updated: the action plan is already approved")
+    }
+
+    @Test
+    fun `cant set desired outcomes when its invalid for the service category`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val serviceCategory =
+        serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = listOf(desiredOutcome))
+      val referral = referralFactory.createSent(selectedServiceCategories = mutableSetOf(serviceCategory))
+
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateReferralDesiredOutcomes(
+          referral.id,
+          AmendDesiredOutcomesDTO(listOf(UUID.randomUUID()), "wrong input"),
+          jwtAuthenticationToken,
+          serviceCategory.id
+        )
+      }
+      assertThat(e.message.equals("desired outcomes cannot be updated: at least one desired outcome is not valid for this service category"))
+    }
+
+    @Test
+    fun `can update an already selected desired outcome for service category`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val serviceCategory = serviceCategoryFactory.create(
+        id = serviceCategoryId,
+        desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2)
+      )
+      val oldReferral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        desiredOutcomes = mutableListOf(desiredOutcome1)
+      )
+      val referral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        desiredOutcomes = mutableListOf(desiredOutcome2)
+      )
+      val expectedChangeLog = changeLogFactory.create(
+        oldVal = ReferralAmendmentDetails(listOf(desiredOutcome1.id.toString())),
+        newVal = ReferralAmendmentDetails(listOf(desiredOutcome2.id.toString()))
+      )
+
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(referralRepository.save(any())).thenReturn(referral)
+      whenever(changelogRepository.save(any())).thenReturn(expectedChangeLog)
+
+      amendReferralService.updateReferralDesiredOutcomes(
+        oldReferral.id,
+        AmendDesiredOutcomesDTO(listOf(desiredOutcome2.id), "needs changing"),
+        jwtAuthenticationToken,
+        serviceCategory.id
+      )
+
+      val changelogArgument: ArgumentCaptor<Changelog> = ArgumentCaptor.forClass(Changelog::class.java)
+      verify(changelogRepository).save(changelogArgument.capture())
+      val expectedChangelog = changelogArgument.value
+
+      assertThat(expectedChangelog?.newVal!!.values.size).isEqualTo(1)
+      assertThat(expectedChangelog.newVal.values).containsExactlyInAnyOrder(desiredOutcome2.id.toString())
+      assertThat(expectedChangelog.reasonForChange).isEqualTo("needs changing")
+
+      val argument: ArgumentCaptor<Referral> = ArgumentCaptor.forClass(Referral::class.java)
+      verify(referralRepository).save(argument.capture())
+      val expectedReferral = argument.value
+
+      assertThat(expectedReferral?.selectedDesiredOutcomes!!.size).isEqualTo(1)
+      assertThat(expectedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
+      assertThat(expectedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome2.id)
+    }
+
+    @Test
+    fun `can update multiple selected desired outcome for a service category`() {
+      val serviceCategoryId1 = UUID.randomUUID()
+      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val desiredOutcome3 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val desiredOutcome4 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val serviceCategory =
+        serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2, desiredOutcome3, desiredOutcome4))
+
+      val oldReferral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        desiredOutcomes = mutableListOf(desiredOutcome1)
+      )
+      val referral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        desiredOutcomes = mutableListOf(desiredOutcome1, desiredOutcome2)
+      )
+
+      val expectedChangeLog = changeLogFactory.create(
+        oldVal = ReferralAmendmentDetails(listOf(desiredOutcome1.id.toString(), desiredOutcome2.id.toString())),
+        newVal = ReferralAmendmentDetails(listOf(desiredOutcome3.id.toString(), desiredOutcome4.id.toString()))
+      )
+
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(referralRepository.save(any())).thenReturn(referral)
+      whenever(changelogRepository.save(any())).thenReturn(expectedChangeLog)
+
+      whenever(changelogRepository.save(any())).thenReturn(expectedChangeLog)
+
+      amendReferralService.updateReferralDesiredOutcomes(
+        oldReferral.id,
+        AmendDesiredOutcomesDTO(listOf(desiredOutcome3.id, desiredOutcome4.id), "needs changing"),
+        jwtAuthenticationToken,
+        serviceCategory.id
+      )
+
+      val changelogArgument: ArgumentCaptor<Changelog> = ArgumentCaptor.forClass(Changelog::class.java)
+      verify(changelogRepository).save(changelogArgument.capture())
+      val expectedChangelog = changelogArgument.value
+
+      assertThat(expectedChangelog?.newVal!!.values.size).isEqualTo(2)
+      assertThat(expectedChangelog.newVal.values).containsExactlyInAnyOrder(desiredOutcome3.id.toString(), desiredOutcome4.id.toString())
+      assertThat(expectedChangelog.reasonForChange).isEqualTo("needs changing")
+
+      val argument: ArgumentCaptor<Referral> = ArgumentCaptor.forClass(Referral::class.java)
+      verify(referralRepository).save(argument.capture())
+      val expectedReferral = argument.value
+
+      assertThat(expectedReferral?.selectedDesiredOutcomes!!.size).isEqualTo(2)
+      assertThat(expectedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
+      assertThat(expectedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome3.id)
+      assertThat(expectedReferral.selectedDesiredOutcomes!![1].serviceCategoryId).isEqualTo(serviceCategory.id)
+      assertThat(expectedReferral.selectedDesiredOutcomes!![1].desiredOutcomeId).isEqualTo(desiredOutcome4.id)
+    }
+  }
+
+  @Nested
+  inner class UpdateComplexityLevelId() {
+
+    val authUser = AuthUser("CRN123", "auth", "user")
+
+    @Test
+    fun `updateComplexityLevel results in changes being saved`() {
+
+      val complexityLevelId1 = UUID.randomUUID()
+      val complexityLevelId2 = UUID.randomUUID()
+
+      val complexityLevel1 = ComplexityLevel(complexityLevelId1, "1", "description")
+      val complexityLevel2 = ComplexityLevel(complexityLevelId2, "2", "description")
+
+      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1, complexityLevel2))
+
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+
+      val referral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        complexityLevelIds = mutableMapOf(serviceCategory.id to complexityLevel1.id)
+      )
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+
+      val updateToReferral = AmendComplexityLevelDTO(complexityLevelId1, "testing change")
+
+      amendReferralService.updateComplexityLevel(referral.id, updateToReferral, serviceCategory.id, jwtAuthenticationToken)
+
+      val argumentCaptorReferral = argumentCaptor<Referral>()
+      verify(referralRepository, atLeast(1)).save(argumentCaptorReferral.capture())
+
+      val referralValues = argumentCaptorReferral.firstValue
+      Assertions.assertEquals(complexityLevelId1, referralValues.complexityLevelIds?.get(serviceCategory.id))
+
+      val argumentCaptorChangelog = argumentCaptor<Changelog>()
+      verify(changelogRepository, atLeast(1)).save(argumentCaptorChangelog.capture())
+
+      val changeLogValues = argumentCaptorChangelog.firstValue
+      assertThat(changeLogValues.id).isNotNull
+      Assertions.assertEquals(authUser.id, changeLogValues.changedBy.id)
+    }
+
+    @Test
+    fun `no sent referral found error returned when appropriate `() {
+      val referralId = UUID.randomUUID()
+      val token = tokenFactory.create()
+
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(null)
+
+      val e = assertThrows<ResponseStatusException> {
+        amendReferralService.getSentReferralForAuthenticatedUser(referralId, token)
+      }
+      assertThat(e.status).isEqualTo(HttpStatus.NOT_FOUND)
+      assertThat(e.message).contains("sent referral not found [id=$referralId]")
+    }
+
+    @Test
+    fun `cant amend complexity level when the action plan is approved`() {
+
+      val complexityLevelId1 = UUID.randomUUID()
+
+      val complexityLevel1 = ComplexityLevel(complexityLevelId1, "1", "description")
+
+      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1))
+
+      val referral = referralFactory.createSent(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        complexityLevelIds = mutableMapOf(serviceCategory.id to complexityLevel1.id),
+        actionPlans = mutableListOf(actionPlanFactory.create(approvedAt = OffsetDateTime.now()))
+      )
+      whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
+      whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)
+
+      val e = assertThrows<ServerWebInputException> {
+        amendReferralService.updateComplexityLevel(
+          referral.id,
+          AmendComplexityLevelDTO(complexityLevelId1, "testing change"),
+          serviceCategory.id,
+          jwtAuthenticationToken
+        )
+      }
+      assertThat(e.reason).isEqualTo("complexity level cannot be updated: the action plan is already approved")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -61,6 +61,8 @@ class NotifyReferralServiceTest {
 
   private fun notifyService(): ReferralNotificationService {
     return ReferralNotificationService(
+      "complexityLevelTemplateID",
+      "desiredOutcomesAmendTemplateID",
       "referralSentTemplateID",
       "referralAssignedTemplateID",
       "completionDeadlineUpdatedTemplateID",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ChangeLogFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ChangeLogFactory.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AmendTopic
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ChangeLogFactory(em: TestEntityManager? = null) : EntityFactory(em) {
+
+  fun create(
+    id: UUID = UUID.randomUUID(),
+    topic: AmendTopic = AmendTopic.DESIRED_OUTCOMES,
+    referralId: UUID = UUID.randomUUID(),
+    oldVal: ReferralAmendmentDetails,
+    newVal: ReferralAmendmentDetails,
+    reasonForChange: String = "the value needs changing",
+    changedAt: OffsetDateTime = OffsetDateTime.now(),
+    changedBy: AuthUser = AuthUserFactory().create()
+  ): Changelog {
+    return save(
+      Changelog(
+        id = id,
+        topic = topic,
+        referralId = referralId,
+        oldVal = oldVal,
+        newVal = newVal,
+        reasonForChange = reasonForChange,
+        changedAt = changedAt,
+        changedBy = changedBy
+      )
+    )
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

- allow the user to amend the desired outcomes for a service category.
- updates the current referral to the new desired outcomes
- captures the audit information in the change log table

## What is the intent behind these changes?

- The user needed the ability the amend the referrals after it is been assigned as it helps them to correct their mistakes and avoid re-referring again
