### PR TITLE
Expose comparison data in the consistency error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RisksAndNeedsService.kt
@@ -102,11 +102,12 @@ class RisksAndNeedsService(
     if (response.statusCode.equals(HttpStatus.CONFLICT)) {
       if (response.body.createdDate != riskCreatedAt.toLocalDateTime()) {
         logger.error(
-          "attempted to update an existing supplementary risk with new data {} {} {} {}",
+          "attempted to update an existing supplementary risk with new data {} {} {} {} {}",
           kv("crn", crn),
           kv("referralId", referralId),
           kv("riskId", response.body.supplementaryRiskId),
-          kv("riskCreatedAt", riskCreatedAt)
+          kv("riskCreatedAt", riskCreatedAt),
+          kv("remoteRiskCreatedAt", response.body.createdDate)
         )
 
         throw WebClientResponseException(409, "Conflict from ARN 'createSupplementaryRisk'", null, null, null)


### PR DESCRIPTION

## What does this pull request do?

Expose comparison data in the consistency error.

## What is the intent behind these changes?

This saves us time retrieving the data from the production system when we want to check why it failed.

E.g. [this error in Sentry](https://sentry.io/organizations/ministryofjustice/issues/3458706764/events/53024508c6cf48118b163231ffa40d67/?project=5807819&statsPeriod=14d) tells us it happened, but does not expose what the remote date was.

The code in question:

```kt
    if (response.statusCode.equals(HttpStatus.CONFLICT)) {
      if (response.body.createdDate != riskCreatedAt.toLocalDateTime()) {
        logger.error(
          "attempted to update an existing supplementary risk with new data ...
{snip}
```