### PR TITLE
Fixing Performance issue when withdrawn referrals are shown in SP das…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSpecificationExecutor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSpecificationExecutor.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SentReferralSummary
+import java.util.UUID
+
+interface SentReferralSpecificationExecutor {
+  fun findReferralIds(spec: Specification<SentReferralSummary>, pageable: Pageable): Page<UUID>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSummariesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSummariesRepository.kt
@@ -1,9 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.lang.Nullable
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SentReferralSummary
 import java.util.UUID
 
@@ -11,5 +14,5 @@ interface SentReferralSummariesRepository : JpaRepository<SentReferralSummary, U
   /** TODO- Projection with specification is not been implemented by Spring JPA yet.So have to come up with this approach of creating a repository for projecting the fields we wanted.
    * Will have to move to projection when that is ready. **/
   @EntityGraph(value = "entity-referral-graph")
-  override fun findAll(spec: Specification<SentReferralSummary>): List<SentReferralSummary>
+  override fun findAll(@Nullable spec: Specification<SentReferralSummary>?, pageable: Pageable): Page<SentReferralSummary>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSummariesRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SentReferralSummariesRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.jpa.repository.query.QueryUtils.toOrders
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository
+import org.springframework.data.support.PageableExecutionUtils
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SentReferralSummary
+import java.util.UUID
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+class SentReferralSummariesRepositoryImpl(@PersistenceContext var entityManager: EntityManager) :
+  SimpleJpaRepository<SentReferralSummary, UUID>(SentReferralSummary::class.java, entityManager), SentReferralSpecificationExecutor {
+
+  override fun findReferralIds(spec: Specification<SentReferralSummary>, pageable: Pageable): Page<UUID> {
+
+    val criteriaBuilder = this.entityManager.criteriaBuilder
+
+    var criteriaQuery = criteriaBuilder.createQuery(UUID::class.java)
+    val root = criteriaQuery.from(SentReferralSummary::class.java)
+    criteriaQuery = criteriaQuery.select(root.get("id"))
+
+    val sort: Sort = if (pageable.isPaged) pageable.sort else Sort.unsorted()
+    if (sort.isSorted) {
+      criteriaQuery.orderBy(toOrders(sort, root, criteriaBuilder))
+    }
+    val predicate = spec.toPredicate(root, criteriaQuery, criteriaBuilder)
+    criteriaQuery.where(predicate)
+
+    val typedQuery = entityManager.createQuery(criteriaQuery)
+    if (pageable.isPaged) {
+      typedQuery.firstResult = pageable.offset.toInt()
+      typedQuery.maxResults = pageable.pageSize
+    }
+    return PageableExecutionUtils.getPage(typedQuery.resultList, pageable) { this.getCountQuery(spec, SentReferralSummary::class.java).singleResult }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -1,16 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
 
 import org.springframework.data.jpa.domain.Specification
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import java.time.OffsetDateTime
+import java.util.UUID
 import javax.persistence.criteria.JoinType
 
 class ReferralSpecifications {
@@ -64,26 +62,6 @@ class ReferralSpecifications {
       }
     }
 
-    fun <T> attendanceNotSubmitted(): Specification<T> {
-      return Specification<T> { root, query, cb ->
-        query.distinct(true)
-        val supplierAssessmentJoin = root.join<T, SupplierAssessment>("supplierAssessment", JoinType.LEFT)
-        val appointmentJoin = supplierAssessmentJoin.join<SupplierAssessment, Appointment>("appointments", JoinType.LEFT)
-        val actionPlanJoin = root.join<T, ActionPlan>("actionPlans", JoinType.LEFT)
-        cb.not(
-          cb.and(
-            cb.and(
-              cb.isNotNull(root.get<OffsetDateTime>("endRequestedAt")),
-              cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
-              root.join<T, EndOfServiceReport>("endOfServiceReport", JoinType.LEFT).isNull
-            ),
-            cb.isNull(appointmentJoin.get<OffsetDateTime>("attendanceSubmittedAt")),
-            cb.isNull(actionPlanJoin.get<OffsetDateTime>("submittedAt")),
-          )
-        )
-      }
-    }
-
     fun <T> withSPAccess(contracts: Set<DynamicFrameworkContract>): Specification<T> {
       return Specification<T> { root, _, _ ->
         val interventionJoin = root.join<T, Intervention>("intervention", JoinType.INNER)
@@ -108,6 +86,12 @@ class ReferralSpecifications {
         val latestAssignment = cb.equal(referralAssignmentJoin.get<Boolean>("superseded"), false)
         val sameUser = cb.equal(authUserJoin.get<String>("id"), authUserId)
         cb.and(latestAssignment, sameUser)
+      }
+    }
+
+    fun <T> idIn(uuids: Set<UUID>): Specification<T> {
+      return Specification<T> { root, _, _ ->
+        root.get<T>("id").`in`(uuids)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import mu.KotlinLogging
 import net.logstash.logback.argument.StructuredArguments.kv
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.domain.Specification.not
@@ -43,6 +44,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Dra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSpecificationExecutor
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification.ReferralSpecifications
@@ -86,6 +88,7 @@ class ReferralService(
   val telemetryService: TelemetryService,
   val draftOasysRiskInformationService: DraftOasysRiskInformationService,
   val referralDetailsRepository: ReferralDetailsRepository,
+  val sentReferralSummariesRepositoryImpl: SentReferralSpecificationExecutor,
   val changelogRepository: ChangelogRepository,
 ) {
   companion object {
@@ -166,8 +169,18 @@ class ReferralService(
   private fun getSentReferralSummaryForServiceProviderUser(user: AuthUser, sentReferralFilterSpecification: Specification<SentReferralSummary>, page: Pageable): Iterable<SentReferralSummary> {
     // todo: query for referrals where the service provider has been granted nominated access only
     val filteredSpec = referralAccessFilter.serviceProviderReferrals(sentReferralFilterSpecification, user)
-    return sentReferralSummariesRepository.findAll(filteredSpec, page)
+    val matchedReferralIds = sentReferralSummariesRepositoryImpl.findReferralIds(filteredSpec, page)
+    val sentReferralSummariesPage = sentReferralSummariesRepository.findAll(ReferralSpecifications.idIn(HashSet(matchedReferralIds.content)), page.sort)
+    val sentReferralSummaries = sentReferralSummariesPage.filterNot { cancelledUnattendedReferrals(it) }
+    val totalElements = if (sentReferralSummariesPage.size > sentReferralSummaries.size) matchedReferralIds.totalElements - (sentReferralSummariesPage.size - sentReferralSummaries.size)
+    else matchedReferralIds.totalElements
+    return PageImpl(sentReferralSummaries, page, totalElements)
   }
+
+  private fun cancelledUnattendedReferrals(it: SentReferralSummary) =
+    (it.concludedAt != null && it.endRequestedAt != null && it.endOfServiceReport == null) &&
+      it.supplierAssessment?.currentAppointment?.attendanceSubmittedAt == null &&
+      (it.actionPlans!!.all { actionPlan -> actionPlan.submittedAt == null })
 
   private fun getSentReferralSummariesForServiceProviderUser(user: AuthUser, dashboardType: DashboardType?): List<ServiceProviderSentReferralSummary> {
     val serviceProviders = serviceProviderUserAccessScopeMapper.fromUser(user).serviceProviders
@@ -177,7 +190,9 @@ class ReferralService(
 
   private fun getSentReferralSummaryForProbationPractitionerUser(user: AuthUser, sentReferralFilterSpecification: Specification<SentReferralSummary>, page: Pageable): Iterable<SentReferralSummary> {
     val filteredSpec = createSpecificationForProbationPractitionerUser(user, sentReferralFilterSpecification)
-    return sentReferralSummariesRepository.findAll(filteredSpec, page)
+    val matchedReferralIds = sentReferralSummariesRepositoryImpl.findReferralIds(filteredSpec, page)
+    val sentReferralSummaries = sentReferralSummariesRepository.findAll(ReferralSpecifications.idIn(HashSet(matchedReferralIds.content)), page.sort)
+    return PageImpl(sentReferralSummaries, page, matchedReferralIds.totalElements)
   }
 
   private inline fun <reified T> createSpecification(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -97,7 +97,7 @@ class ReferralServiceTest @Autowired constructor(
   val endOfServiceReportRepository: EndOfServiceReportRepository,
   val serviceCategoryRepository: ServiceCategoryRepository,
   val referralDetailsRepository: ReferralDetailsRepository,
-  val changelogRepository: ChangelogRepository
+  val changelogRepository: ChangelogRepository,
   val sentReferralSummariesRepositoryImpl: SentReferralSpecificationExecutor
 ) {
 
@@ -567,16 +567,19 @@ class ReferralServiceTest @Autowired constructor(
     @Test
     fun `returns referrals started by the user in the sorted order`() {
       val user = userFactory.create("pp_user_1", "delius")
-      val startedReferral1 = referralFactory.createSent(createdBy = user)
-      val serviceUserData1 = serviceUserDataFactory.create("Zack", "Synder", startedReferral1)
+      val startDraftReferral1 = referralFactory.createDraft(createdBy = user)
+      val startedReferral1 = referralFactory.createSent(id = startDraftReferral1.id, createdBy = user, createDraft = false)
+      val serviceUserData1 = serviceUserDataFactory.create("Zack", "Synder", startDraftReferral1)
       startedReferral1.serviceUserData = serviceUserData1
       entityManager.refresh(startedReferral1)
-      val startedReferral2 = referralFactory.createSent(createdBy = user)
-      val serviceUserData2 = serviceUserDataFactory.create("Dom", "Barnett", startedReferral2)
+      val startDraftReferral2 = referralFactory.createDraft(createdBy = user)
+      val startedReferral2 = referralFactory.createSent(id = startDraftReferral2.id, createdBy = user, createDraft = false)
+      val serviceUserData2 = serviceUserDataFactory.create("Dom", "Barnett", startDraftReferral2)
       startedReferral2.serviceUserData = serviceUserData2
       entityManager.refresh(startedReferral2)
-      val startedReferral3 = referralFactory.createSent(createdBy = user)
-      val serviceUserData3 = serviceUserDataFactory.create("Alice", "Wonderland", startedReferral3)
+      val startDraftReferral3 = referralFactory.createDraft(createdBy = user)
+      val startedReferral3 = referralFactory.createSent(id = startDraftReferral3.id, createdBy = user)
+      val serviceUserData3 = serviceUserDataFactory.create("Alice", "Wonderland", startDraftReferral3)
       startedReferral3.serviceUserData = serviceUserData3
       entityManager.refresh(startedReferral3)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -46,6 +46,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Dra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSpecificationExecutor
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
@@ -88,6 +89,7 @@ class ReferralServiceUnitTest {
   private val telemetryService: TelemetryService = mock()
   private val draftOasysRiskInformationService: DraftOasysRiskInformationService = mock()
   private val referralDetailsRepository: ReferralDetailsRepository = mock()
+  private val sentReferralSummariesRepositoryImpl: SentReferralSpecificationExecutor = mock()
   private val changeLogRepository: ChangelogRepository = mock()
 
   private val referralFactory = ReferralFactory()
@@ -106,7 +108,7 @@ class ReferralServiceUnitTest {
     deliverySessionRepository, serviceCategoryRepository, referralAccessChecker, userTypeChecker,
     serviceProviderAccessScopeMapper, referralAccessFilter, communityAPIReferralService, serviceUserAccessChecker,
     assessRisksAndNeedsService, communityAPIOffenderService, supplierAssessmentService, hmppsAuthService,
-    telemetryService, draftOasysRiskInformationService, referralDetailsRepository, changeLogRepository
+    telemetryService, draftOasysRiskInformationService, referralDetailsRepository, sentReferralSummariesRepositoryImpl, changeLogRepository
   )
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

- Fixing Hibernate HHH000104 firstResult maxResults warning. 
- Now retrieving the data is a two step process, first we retrieve only the ID's using the Spec query
- Then we retrieve the entity using the Id's which we got as a result of the previous query

## What is the intent behind these changes?

- When the fix for hiding withdrawn referrals was introduced in production, the performance issue started happening where the entire service was crashing because Hibernate did lots of pagination in memory. This fix was done as part of recommendation to fix the HHH000104 error.

## Performance testing

- As part of our team discussion, we decided to do performance test for the dashboard to make sure the new application is performing well after this change is introduced. 