### PR TITLE
set performance-report maxUnavailable to 0

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -12,7 +12,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "performanceReportApp.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## What does this pull request do?

when doing a deploy Kubernetes should wait for the new pod to be available before killing the old pod
https://trello.com/c/OWaiT7V7

## What is the intent behind these changes?

Keeps a pod available during deploys, so that any users, that are trying to generate a report at the same time as the deploy runs, will not get errors
(use same `maxUnavailable` setting as standard helm generic service [setup](https://github.com/ministryofjustice/hmpps-helm-charts/blob/8f9c3586c78132d6498308d900e24d4938570d35/charts/generic-service/values.yaml#L126)) 
