### PR TITLE
Shrink image by switching back to JRE from JDK and Update data dictionary base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/script"
+  schedule:
+    interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim AS builder
+FROM eclipse-temurin:17-jre-alpine AS builder
 
 WORKDIR /app
 
@@ -23,7 +23,7 @@ RUN ./gradlew assemble
 
 
 # ---
-FROM alpine:3.16 AS final
+FROM eclipse-temurin:17-jre-alpine AS final
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 # force a rebuild of `apk upgrade` below by invalidating the BUILD_NUMBER env variable on every commit
@@ -33,7 +33,6 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 RUN apk upgrade --no-cache && \
      apk add --no-cache \
        curl \
-       openjdk17-jdk \
        tzdata
 
 ENV TZ=Europe/London

--- a/script/Dockerfile.data-dictionary
+++ b/script/Dockerfile.data-dictionary
@@ -1,4 +1,4 @@
-FROM bitnami/nginx:1.21
+FROM bitnami/nginx:1.23
 
 WORKDIR /app
 COPY schema/ meta/schema/


### PR DESCRIPTION
## What does this pull request do?

Update data dictionary base image. Enables Dependabot to bump this image any time it updates.




## What is the intent behind these changes?

To roll out security fixes 
