### PR TITLE
Fix for session feedback link not going to correct page

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIService.kt
@@ -214,7 +214,7 @@ class CommunityAPIActionPlanAppointmentEventService(
         }
         val url = UriComponentsBuilder.fromHttpUrl(interventionsUIBaseURL)
           .path(ppSessionFeedbackLocation)
-          .buildAndExpand(event.referral.id, event.deliverySession.sessionNumber)
+          .buildAndExpand(event.referral.id, event.deliverySession.sessionNumber, event.deliverySession.deliusAppointmentId!!)
           .toString()
 
         val notifyPP = setNotifyPPIfRequired(event.deliverySession)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
-import java.net.URI
 import mu.KLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationListener
@@ -19,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import java.net.URI
 
 interface NotifyService {
   fun generateResourceUrl(baseURL: String, path: String, vararg args: Any): URI {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
+import java.net.URI
 import mu.KLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationListener
@@ -18,7 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
-import java.net.URI
 
 interface NotifyService {
   fun generateResourceUrl(baseURL: String, path: String, vararg args: Any): URI {
@@ -135,6 +135,7 @@ class NotifyActionPlanAppointmentService(
         ppSessionFeedbackLocation,
         event.referral.id,
         event.deliverySession.sessionNumber,
+        event.deliverySession.deliusAppointmentId!!,
       )
 
       when (event.type) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,7 +130,7 @@ interventions-ui:
       intervention-progress: "/probation-practitioner/referrals/{id}/progress"
       supplier-assessment: "/probation-practitioner/referrals/{id}/supplier-assessment"
       action-plan: "/probation-practitioner/referrals/{id}/action-plan"
-      session-feedback: "/probation-practitioner/referrals/{id}/appointment/{sessionNumber}/post-session-feedback"
+      session-feedback: "/probation-practitioner/referrals/{id}/session/{sessionNumber}/appointment/{appointmentId}/post-session-feedback"
       supplier-assessment-feedback: "/probation-practitioner/referrals/{id}/supplier-assessment/post-assessment-feedback"
       end-of-service-report: "/probation-practitioner/end-of-service-report/{id}"
       case-note-details: "/probation-practitioner/case-note/{id}"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
@@ -34,6 +34,7 @@ class NotifyActionPlanAppointmentServiceTest {
       type,
       deliverySessionFactory.createAttended(
         id = UUID.fromString("42c7d267-0776-4272-a8e8-a673bfe30d0d"),
+        deliusAppointmentId = 12345L,
         referral = SampleData.sampleReferral(
           "X123456",
           "Harmony Living",
@@ -52,13 +53,12 @@ class NotifyActionPlanAppointmentServiceTest {
       "http://localhost:8080/appointment/42c7d267-0776-4272-a8e8-a673bfe30d0d"
     )
   }
-
   private fun notifyService(): NotifyActionPlanAppointmentService {
     return NotifyActionPlanAppointmentService(
       "template",
       "template",
       "http://example.com",
-      "/pp/referrals/{id}/appointment/sessionNumber/{sessionNumber}/feedback",
+      "/pp/referrals/{id}/session/{sessionNumber}/appointment/{appointmentId}/feedback",
       emailSender,
       referralService,
     )
@@ -88,7 +88,7 @@ class NotifyActionPlanAppointmentServiceTest {
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
     Assertions.assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("HAS71263")
-    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/appointment/sessionNumber/1/feedback")
+    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1/appointment/12345/feedback")
   }
 
   @Test
@@ -115,6 +115,6 @@ class NotifyActionPlanAppointmentServiceTest {
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
     Assertions.assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("HAS71263")
-    Assertions.assertThat(personalisationCaptor.firstValue["sessionUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/appointment/sessionNumber/1/feedback")
+    Assertions.assertThat(personalisationCaptor.firstValue["sessionUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1/appointment/12345/feedback")
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Fix for session feedback link not going to correct page when an email is sent

## What is the intent behind these changes?

Currently we have a bug where the link in emails sent to PP's are wrong for the feedback 
