### PR TITLE
Prevent feedback for future appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -178,6 +178,12 @@ class AppointmentService(
         "Feedback has already been submitted for this appointment [id=${appointment.id}]"
       )
     }
+    if (appointment.appointmentTime.isAfter(OffsetDateTime.now())) {
+      throw ResponseStatusException(
+        HttpStatus.BAD_REQUEST,
+        "Cannot submit feedback for a future appointment [id=${appointment.id}]"
+      )
+    }
     setAttendanceFields(appointment, attended, additionalAttendanceInformation, submittedBy)
     return appointmentRepository.save(appointment)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -325,9 +325,10 @@ class SetupAssistant(
     attended: Attended? = null,
     additionalAttendanceInformation: String? = null,
     attendanceBehaviour: String? = null,
-    notifyPPOfAttendanceBehaviour: Boolean? = null
+    notifyPPOfAttendanceBehaviour: Boolean? = null,
+    appointmentTime: OffsetDateTime = OffsetDateTime.now().plusMonths(2)
   ) {
-    val appointment: Appointment = appointmentFactory.create(createdBy = createPPUser(), referral = referral)
+    val appointment: Appointment = appointmentFactory.create(createdBy = createPPUser(), referral = referral, appointmentTime = appointmentTime)
     if (attended !== null) {
       appointment.attended = attended
       appointment.additionalAttendanceInformation = additionalAttendanceInformation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/SupplierAssessmentContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/SupplierAssessmentContracts.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AddressDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.SetupAssistant
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class SupplierAssessmentContracts(private val setupAssistant: SetupAssistant) {
@@ -47,7 +48,7 @@ class SupplierAssessmentContracts(private val setupAssistant: SetupAssistant) {
   @State("There is an existing sent referral with ID 58963698-0f2e-4d6e-a072-0e2cf351f3b2 and the supplier assessment has been booked but no feedback details have yet been submitted")
   fun `create a sent referral with supplier assessment without any feedback`() {
     val referral = setupAssistant.createSentReferral(id = UUID.fromString("58963698-0f2e-4d6e-a072-0e2cf351f3b2"))
-    setupAssistant.addSupplierAssessmentAppointment(referral.supplierAssessment!!, referral = referral, appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL)
+    setupAssistant.addSupplierAssessmentAppointment(referral.supplierAssessment!!, referral = referral, appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL, appointmentTime = OffsetDateTime.now())
   }
 
   @State("There is an existing sent referral with ID caac2a85-578f-4b0b-996d-2893311eb60e and the supplier assessment attendance details have been recorded")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -480,7 +480,7 @@ internal class DeliverySessionsServiceTest {
   @Test
   fun `updating session behaviour sets relevant fields`() {
     val actionPlanId = UUID.randomUUID()
-    val session = deliverySessionFactory.createScheduled()
+    val session = deliverySessionFactory.createScheduled(appointmentTime = OffsetDateTime.now())
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(any(), any())).thenReturn(session)
     whenever(deliverySessionRepository.save(any())).thenReturn(session)
 
@@ -507,7 +507,7 @@ internal class DeliverySessionsServiceTest {
 
   @Test
   fun `session feedback cant be submitted more than once`() {
-    val session = deliverySessionFactory.createScheduled()
+    val session = deliverySessionFactory.createScheduled(appointmentTime = OffsetDateTime.now())
     val actionPlanId = UUID.randomUUID()
 
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, 1)).thenReturn(session)
@@ -543,7 +543,7 @@ internal class DeliverySessionsServiceTest {
 
   @Test
   fun `session feedback can be submitted and stores time and actor`() {
-    val session = deliverySessionFactory.createScheduled()
+    val session = deliverySessionFactory.createScheduled(appointmentTime = OffsetDateTime.now())
     val actionPlanId = UUID.randomUUID()
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, 1)).thenReturn(
       session
@@ -573,7 +573,7 @@ internal class DeliverySessionsServiceTest {
   @Test
   fun `session feedback emits application events`() {
     val user = createActor()
-    val session = deliverySessionFactory.createScheduled()
+    val session = deliverySessionFactory.createScheduled(appointmentTime = OffsetDateTime.now())
     val actionPlanId = UUID.randomUUID()
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, 1)).thenReturn(
       session
@@ -614,7 +614,7 @@ internal class DeliverySessionsServiceTest {
 
   @Test
   fun `session feedback can be submitted when session not attended`() {
-    val session = deliverySessionFactory.createScheduled()
+    val session = deliverySessionFactory.createScheduled(appointmentTime = OffsetDateTime.now())
     val actionPlanId = UUID.randomUUID()
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, 1)).thenReturn(
       session
@@ -632,7 +632,7 @@ internal class DeliverySessionsServiceTest {
 
   @Test
   fun `session feedback can be submitted when session is attended and there is no behaviour feedback`() {
-    val session = deliverySessionFactory.createScheduled()
+    val session = deliverySessionFactory.createScheduled(appointmentTime = OffsetDateTime.now())
     val actionPlanId = UUID.randomUUID()
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, 1)).thenReturn(
       session


### PR DESCRIPTION
## What does this pull request do?

https://trello.com/c/SP3ESYUs
returns bad request if attempting to set feedback on a future appointment

## What is the intent behind these changes?

users should not be able to add feedback for an appointment that hasn't happened yet.
