### PR TITLE
upgrade springdoc-openapi-ui to 1.6.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
   runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3") // needed for OffsetDateTime for AppInsights
 
   // openapi
-  implementation("org.springdoc:springdoc-openapi-ui:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-ui:1.6.10")
 
   // notifications
   implementation("uk.gov.service.notify:notifications-java-client:3.17.3-RELEASE")


### PR DESCRIPTION
## What does this pull request do?

- upgrading springdoc-openapi-ui to 1.6.10

## What is the intent behind these changes?

- The previous version has got security vulnerability issue which is resolved in this version
