### PR TITLE
Revert "Shrink image by switching back to JRE from JDK"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine AS builder
+FROM openjdk:17-slim AS builder
 
 WORKDIR /app
 
@@ -23,7 +23,7 @@ RUN ./gradlew assemble
 
 
 # ---
-FROM eclipse-temurin:17-jre-alpine AS final
+FROM alpine:3.16 AS final
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 # force a rebuild of `apk upgrade` below by invalidating the BUILD_NUMBER env variable on every commit
@@ -33,6 +33,7 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 RUN apk upgrade --no-cache && \
      apk add --no-cache \
        curl \
+       openjdk17-jdk \
        tzdata
 
 ENV TZ=Europe/London


### PR DESCRIPTION
This reverts commit 3a59b6bd14bbcc30e3d4efec36efa0edc0765951.

## What does this pull request do?

-reverting the base image of docker from eclipse-temurin:17-jre-alpine to openjdk:17-slim to see if this is causing the production outage

## What is the intent behind these changes?

- due to production pods been crashing, reverting to see if this change is causing the issue
