### PR TITLE
Remove extra FBD East Midlands outcome

### DIFF
--- a/src/main/resources/db/migration/V1_103__remove_east_midlands_outcome.sql
+++ b/src/main/resources/db/migration/V1_103__remove_east_midlands_outcome.sql
@@ -1,0 +1,1 @@
+DELETE from desired_outcome where id = 'b16a54f3-fa51-4bcb-bc33-4df47cbdec79';


### PR DESCRIPTION
## What does this pull request do?

Removes extra outcome from FBD East Midlands 

## What is the intent behind these changes?

Corrects the list of outcomes
