### PR TITLE
Split ReferralService into draft and non-draft service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -1,0 +1,473 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import mu.KotlinLogging
+import net.logstash.logback.argument.StructuredArguments
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ServerWebInputException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceUserAccessChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateReferralDetailsDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SelectedDesiredOutcomesMapping
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.transaction.Transactional
+
+@Service
+@Transactional
+class DraftReferralService(
+  val referralRepository: ReferralRepository,
+  val draftReferralRepository: DraftReferralRepository,
+  val referralAccessFilter: ReferralAccessFilter,
+  val referralAccessChecker: ReferralAccessChecker,
+  val serviceUserAccessChecker: ServiceUserAccessChecker,
+  val authUserRepository: AuthUserRepository,
+  val interventionRepository: InterventionRepository,
+  val eventPublisher: ReferralEventPublisher,
+  val referenceGenerator: ReferralReferenceGenerator,
+  val deliverySessionRepository: DeliverySessionRepository,
+  val serviceCategoryRepository: ServiceCategoryRepository,
+  val userTypeChecker: UserTypeChecker,
+  val communityAPIReferralService: CommunityAPIReferralService,
+  val assessRisksAndNeedsService: RisksAndNeedsService,
+  val supplierAssessmentService: SupplierAssessmentService,
+  val hmppsAuthService: HMPPSAuthService,
+  val referralDetailsRepository: ReferralDetailsRepository,
+  val draftOasysRiskInformationService: DraftOasysRiskInformationService,
+) {
+  companion object {
+    private val logger = KotlinLogging.logger {}
+    private const val maxReferenceNumberTries = 10
+  }
+
+  fun createDraftReferral(
+    user: AuthUser,
+    crn: String,
+    interventionId: UUID,
+    overrideID: UUID? = null,
+    overrideCreatedAt: OffsetDateTime? = null,
+  ): DraftReferral {
+    if (!userTypeChecker.isProbationPractitionerUser(user)) {
+      throw AccessError(user, "user cannot create referral", listOf("only probation practitioners can create draft referrals"))
+    }
+
+    // PPs can't create referrals for service users they are not allowed to see
+    serviceUserAccessChecker.forProbationPractitionerUser(crn, user)
+
+    val intervention = interventionRepository.getById(interventionId)
+    val serviceCategories = intervention.dynamicFrameworkContract.contractType.serviceCategories
+    val selectedServiceCategories = if (serviceCategories.size == 1) serviceCategories.toMutableSet() else null
+
+    return draftReferralRepository.save(
+      DraftReferral(
+        id = overrideID ?: UUID.randomUUID(),
+        createdAt = overrideCreatedAt ?: OffsetDateTime.now(),
+        createdBy = authUserRepository.save(user),
+        serviceUserCRN = crn,
+        intervention = interventionRepository.getById(interventionId),
+        selectedServiceCategories = selectedServiceCategories,
+      )
+    )
+  }
+
+  fun updateDraftReferral(referral: DraftReferral, update: DraftReferralDTO): DraftReferral {
+    validateDraftReferralUpdate(referral, update)
+
+    updateDraftReferralDetails(
+      referral,
+      UpdateReferralDetailsDTO(
+        update.maximumEnforceableDays,
+        update.completionDeadline,
+        update.furtherInformation,
+        "initial referral details",
+      ),
+      referral.createdBy,
+    )
+    updateServiceUserDetails(referral, update)
+    updateServiceUserNeeds(referral, update)
+    updateDraftRiskInformation(referral, update)
+    updateServiceCategoryDetails(referral, update)
+
+    // this field doesn't fit into any other categories - is this a smell?
+    update.relevantSentenceId?.let {
+      referral.relevantSentenceId = it
+    }
+
+    return draftReferralRepository.save(referral)
+  }
+
+  private fun updateServiceCategoryDetails(referral: DraftReferral, update: DraftReferralDTO) {
+    // The selected complexity levels and desired outcomes need to be removed if the user has unselected service categories that are linked to them
+    update.serviceCategoryIds?.let { serviceCategoryIds ->
+      referral.complexityLevelIds =
+        referral.complexityLevelIds?.filterKeys { serviceCategoryId -> serviceCategoryIds.contains(serviceCategoryId) }
+          ?.toMutableMap()
+      referral.selectedDesiredOutcomes =
+        referral.selectedDesiredOutcomes?.filter { desiredOutcome -> serviceCategoryIds.contains(desiredOutcome.serviceCategoryId) }
+          ?.toMutableList()
+    }
+
+    // Need to save and flush the entity before removing selected service categories due to constraint violations being thrown from selected complexity levels and desired outcomes
+    draftReferralRepository.saveAndFlush(referral)
+
+    update.serviceCategoryIds?.let { serviceCategoryIds ->
+      val updatedServiceCategories = serviceCategoryRepository.findByIdIn(serviceCategoryIds)
+      // the following code looks like a strange way to do this ...
+      // however we have to be very intentional about updating the service categories,
+      // rather than replacing the collection entirely. in the former case, hibernate
+      // runs an update as you would expect. in the latter case, hibernate deletes the
+      // entity entirely and creates a new one. this causes SQL constraint violations
+      // because these service category ids are referenced in the selected complexity
+      // level and desired outcomes tables.
+      referral.selectedServiceCategories?.let {
+        it.removeIf { true }
+        it.addAll(updatedServiceCategories)
+      } ?: run {
+        referral.selectedServiceCategories = updatedServiceCategories.toMutableSet()
+      }
+    }
+  }
+
+  fun updateDraftReferralDetails(referral: DraftReferral, update: UpdateReferralDetailsDTO, actor: AuthUser): ReferralDetails? {
+    if (!update.isValidUpdate) {
+      return null
+    }
+
+    val existingDetails = referralDetailsRepository.findLatestByReferralId(referral.id)
+
+    // if we are updating a draft referral, and there is already a ReferralDetails record,
+    // we update it. otherwise, we create a new one to record the changes.
+    val newDetails = existingDetails
+      ?: ReferralDetails(
+        UUID.randomUUID(),
+        null,
+        referral.id,
+        referral.createdAt,
+        actor.id,
+        update.reasonForChange,
+      )
+
+    update.completionDeadline?.let {
+      newDetails.completionDeadline = it
+    }
+
+    update.furtherInformation?.let {
+      newDetails.furtherInformation = it
+    }
+
+    update.maximumEnforceableDays?.let {
+      newDetails.maximumEnforceableDays = it
+    }
+
+    referralDetailsRepository.saveAndFlush(newDetails)
+
+    return newDetails
+  }
+
+  private fun updateServiceUserNeeds(draftReferral: DraftReferral, update: DraftReferralDTO) {
+    update.additionalNeedsInformation?.let {
+      draftReferral.additionalNeedsInformation = it
+    }
+
+    update.accessibilityNeeds?.let {
+      draftReferral.accessibilityNeeds = it
+    }
+
+    update.needsInterpreter?.let {
+      draftReferral.needsInterpreter = it
+      draftReferral.interpreterLanguage = if (it) update.interpreterLanguage else null
+    }
+
+    update.hasAdditionalResponsibilities?.let {
+      draftReferral.hasAdditionalResponsibilities = it
+      draftReferral.whenUnavailable = if (it) update.whenUnavailable else null
+    }
+  }
+
+  private fun updateDraftRiskInformation(draftReferral: DraftReferral, update: DraftReferralDTO) {
+    update.additionalRiskInformation?.let {
+      draftReferral.additionalRiskInformation = it
+      draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
+    }
+  }
+
+  private fun updateServiceUserDetails(draftReferral: DraftReferral, update: DraftReferralDTO) {
+    update.serviceUser?.let {
+      draftReferral.serviceUserData = ServiceUserData(
+        title = it.title,
+        firstName = it.firstName,
+        lastName = it.lastName,
+        dateOfBirth = it.dateOfBirth,
+        gender = it.gender,
+        ethnicity = it.ethnicity,
+        draftReferral = draftReferral,
+        preferredLanguage = it.preferredLanguage,
+        religionOrBelief = it.religionOrBelief,
+        disabilities = it.disabilities,
+      )
+    }
+  }
+
+  fun updateDraftReferralComplexityLevel(referral: DraftReferral, serviceCategoryId: UUID, complexityLevelId: UUID): DraftReferral {
+    if (referral.selectedServiceCategories.isNullOrEmpty()) {
+      throw ServerWebInputException("complexity level cannot be updated: no service categories selected for this referral")
+    }
+
+    if (!referral.selectedServiceCategories!!.map { it.id }.contains(serviceCategoryId)) {
+      throw ServerWebInputException("complexity level cannot be updated: specified service category not selected for this referral")
+    }
+
+    val validComplexityLevelIds = serviceCategoryRepository.findByIdOrNull(serviceCategoryId)?.complexityLevels?.map { it.id }
+      ?: throw ServerWebInputException("complexity level cannot be updated: specified service category not found")
+
+    if (!validComplexityLevelIds.contains(complexityLevelId)) {
+      throw ServerWebInputException("complexity level cannot be updated: complexity level not valid for this service category")
+    }
+
+    if (referral.complexityLevelIds == null) {
+      referral.complexityLevelIds = mutableMapOf()
+    }
+
+    referral.complexityLevelIds!![serviceCategoryId] = complexityLevelId
+    return draftReferralRepository.save(referral)
+  }
+
+  fun updateDraftReferralDesiredOutcomes(referral: DraftReferral, serviceCategoryId: UUID, desiredOutcomeIds: List<UUID>): DraftReferral {
+    if (desiredOutcomeIds.isEmpty()) {
+      throw ServerWebInputException("desired outcomes cannot be empty")
+    }
+
+    if (referral.selectedServiceCategories.isNullOrEmpty()) {
+      throw ServerWebInputException("desired outcomes cannot be updated: no service categories selected for this referral")
+    }
+
+    if (!referral.selectedServiceCategories!!.map { it.id }.contains(serviceCategoryId)) {
+      throw ServerWebInputException("desired outcomes cannot be updated: specified service category not selected for this referral")
+    }
+
+    val validDesiredOutcomeIds = serviceCategoryRepository.findByIdOrNull(serviceCategoryId)?.desiredOutcomes?.map { it.id }
+      ?: throw ServerWebInputException("desired outcomes cannot be updated: specified service category not found")
+
+    if (!validDesiredOutcomeIds.containsAll(desiredOutcomeIds)) {
+      throw ServerWebInputException("desired outcomes cannot be updated: at least one desired outcome is not valid for this service category")
+    }
+
+    if (referral.selectedDesiredOutcomes == null) {
+      referral.selectedDesiredOutcomes = mutableListOf()
+    }
+
+    referral.selectedDesiredOutcomes!!.removeIf { desiredOutcome -> desiredOutcome.serviceCategoryId == serviceCategoryId }
+    desiredOutcomeIds.forEach { desiredOutcomeId ->
+      referral.selectedDesiredOutcomes!!.add(
+        SelectedDesiredOutcomesMapping(serviceCategoryId, desiredOutcomeId)
+      )
+    }
+    return draftReferralRepository.save(referral)
+  }
+
+  fun getDraftReferralForUser(id: UUID, user: AuthUser): DraftReferral? {
+    if (!userTypeChecker.isProbationPractitionerUser(user)) {
+      throw AccessError(user, "unsupported user type", listOf("only probation practitioners can access draft referrals"))
+    }
+
+    val referral = draftReferralRepository.findById(id)
+    referral.ifPresent {
+      referralAccessChecker.forUser(it, user)
+    }
+    return referral.map { it }.orElse(null)
+  }
+
+  fun getDraftReferralsForUser(user: AuthUser): List<DraftReferral> {
+    if (!userTypeChecker.isProbationPractitionerUser(user)) {
+      throw AccessError(user, "user does not have access to referrals", listOf("only probation practitioners can access draft referrals"))
+    }
+
+    val referrals = draftReferralRepository.findByCreatedById(user.id)
+    return referralAccessFilter.probationPractitionerReferrals(referrals, user)
+  }
+
+  private fun validateDraftReferralUpdate(draftReferral: DraftReferral, update: DraftReferralDTO) {
+    val errors = mutableListOf<FieldError>()
+
+    update.completionDeadline?.let {
+      if (it.isBefore(LocalDate.now())) {
+        errors.add(FieldError(field = "completionDeadline", error = Code.DATE_MUST_BE_IN_THE_FUTURE))
+      }
+
+      // fixme: error if completion deadline is after sentence end date
+    }
+
+    update.needsInterpreter?.let {
+      if (it && update.interpreterLanguage == null) {
+        errors.add(FieldError(field = "needsInterpreter", error = Code.CONDITIONAL_FIELD_MUST_BE_SET))
+      }
+    }
+
+    update.hasAdditionalResponsibilities?.let {
+      if (it && update.whenUnavailable == null) {
+        errors.add(FieldError(field = "hasAdditionalResponsibilities", error = Code.CONDITIONAL_FIELD_MUST_BE_SET))
+      }
+    }
+
+    update.serviceUser?.let {
+      if (it.crn != draftReferral.serviceUserCRN) {
+        errors.add(FieldError(field = "serviceUser.crn", error = Code.FIELD_CANNOT_BE_CHANGED))
+      }
+    }
+
+    update.serviceCategoryIds?.let {
+      if (!draftReferral.intervention.dynamicFrameworkContract.contractType.serviceCategories.map {
+        serviceCategory ->
+        serviceCategory.id
+      }.containsAll(it)
+      ) {
+        errors.add(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT))
+      }
+    }
+
+    if (errors.isNotEmpty()) {
+      throw ValidationError("draft referral update invalid", errors)
+    }
+  }
+
+  fun sendDraftReferral(draftReferral: DraftReferral, user: AuthUser): Referral {
+    val referral = createReferral(draftReferral)
+    referral.sentAt = OffsetDateTime.now()
+    referral.sentBy = authUserRepository.save(user)
+
+    referral.referenceNumber = generateReferenceNumber(draftReferral)
+
+    /*
+     * This is a temporary solution until a robust asynchronous link is created between Interventions
+     * and Delius/ARN. Once the asynchronous link is implemented, this feature can be turned off, and instead
+     * Delius/ARN will be notified via the normal asynchronous route
+     *
+     * Order is important: ARN is more likely to fail via a timeout and thus when repeated by the user a
+     * duplicate NSI gets created in Delius as the Delius call is not idempotent. This order avoids creating
+     * duplicate NSIs in nDelius on user retry.
+     */
+    submitAdditionalRiskInformation(referral, user)
+    communityAPIReferralService.send(referral)
+
+    val sentReferral = referralRepository.save(referral)
+    eventPublisher.referralSentEvent(sentReferral)
+    supplierAssessmentService.createSupplierAssessment(referral)
+    return sentReferral
+  }
+
+  private fun createReferral(draftReferral: DraftReferral): Referral {
+    return Referral(
+      id = draftReferral.id,
+      furtherInformation = draftReferral.furtherInformation,
+      additionalNeedsInformation = draftReferral.additionalNeedsInformation,
+      additionalRiskInformation = draftReferral.additionalRiskInformation,
+      additionalRiskInformationUpdatedAt = draftReferral.additionalRiskInformationUpdatedAt,
+      accessibilityNeeds = draftReferral.accessibilityNeeds,
+      needsInterpreter = draftReferral.needsInterpreter,
+      interpreterLanguage = draftReferral.interpreterLanguage,
+      hasAdditionalResponsibilities = draftReferral.hasAdditionalResponsibilities,
+      whenUnavailable = draftReferral.whenUnavailable,
+      maximumEnforceableDays = draftReferral.maximumEnforceableDays,
+      selectedDesiredOutcomes = draftReferral.selectedDesiredOutcomes,
+      completionDeadline = draftReferral.completionDeadline,
+      relevantSentenceId = draftReferral.relevantSentenceId,
+      intervention = draftReferral.intervention,
+      serviceUserCRN = draftReferral.serviceUserCRN,
+      createdBy = draftReferral.createdBy,
+      createdAt = draftReferral.createdAt,
+      referralDetailsHistory = draftReferral.referralDetailsHistory,
+    )
+  }
+
+  private fun submitAdditionalRiskInformation(referral: Referral, user: AuthUser) {
+    // todo: throw exception once posting full risk to ARN feature is enabled, however allow some time for in-flight
+    //  make-referral requests to pass
+
+    val oasysRiskInformation = draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)
+    val riskId = if (oasysRiskInformation != null && assessRisksAndNeedsService.canPostFullRiskInformation()) {
+      assessRisksAndNeedsService.createSupplementaryRisk(
+        referral.id,
+        referral.serviceUserCRN,
+        user,
+        oasysRiskInformation.updatedAt,
+        oasysRiskInformation.additionalInformation ?: "",
+        RedactedRisk(
+          riskWho = oasysRiskInformation.riskSummaryWhoIsAtRisk ?: "",
+          riskWhen = oasysRiskInformation.riskSummaryRiskImminence ?: "",
+          riskNature = oasysRiskInformation.riskSummaryNatureOfRisk ?: "",
+          concernsSelfHarm = oasysRiskInformation.riskToSelfSelfHarm ?: "",
+          concernsSuicide = oasysRiskInformation.riskToSelfSuicide ?: "",
+          concernsHostel = oasysRiskInformation.riskToSelfHostelSetting ?: "",
+          concernsVulnerability = oasysRiskInformation.riskToSelfVulnerability ?: "",
+        )
+      )
+    } else {
+      val additionalRiskInformation = referral.additionalRiskInformation
+        ?: throw ServerWebInputException("can't submit a referral without risk information")
+
+      val riskSubmittedAt = referral.additionalRiskInformationUpdatedAt
+        ?: run {
+          // this should NEVER happen. i'm not really sure why we have this as a fallback.
+          logger.warn("no additionalRiskInformationUpdatedAt on referral; setting to current time")
+          OffsetDateTime.now()
+        }
+
+      assessRisksAndNeedsService.createSupplementaryRisk(
+        referral.id,
+        referral.serviceUserCRN,
+        user,
+        riskSubmittedAt,
+        additionalRiskInformation,
+        null
+      )
+    }
+
+    referral.supplementaryRiskId = riskId
+    // we do not store _any_ risk information in interventions once it has been sent to ARN
+    referral.additionalRiskInformation = null
+    draftOasysRiskInformationService.deleteDraftOasysRiskInformation(referral.id)
+  }
+
+  private fun generateReferenceNumber(draftReferral: DraftReferral): String? {
+    val type = draftReferral.intervention.dynamicFrameworkContract.contractType.name
+
+    for (i in 1..maxReferenceNumberTries) {
+      val candidate = referenceGenerator.generate(type)
+      if (!referralRepository.existsByReferenceNumber(candidate))
+        return candidate
+      else
+        logger.warn(
+          "Clash found for referral number {}",
+          StructuredArguments.kv("candidate", candidate)
+        )
+    }
+
+    logger.error(
+      "Unable to generate a referral number {} {}",
+      StructuredArguments.kv("tries", maxReferenceNumberTries),
+      StructuredArguments.kv("referral_id", draftReferral.id)
+    )
+    return null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -9,32 +9,23 @@ import org.springframework.data.jpa.domain.Specification.where
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceProviderAccessScopeMapper
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceUserAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.AccessError
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DashboardType
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateReferralDetailsDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SelectedDesiredOutcomesMapping
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SentReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ChangelogRepository
@@ -46,7 +37,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ref
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.SentReferralSummariesRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification.ReferralSpecifications
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.transaction.Transactional
@@ -69,7 +59,6 @@ class ReferralService(
   val interventionRepository: InterventionRepository,
   val referralConcluder: ReferralConcluder,
   val eventPublisher: ReferralEventPublisher,
-  val referenceGenerator: ReferralReferenceGenerator,
   val cancellationReasonRepository: CancellationReasonRepository,
   val deliverySessionRepository: DeliverySessionRepository,
   val serviceCategoryRepository: ServiceCategoryRepository,
@@ -77,20 +66,14 @@ class ReferralService(
   val userTypeChecker: UserTypeChecker,
   val serviceProviderUserAccessScopeMapper: ServiceProviderAccessScopeMapper,
   val referralAccessFilter: ReferralAccessFilter,
-  val communityAPIReferralService: CommunityAPIReferralService,
-  val serviceUserAccessChecker: ServiceUserAccessChecker,
-  val assessRisksAndNeedsService: RisksAndNeedsService,
   val communityAPIOffenderService: CommunityAPIOffenderService,
-  val supplierAssessmentService: SupplierAssessmentService,
   val hmppsAuthService: HMPPSAuthService,
   val telemetryService: TelemetryService,
-  val draftOasysRiskInformationService: DraftOasysRiskInformationService,
   val referralDetailsRepository: ReferralDetailsRepository,
   val changelogRepository: ChangelogRepository,
 ) {
   companion object {
     private val logger = KotlinLogging.logger {}
-    private const val maxReferenceNumberTries = 10
   }
 
   fun getSentReferralForUser(id: UUID, user: AuthUser): Referral? {
@@ -109,18 +92,6 @@ class ReferralService(
   }
   fun getReferralDetailsById(id: UUID?): ReferralDetails? {
     return referralDetailsRepository.findByIdOrNull(id)
-  }
-
-  fun getDraftReferralForUser(id: UUID, user: AuthUser): DraftReferral? {
-    if (!userTypeChecker.isProbationPractitionerUser(user)) {
-      throw AccessError(user, "unsupported user type", listOf("only probation practitioners can access draft referrals"))
-    }
-
-    val referral = draftReferralRepository.findById(id)
-    referral.ifPresent {
-      referralAccessChecker.forUser(it, user)
-    }
-    return referral.map { it }.orElse(null)
   }
 
   fun assignSentReferral(referral: Referral, assignedBy: AuthUser, assignedTo: AuthUser): Referral {
@@ -241,199 +212,6 @@ class ReferralService(
     return savedReferral
   }
 
-  fun sendDraftReferral(draftReferral: DraftReferral, user: AuthUser): Referral {
-    val referral = createReferral(draftReferral)
-    referral.sentAt = OffsetDateTime.now()
-    referral.sentBy = authUserRepository.save(user)
-
-    referral.referenceNumber = generateReferenceNumber(draftReferral)
-
-    /*
-     * This is a temporary solution until a robust asynchronous link is created between Interventions
-     * and Delius/ARN. Once the asynchronous link is implemented, this feature can be turned off, and instead
-     * Delius/ARN will be notified via the normal asynchronous route
-     *
-     * Order is important: ARN is more likely to fail via a timeout and thus when repeated by the user a
-     * duplicate NSI gets created in Delius as the Delius call is not idempotent. This order avoids creating
-     * duplicate NSIs in nDelius on user retry.
-     */
-    submitAdditionalRiskInformation(referral, user)
-    communityAPIReferralService.send(referral)
-
-    val sentReferral = referralRepository.save(referral)
-    eventPublisher.referralSentEvent(sentReferral)
-    supplierAssessmentService.createSupplierAssessment(referral)
-    return sentReferral
-  }
-
-  private fun createReferral(draftReferral: DraftReferral): Referral {
-    return Referral(
-      id = draftReferral.id,
-      furtherInformation = draftReferral.furtherInformation,
-      additionalNeedsInformation = draftReferral.additionalNeedsInformation,
-      additionalRiskInformation = draftReferral.additionalRiskInformation,
-      additionalRiskInformationUpdatedAt = draftReferral.additionalRiskInformationUpdatedAt,
-      accessibilityNeeds = draftReferral.accessibilityNeeds,
-      needsInterpreter = draftReferral.needsInterpreter,
-      interpreterLanguage = draftReferral.interpreterLanguage,
-      hasAdditionalResponsibilities = draftReferral.hasAdditionalResponsibilities,
-      whenUnavailable = draftReferral.whenUnavailable,
-      maximumEnforceableDays = draftReferral.maximumEnforceableDays,
-      selectedDesiredOutcomes = draftReferral.selectedDesiredOutcomes,
-      completionDeadline = draftReferral.completionDeadline,
-      relevantSentenceId = draftReferral.relevantSentenceId,
-      intervention = draftReferral.intervention,
-      serviceUserCRN = draftReferral.serviceUserCRN,
-      createdBy = draftReferral.createdBy,
-      createdAt = draftReferral.createdAt,
-      referralDetailsHistory = draftReferral.referralDetailsHistory,
-    )
-  }
-
-  private fun submitAdditionalRiskInformation(referral: Referral, user: AuthUser) {
-    // todo: throw exception once posting full risk to ARN feature is enabled, however allow some time for in-flight
-    //  make-referral requests to pass
-
-    val oasysRiskInformation = draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)
-    val riskId = if (oasysRiskInformation != null && assessRisksAndNeedsService.canPostFullRiskInformation()) {
-      assessRisksAndNeedsService.createSupplementaryRisk(
-        referral.id,
-        referral.serviceUserCRN,
-        user,
-        oasysRiskInformation.updatedAt,
-        oasysRiskInformation.additionalInformation ?: "",
-        RedactedRisk(
-          riskWho = oasysRiskInformation.riskSummaryWhoIsAtRisk ?: "",
-          riskWhen = oasysRiskInformation.riskSummaryRiskImminence ?: "",
-          riskNature = oasysRiskInformation.riskSummaryNatureOfRisk ?: "",
-          concernsSelfHarm = oasysRiskInformation.riskToSelfSelfHarm ?: "",
-          concernsSuicide = oasysRiskInformation.riskToSelfSuicide ?: "",
-          concernsHostel = oasysRiskInformation.riskToSelfHostelSetting ?: "",
-          concernsVulnerability = oasysRiskInformation.riskToSelfVulnerability ?: "",
-        )
-      )
-    } else {
-      val additionalRiskInformation = referral.additionalRiskInformation
-        ?: throw ServerWebInputException("can't submit a referral without risk information")
-
-      val riskSubmittedAt = referral.additionalRiskInformationUpdatedAt
-        ?: run {
-          // this should NEVER happen. i'm not really sure why we have this as a fallback.
-          logger.warn("no additionalRiskInformationUpdatedAt on referral; setting to current time")
-          OffsetDateTime.now()
-        }
-
-      assessRisksAndNeedsService.createSupplementaryRisk(
-        referral.id,
-        referral.serviceUserCRN,
-        user,
-        riskSubmittedAt,
-        additionalRiskInformation,
-        null
-      )
-    }
-
-    referral.supplementaryRiskId = riskId
-    // we do not store _any_ risk information in interventions once it has been sent to ARN
-    referral.additionalRiskInformation = null
-    draftOasysRiskInformationService.deleteDraftOasysRiskInformation(referral.id)
-  }
-
-  fun createDraftReferral(
-    user: AuthUser,
-    crn: String,
-    interventionId: UUID,
-    overrideID: UUID? = null,
-    overrideCreatedAt: OffsetDateTime? = null,
-  ): DraftReferral {
-    if (!userTypeChecker.isProbationPractitionerUser(user)) {
-      throw AccessError(user, "user cannot create referral", listOf("only probation practitioners can create draft referrals"))
-    }
-
-    // PPs can't create referrals for service users they are not allowed to see
-    serviceUserAccessChecker.forProbationPractitionerUser(crn, user)
-
-    val intervention = interventionRepository.getById(interventionId)
-    val serviceCategories = intervention.dynamicFrameworkContract.contractType.serviceCategories
-    val selectedServiceCategories = if (serviceCategories.size == 1) serviceCategories.toMutableSet() else null
-
-    return draftReferralRepository.save(
-      DraftReferral(
-        id = overrideID ?: UUID.randomUUID(),
-        createdAt = overrideCreatedAt ?: OffsetDateTime.now(),
-        createdBy = authUserRepository.save(user),
-        serviceUserCRN = crn,
-        intervention = interventionRepository.getById(interventionId),
-        selectedServiceCategories = selectedServiceCategories,
-      )
-    )
-  }
-
-  private fun validateDraftReferralUpdate(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    val errors = mutableListOf<FieldError>()
-
-    update.completionDeadline?.let {
-      if (it.isBefore(LocalDate.now())) {
-        errors.add(FieldError(field = "completionDeadline", error = Code.DATE_MUST_BE_IN_THE_FUTURE))
-      }
-
-      // fixme: error if completion deadline is after sentence end date
-    }
-
-    update.needsInterpreter?.let {
-      if (it && update.interpreterLanguage == null) {
-        errors.add(FieldError(field = "needsInterpreter", error = Code.CONDITIONAL_FIELD_MUST_BE_SET))
-      }
-    }
-
-    update.hasAdditionalResponsibilities?.let {
-      if (it && update.whenUnavailable == null) {
-        errors.add(FieldError(field = "hasAdditionalResponsibilities", error = Code.CONDITIONAL_FIELD_MUST_BE_SET))
-      }
-    }
-
-    update.serviceUser?.let {
-      if (it.crn != draftReferral.serviceUserCRN) {
-        errors.add(FieldError(field = "serviceUser.crn", error = Code.FIELD_CANNOT_BE_CHANGED))
-      }
-    }
-
-    update.serviceCategoryIds?.let {
-      if (!draftReferral.intervention.dynamicFrameworkContract.contractType.serviceCategories.map {
-        serviceCategory ->
-        serviceCategory.id
-      }.containsAll(it)
-      ) {
-        errors.add(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT))
-      }
-    }
-
-    if (errors.isNotEmpty()) {
-      throw ValidationError("draft referral update invalid", errors)
-    }
-  }
-
-  @Deprecated(
-    """
-    currently we are duplicating these fields in both the referral 
-    and referral_details tables. once we solely rely on the latter, 
-    we can remove this method entirely.
-  """
-  )
-  private fun legacyUpdateReferralDetails(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    update.completionDeadline?.let {
-      draftReferral.completionDeadline = it
-    }
-
-    update.furtherInformation?.let {
-      draftReferral.furtherInformation = it
-    }
-
-    update.maximumEnforceableDays?.let {
-      draftReferral.maximumEnforceableDays = it
-    }
-  }
-
   fun updateReferralDetails(referral: Referral, update: UpdateReferralDetailsDTO, actor: AuthUser): ReferralDetails? {
     if (!update.isValidUpdate) {
       return null
@@ -528,223 +306,8 @@ class ReferralService(
     }
   }
 
-  fun updateDraftReferralDetails(referral: DraftReferral, update: UpdateReferralDetailsDTO, actor: AuthUser): ReferralDetails? {
-    if (!update.isValidUpdate) {
-      return null
-    }
-
-    val existingDetails = referralDetailsRepository.findLatestByReferralId(referral.id)
-
-    // if we are updating a draft referral, and there is already a ReferralDetails record,
-    // we update it. otherwise, we create a new one to record the changes.
-    val newDetails = existingDetails
-      ?: ReferralDetails(
-        UUID.randomUUID(),
-        null,
-        referral.id,
-        referral.createdAt,
-        actor.id,
-        update.reasonForChange,
-      )
-
-    update.completionDeadline?.let {
-      newDetails.completionDeadline = it
-    }
-
-    update.furtherInformation?.let {
-      newDetails.furtherInformation = it
-    }
-
-    update.maximumEnforceableDays?.let {
-      newDetails.maximumEnforceableDays = it
-    }
-
-    referralDetailsRepository.saveAndFlush(newDetails)
-
-    return newDetails
-  }
-
-  private fun updateServiceUserNeeds(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    update.additionalNeedsInformation?.let {
-      draftReferral.additionalNeedsInformation = it
-    }
-
-    update.accessibilityNeeds?.let {
-      draftReferral.accessibilityNeeds = it
-    }
-
-    update.needsInterpreter?.let {
-      draftReferral.needsInterpreter = it
-      draftReferral.interpreterLanguage = if (it) update.interpreterLanguage else null
-    }
-
-    update.hasAdditionalResponsibilities?.let {
-      draftReferral.hasAdditionalResponsibilities = it
-      draftReferral.whenUnavailable = if (it) update.whenUnavailable else null
-    }
-  }
-
-  private fun updateDraftRiskInformation(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    update.additionalRiskInformation?.let {
-      draftReferral.additionalRiskInformation = it
-      draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
-    }
-  }
-  private fun updateServiceUserDetails(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    update.serviceUser?.let {
-      draftReferral.serviceUserData = ServiceUserData(
-        title = it.title,
-        firstName = it.firstName,
-        lastName = it.lastName,
-        dateOfBirth = it.dateOfBirth,
-        gender = it.gender,
-        ethnicity = it.ethnicity,
-        draftReferral = draftReferral,
-        preferredLanguage = it.preferredLanguage,
-        religionOrBelief = it.religionOrBelief,
-        disabilities = it.disabilities,
-      )
-    }
-  }
-
-  private fun updateServiceCategoryDetails(referral: DraftReferral, update: DraftReferralDTO) {
-    // The selected complexity levels and desired outcomes need to be removed if the user has unselected service categories that are linked to them
-    update.serviceCategoryIds?.let { serviceCategoryIds ->
-      referral.complexityLevelIds =
-        referral.complexityLevelIds?.filterKeys { serviceCategoryId -> serviceCategoryIds.contains(serviceCategoryId) }
-          ?.toMutableMap()
-      referral.selectedDesiredOutcomes =
-        referral.selectedDesiredOutcomes?.filter { desiredOutcome -> serviceCategoryIds.contains(desiredOutcome.serviceCategoryId) }
-          ?.toMutableList()
-    }
-
-    // Need to save and flush the entity before removing selected service categories due to constraint violations being thrown from selected complexity levels and desired outcomes
-    draftReferralRepository.saveAndFlush(referral)
-
-    update.serviceCategoryIds?.let { serviceCategoryIds ->
-      val updatedServiceCategories = serviceCategoryRepository.findByIdIn(serviceCategoryIds)
-      // the following code looks like a strange way to do this ...
-      // however we have to be very intentional about updating the service categories,
-      // rather than replacing the collection entirely. in the former case, hibernate
-      // runs an update as you would expect. in the latter case, hibernate deletes the
-      // entity entirely and creates a new one. this causes SQL constraint violations
-      // because these service category ids are referenced in the selected complexity
-      // level and desired outcomes tables.
-      referral.selectedServiceCategories?.let {
-        it.removeIf { true }
-        it.addAll(updatedServiceCategories)
-      } ?: run {
-        referral.selectedServiceCategories = updatedServiceCategories.toMutableSet()
-      }
-    }
-  }
-
-  fun updateDraftReferral(referral: DraftReferral, update: DraftReferralDTO): DraftReferral {
-    validateDraftReferralUpdate(referral, update)
-
-    legacyUpdateReferralDetails(referral, update)
-    updateDraftReferralDetails(
-      referral,
-      UpdateReferralDetailsDTO(
-        update.maximumEnforceableDays,
-        update.completionDeadline,
-        update.furtherInformation,
-        "initial referral details",
-      ),
-      referral.createdBy,
-    )
-    updateServiceUserDetails(referral, update)
-    updateServiceUserNeeds(referral, update)
-    updateDraftRiskInformation(referral, update)
-    updateServiceCategoryDetails(referral, update)
-
-    // this field doesn't fit into any other categories - is this a smell?
-    update.relevantSentenceId?.let {
-      referral.relevantSentenceId = it
-    }
-
-    return draftReferralRepository.save(referral)
-  }
-
-  fun updateDraftReferralComplexityLevel(referral: DraftReferral, serviceCategoryId: UUID, complexityLevelId: UUID): DraftReferral {
-    if (referral.selectedServiceCategories.isNullOrEmpty()) {
-      throw ServerWebInputException("complexity level cannot be updated: no service categories selected for this referral")
-    }
-
-    if (!referral.selectedServiceCategories!!.map { it.id }.contains(serviceCategoryId)) {
-      throw ServerWebInputException("complexity level cannot be updated: specified service category not selected for this referral")
-    }
-
-    val validComplexityLevelIds = serviceCategoryRepository.findByIdOrNull(serviceCategoryId)?.complexityLevels?.map { it.id }
-      ?: throw ServerWebInputException("complexity level cannot be updated: specified service category not found")
-
-    if (!validComplexityLevelIds.contains(complexityLevelId)) {
-      throw ServerWebInputException("complexity level cannot be updated: complexity level not valid for this service category")
-    }
-
-    if (referral.complexityLevelIds == null) {
-      referral.complexityLevelIds = mutableMapOf()
-    }
-
-    referral.complexityLevelIds!![serviceCategoryId] = complexityLevelId
-    return draftReferralRepository.save(referral)
-  }
-
-  fun updateDraftReferralDesiredOutcomes(referral: DraftReferral, serviceCategoryId: UUID, desiredOutcomeIds: List<UUID>): DraftReferral {
-    if (desiredOutcomeIds.isEmpty()) {
-      throw ServerWebInputException("desired outcomes cannot be empty")
-    }
-
-    if (referral.selectedServiceCategories.isNullOrEmpty()) {
-      throw ServerWebInputException("desired outcomes cannot be updated: no service categories selected for this referral")
-    }
-
-    if (!referral.selectedServiceCategories!!.map { it.id }.contains(serviceCategoryId)) {
-      throw ServerWebInputException("desired outcomes cannot be updated: specified service category not selected for this referral")
-    }
-
-    val validDesiredOutcomeIds = serviceCategoryRepository.findByIdOrNull(serviceCategoryId)?.desiredOutcomes?.map { it.id }
-      ?: throw ServerWebInputException("desired outcomes cannot be updated: specified service category not found")
-
-    if (!validDesiredOutcomeIds.containsAll(desiredOutcomeIds)) {
-      throw ServerWebInputException("desired outcomes cannot be updated: at least one desired outcome is not valid for this service category")
-    }
-
-    if (referral.selectedDesiredOutcomes == null) {
-      referral.selectedDesiredOutcomes = mutableListOf()
-    }
-
-    referral.selectedDesiredOutcomes!!.removeIf { desiredOutcome -> desiredOutcome.serviceCategoryId == serviceCategoryId }
-    desiredOutcomeIds.forEach { desiredOutcomeId -> referral.selectedDesiredOutcomes!!.add(SelectedDesiredOutcomesMapping(serviceCategoryId, desiredOutcomeId)) }
-    return draftReferralRepository.save(referral)
-  }
-
-  fun getDraftReferralsForUser(user: AuthUser): List<DraftReferral> {
-    if (!userTypeChecker.isProbationPractitionerUser(user)) {
-      throw AccessError(user, "user does not have access to referrals", listOf("only probation practitioners can access draft referrals"))
-    }
-
-    val referrals = draftReferralRepository.findByCreatedById(user.id)
-    return referralAccessFilter.probationPractitionerReferrals(referrals, user)
-  }
-
   fun getCancellationReasons(): List<CancellationReason> {
     return cancellationReasonRepository.findAll()
-  }
-
-  private fun generateReferenceNumber(draftReferral: DraftReferral): String? {
-    val type = draftReferral.intervention.dynamicFrameworkContract.contractType.name
-
-    for (i in 1..maxReferenceNumberTries) {
-      val candidate = referenceGenerator.generate(type)
-      if (!referralRepository.existsByReferenceNumber(candidate))
-        return candidate
-      else
-        logger.warn("Clash found for referral number {}", kv("candidate", candidate))
-    }
-
-    logger.error("Unable to generate a referral number {} {}", kv("tries", maxReferenceNumberTries), kv("referral_id", draftReferral.id))
-    return null
   }
 
   fun getResponsibleProbationPractitioner(referral: Referral): ResponsibleProbationPractitioner {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -1,0 +1,484 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceProviderAccessScopeMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceUserAccessChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ContractTypeFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.RepositoryTest
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.random.Random
+
+@RepositoryTest
+class DraftReferralServiceTest @Autowired constructor(
+  val entityManager: TestEntityManager,
+  val referralRepository: ReferralRepository,
+  val draftReferralRepository: DraftReferralRepository,
+  val authUserRepository: AuthUserRepository,
+  val interventionRepository: InterventionRepository,
+  val deliverySessionRepository: DeliverySessionRepository,
+  val actionPlanRepository: ActionPlanRepository,
+  val endOfServiceReportRepository: EndOfServiceReportRepository,
+  val serviceCategoryRepository: ServiceCategoryRepository,
+  val referralDetailsRepository: ReferralDetailsRepository,
+) {
+  private val userFactory = AuthUserFactory(entityManager)
+  private val interventionFactory = InterventionFactory(entityManager)
+  private val referralFactory = ReferralFactory(entityManager)
+  private val serviceCategoryFactory = ServiceCategoryFactory(entityManager)
+  private val contractTypeFactory = ContractTypeFactory(entityManager)
+  private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory(entityManager)
+
+  private val referralEventPublisher: ReferralEventPublisher = mock()
+  private val referenceGenerator: ReferralReferenceGenerator = spy(ReferralReferenceGenerator())
+  private val referralAccessChecker: ReferralAccessChecker = mock()
+  private val userTypeChecker = UserTypeChecker()
+  private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper = mock()
+  private val referralAccessFilter = ReferralAccessFilter(serviceProviderAccessScopeMapper)
+  private val communityAPIReferralService: CommunityAPIReferralService = mock()
+  private val serviceUserAccessChecker: ServiceUserAccessChecker = mock()
+  private val assessRisksAndNeedsService: RisksAndNeedsService = mock()
+  private val supplierAssessmentService: SupplierAssessmentService = mock()
+  private val hmppsAuthService: HMPPSAuthService = mock()
+  private val draftOasysRiskInformationService: DraftOasysRiskInformationService = mock()
+
+  private val draftReferralService = DraftReferralService(
+    referralRepository,
+    draftReferralRepository,
+    referralAccessFilter,
+    referralAccessChecker,
+    serviceUserAccessChecker,
+    authUserRepository,
+    interventionRepository,
+    referralEventPublisher,
+    referenceGenerator,
+    deliverySessionRepository,
+    serviceCategoryRepository,
+    userTypeChecker,
+    communityAPIReferralService,
+    assessRisksAndNeedsService,
+    supplierAssessmentService,
+    hmppsAuthService,
+    referralDetailsRepository,
+    draftOasysRiskInformationService
+  )
+
+  @AfterEach
+  fun `clear referrals`() {
+    entityManager.flush()
+    interventionRepository.deleteAll()
+    referralDetailsRepository.deleteAll()
+    authUserRepository.deleteAll()
+    draftReferralRepository.deleteAll()
+    referralRepository.deleteAll()
+  }
+
+  @Nested
+  @DisplayName("create / find / update / send draft referrals")
+  inner class CreateFindUpdateAndSendDraftReferrals {
+    private lateinit var sampleDraftReferral: DraftReferral
+    private lateinit var sampleIntervention: Intervention
+    private lateinit var sampleCohortIntervention: Intervention
+
+    @BeforeEach
+    fun beforeEach() {
+      sampleDraftReferral = SampleData.persistReferral(
+        entityManager,
+        SampleData.sampleDraftReferral("X123456", "Harmony Living")
+      )
+      sampleIntervention = sampleDraftReferral.intervention
+
+      sampleCohortIntervention = SampleData.persistIntervention(
+        entityManager,
+        SampleData.sampleIntervention(
+          dynamicFrameworkContract = SampleData.sampleContract(
+            primeProvider = sampleDraftReferral.intervention.dynamicFrameworkContract.primeProvider,
+            contractType = SampleData.sampleContractType(
+              name = "Personal Wellbeing",
+              code = "PWB",
+              serviceCategories = mutableSetOf(
+                SampleData.sampleServiceCategory(),
+                SampleData.sampleServiceCategory(name = "Social inclusion")
+              )
+            )
+          )
+        )
+      )
+    }
+
+    @Test
+    fun `update cannot overwrite identifier fields`() {
+      val draftReferral = DraftReferralDTO(
+        id = UUID.fromString("ce364949-7301-497b-894d-130f34a98bff"),
+        createdAt = OffsetDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.MIN, ZoneOffset.UTC)
+      )
+
+      val updated = draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
+      assertThat(updated.id).isEqualTo(sampleDraftReferral.id)
+      assertThat(updated.createdAt).isEqualTo(sampleDraftReferral.createdAt)
+    }
+
+    @Test
+    fun `null fields in the update do not overwrite original fields`() {
+      val sentenceId = Random.nextLong()
+      sampleDraftReferral.relevantSentenceId = sentenceId
+      entityManager.persistAndFlush(sampleDraftReferral)
+
+      val draftReferral = DraftReferralDTO(relevantSentenceId = null)
+
+      val updated = draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
+      assertThat(updated.relevantSentenceId).isEqualTo(sentenceId)
+    }
+
+    @Test
+    fun `non-null fields in the update overwrite original fields`() {
+      val existingSentenceId = Random.nextLong()
+      val newSentenceId = Random.nextLong()
+      sampleDraftReferral.relevantSentenceId = existingSentenceId
+      entityManager.persistAndFlush(sampleDraftReferral)
+
+      val draftReferral = DraftReferralDTO(relevantSentenceId = newSentenceId)
+
+      val updated = draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
+      assertThat(updated.relevantSentenceId).isEqualTo(newSentenceId)
+    }
+
+    @Test
+    fun `update mutates the original object`() {
+      val existingSentenceId = Random.nextLong()
+      val newSentenceId = Random.nextLong()
+      sampleDraftReferral.relevantSentenceId = existingSentenceId
+      entityManager.persistAndFlush(sampleDraftReferral)
+
+      val today = LocalDate.now()
+      val draftReferral = DraftReferralDTO(relevantSentenceId = newSentenceId)
+
+      val updated = draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
+      assertThat(updated.relevantSentenceId).isEqualTo(newSentenceId)
+    }
+
+    @Test
+    fun `update successfully persists the updated draft referral`() {
+      val existingSentenceId = Random.nextLong()
+      val newSentenceId = Random.nextLong()
+      sampleDraftReferral.relevantSentenceId = existingSentenceId
+      entityManager.persistAndFlush(sampleDraftReferral)
+
+      val draftReferral = DraftReferralDTO(relevantSentenceId = newSentenceId)
+      draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
+      val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
+      assertThat(savedDraftReferral).isNotNull
+      assertThat(savedDraftReferral?.id).isEqualTo(sampleDraftReferral.id)
+      assertThat(savedDraftReferral?.createdAt).isEqualTo(sampleDraftReferral.createdAt)
+      assertThat(savedDraftReferral?.relevantSentenceId).isEqualTo(draftReferral.relevantSentenceId)
+    }
+
+    @Test
+    fun `create and persist non-cohort draft referral`() {
+      val authUser = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = draftReferralService.createDraftReferral(authUser, "X123456", sampleIntervention.id)
+      entityManager.flush()
+
+      val savedDraftReferral = draftReferralService.getDraftReferralForUser(draftReferral.id, authUser)
+      assertThat(savedDraftReferral?.id).isNotNull
+      assertThat(savedDraftReferral?.createdAt).isNotNull
+      assertThat(savedDraftReferral?.createdBy).isEqualTo(authUser)
+      assertThat(savedDraftReferral?.serviceUserCRN).isEqualTo("X123456")
+      assertThat(savedDraftReferral?.selectedServiceCategories).hasSize(1)
+      assertThat(savedDraftReferral?.selectedServiceCategories!!.elementAt(0).id).isEqualTo(
+        sampleIntervention.dynamicFrameworkContract.contractType.serviceCategories.elementAt(
+          0
+        ).id
+      )
+    }
+
+    @Test
+    fun `create and persist cohort draft referral`() {
+      val authUser = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = draftReferralService.createDraftReferral(authUser, "X123456", sampleCohortIntervention.id)
+      entityManager.flush()
+
+      val savedDraftReferral = draftReferralService.getDraftReferralForUser(draftReferral.id, authUser)
+      assertThat(savedDraftReferral).isNotNull
+      assertThat(savedDraftReferral?.id).isNotNull
+      assertThat(savedDraftReferral?.createdAt).isNotNull
+      assertThat(savedDraftReferral?.createdBy).isEqualTo(authUser)
+      assertThat(savedDraftReferral?.serviceUserCRN).isEqualTo("X123456")
+      assertThat(savedDraftReferral?.selectedServiceCategories).isNull()
+    }
+
+    @Test
+    fun `get a draft referral`() {
+      val sentenceId = Random.nextLong()
+      sampleDraftReferral.relevantSentenceId = sentenceId
+      entityManager.persistAndFlush(sampleDraftReferral)
+
+      val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
+      assertThat(savedDraftReferral?.id).isEqualTo(sampleDraftReferral.id)
+      assertThat(savedDraftReferral?.createdAt).isEqualTo(sampleDraftReferral.createdAt)
+      assertThat(savedDraftReferral?.relevantSentenceId).isEqualTo(sampleDraftReferral.relevantSentenceId)
+    }
+
+    @Test
+    fun `find by userID returns list of draft referrals`() {
+      val user1 = AuthUser("123", "delius", "bernie.b")
+      val user2 = AuthUser("456", "delius", "sheila.h")
+      val user3 = AuthUser("789", "delius", "tom.myers")
+      draftReferralService.createDraftReferral(user1, "X123456", sampleIntervention.id)
+      draftReferralService.createDraftReferral(user1, "X123456", sampleIntervention.id)
+      draftReferralService.createDraftReferral(user2, "X123456", sampleIntervention.id)
+      entityManager.flush()
+
+      val single = draftReferralService.getDraftReferralsForUser(user2)
+      assertThat(single).hasSize(1)
+
+      val multiple = draftReferralService.getDraftReferralsForUser(user1)
+      assertThat(multiple).hasSize(2)
+
+      val none = draftReferralService.getDraftReferralsForUser(user3)
+      assertThat(none).hasSize(0)
+    }
+
+    @Test
+    fun `completion date must be in the future`() {
+      val update = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 1, 1))
+      val error = assertThrows<ValidationError> {
+        draftReferralService.updateDraftReferral(sampleDraftReferral, update)
+      }
+      assertThat(error.errors.size).isEqualTo(1)
+      assertThat(error.errors[0].field).isEqualTo("completionDeadline")
+    }
+
+    @Test
+    fun `when needsInterpreter is true, interpreterLanguage must be set`() {
+      // this is fine
+      draftReferralService.updateDraftReferral(sampleDraftReferral, DraftReferralDTO(needsInterpreter = false))
+
+      val error = assertThrows<ValidationError> {
+        // this throws ValidationError
+        draftReferralService.updateDraftReferral(sampleDraftReferral, DraftReferralDTO(needsInterpreter = true))
+      }
+      assertThat(error.errors.size).isEqualTo(1)
+      assertThat(error.errors[0].field).isEqualTo("needsInterpreter")
+
+      // this is also fine
+      draftReferralService.updateDraftReferral(
+        sampleDraftReferral,
+        DraftReferralDTO(needsInterpreter = true, interpreterLanguage = "German")
+      )
+    }
+
+    @Test
+    fun `when hasAdditionalResponsibilities is true, whenUnavailable must be set`() {
+      // this is fine
+      draftReferralService.updateDraftReferral(sampleDraftReferral, DraftReferralDTO(hasAdditionalResponsibilities = false))
+
+      val error = assertThrows<ValidationError> {
+        // this throws ValidationError
+        draftReferralService.updateDraftReferral(sampleDraftReferral, DraftReferralDTO(hasAdditionalResponsibilities = true))
+      }
+      assertThat(error.errors.size).isEqualTo(1)
+      assertThat(error.errors[0].field).isEqualTo("hasAdditionalResponsibilities")
+
+      // this is also fine
+      draftReferralService.updateDraftReferral(
+        sampleDraftReferral,
+        DraftReferralDTO(hasAdditionalResponsibilities = true, whenUnavailable = "wednesdays")
+      )
+    }
+
+    @Test
+    fun `multiple errors at once`() {
+      val update = DraftReferralDTO(completionDeadline = LocalDate.of(2020, 1, 1), needsInterpreter = true)
+      val error = assertThrows<ValidationError> {
+        draftReferralService.updateDraftReferral(sampleDraftReferral, update)
+      }
+      assertThat(error.errors.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `the referral isn't actually updated if any of the fields contain validation errors`() {
+      // any invalid fields should mean that no fields are written to the db
+      val update = DraftReferralDTO(
+        // valid field
+        additionalNeedsInformation = "requires wheelchair access",
+        // invalid field
+        completionDeadline = LocalDate.of(2020, 1, 1),
+      )
+      assertThrows<ValidationError> {
+        draftReferralService.updateDraftReferral(sampleDraftReferral, update)
+      }
+
+      entityManager.flush()
+      val draftReferral = draftReferralService.getDraftReferralForUser(
+        sampleDraftReferral.id,
+        userFactory.create()
+      )
+      assertThat(draftReferral?.additionalNeedsInformation).isNull()
+    }
+
+    @Test
+    fun `once a draft referral is sent to referral it's id is still valid in draft referral`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+
+      assertThat(draftReferralService.getDraftReferralForUser(draftReferral.id, user)).isNotNull
+
+      draftReferralService.sendDraftReferral(draftReferral, user)
+
+      assertThat(draftReferralService.getDraftReferralForUser(draftReferral.id, user)).isNotNull
+    }
+
+    @Test
+    fun `sending a draft referral generates a referral reference number`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+
+      val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
+      assertThat(sentReferral.referenceNumber).isNotNull
+    }
+
+    @Test
+    fun `sending a draft referral generates a unique reference, even if the previous reference already exists`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draft1 = draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      val draft2 = draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draft1.additionalRiskInformation = "risk"
+      draft2.additionalRiskInformation = "risk"
+
+      whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.name))
+        .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
+
+      val sent1 = draftReferralService.sendDraftReferral(draft1, user)
+      assertThat(sent1.referenceNumber).isEqualTo("AA0000ZZ")
+
+      val sent2 = draftReferralService.sendDraftReferral(draft2, user)
+      assertThat(sent2.referenceNumber).isNotEqualTo("AA0000ZZ").isEqualTo("BB0000ZZ")
+    }
+
+    @Test
+    fun `sending a draft referral triggers an event`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+
+      val referral = draftReferralService.sendDraftReferral(draftReferral, user)
+      val eventCaptor = argumentCaptor<Referral>()
+      verify(communityAPIReferralService).send(eventCaptor.capture())
+      val capturedReferral = eventCaptor.firstValue
+      assertThat(capturedReferral.id).isEqualTo(referral.id)
+      verify(referralEventPublisher).referralSentEvent(referral)
+    }
+
+    @Test
+    fun `multiple draft referrals can be started by the same user`() {
+      val user = AuthUser("multi_user_id", "delius", "user_name")
+
+      for (i in 1..3) {
+        assertDoesNotThrow { draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id) }
+      }
+      assertThat(draftReferralService.getDraftReferralsForUser(user)).hasSize(3)
+    }
+  }
+
+  @Test
+  fun `ensure that desired outcomes are actually removed via orphan removal`() {
+    val serviceCategoryId1 = UUID.randomUUID()
+    val serviceCategoryId2 = UUID.randomUUID()
+    val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+    val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId2)
+    val serviceCategory1 =
+      serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = mutableListOf(desiredOutcome1))
+    val serviceCategory2 =
+      serviceCategoryFactory.create(id = serviceCategoryId2, desiredOutcomes = mutableListOf(desiredOutcome2))
+
+    val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1, serviceCategory2))
+    val referral = referralFactory.createDraft(
+      intervention = interventionFactory.create(
+        contract = dynamicFrameworkContractFactory.create(
+          contractType = contractType
+        )
+      ),
+      selectedServiceCategories = setOf(serviceCategory1).toMutableSet(),
+      desiredOutcomes = listOf(desiredOutcome1).toMutableList()
+    )
+    draftReferralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategoryId2)))
+
+    draftReferralRepository.flush()
+    val updatedReferral = draftReferralRepository.findById(referral.id).get()
+    assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
+    assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId2)
+    assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(0)
+  }
+
+  @Test
+  fun `ensure that service categories constraint is not thrown when service categories is reselected with an already selected desired outcome`() {
+    val serviceCategoryId = UUID.randomUUID()
+    val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+    val serviceCategory =
+      serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = mutableListOf(desiredOutcome))
+
+    val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory))
+    val referral = referralFactory.createDraft(
+      intervention = interventionFactory.create(
+        contract = dynamicFrameworkContractFactory.create(
+          contractType = contractType
+        )
+      ),
+      selectedServiceCategories = setOf(serviceCategory).toMutableSet(),
+      desiredOutcomes = listOf(desiredOutcome).toMutableList(),
+    )
+    draftReferralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategoryId)))
+
+    draftReferralRepository.flush()
+    val updatedReferral = draftReferralRepository.findById(referral.id).get()
+    assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
+    assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId)
+    assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(1)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
@@ -1,0 +1,845 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.web.server.ServerWebInputException
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceUserAccessChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ComplexityLevel
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ContractTypeFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DraftOasysRiskInformationFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Optional
+import java.util.UUID
+
+class DraftReferralServiceUnitTest {
+  private val authUserRepository: AuthUserRepository = mock()
+  private val referralRepository: ReferralRepository = mock()
+  private val draftReferralRepository: DraftReferralRepository = mock()
+  private val interventionRepository: InterventionRepository = mock()
+  private val referralEventPublisher: ReferralEventPublisher = mock()
+  private val referralReferenceGenerator: ReferralReferenceGenerator = mock()
+  private val deliverySessionRepository: DeliverySessionRepository = mock()
+  private val serviceCategoryRepository: ServiceCategoryRepository = mock()
+  private val referralAccessFilter: ReferralAccessFilter = mock()
+  private val referralAccessChecker: ReferralAccessChecker = mock()
+  private val communityAPIReferralService: CommunityAPIReferralService = mock()
+  private val userTypeChecker: UserTypeChecker = mock()
+  private val serviceUserAccessChecker: ServiceUserAccessChecker = mock()
+  private val assessRisksAndNeedsService: RisksAndNeedsService = mock()
+  private val supplierAssessmentService: SupplierAssessmentService = mock()
+  private val hmppsAuthService: HMPPSAuthService = mock()
+  private val draftOasysRiskInformationService: DraftOasysRiskInformationService = mock()
+  private val referralDetailsRepository: ReferralDetailsRepository = mock()
+
+  private val referralFactory = ReferralFactory()
+  private val authUserFactory = AuthUserFactory()
+  private val serviceCategoryFactory = ServiceCategoryFactory()
+  private val contractTypeFactory = ContractTypeFactory()
+  private val interventionFactory = InterventionFactory()
+  private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
+  private val draftOasysRiskInformationFactory = DraftOasysRiskInformationFactory()
+
+  private val draftReferralService = DraftReferralService(
+    referralRepository,
+    draftReferralRepository,
+    referralAccessFilter,
+    referralAccessChecker,
+    serviceUserAccessChecker,
+    authUserRepository,
+    interventionRepository,
+    referralEventPublisher,
+    referralReferenceGenerator,
+    deliverySessionRepository,
+    serviceCategoryRepository,
+    userTypeChecker,
+    communityAPIReferralService,
+    assessRisksAndNeedsService,
+    supplierAssessmentService,
+    hmppsAuthService,
+    referralDetailsRepository,
+    draftOasysRiskInformationService
+  )
+
+  @Nested
+  inner class UpdateDraftReferralComplexityLevel {
+    @Test
+    fun `cant set complexity level when no service categories have been selected`() {
+      val referral = referralFactory.createDraft()
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralComplexityLevel(
+          referral,
+          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
+          UUID.randomUUID()
+        )
+      }
+
+      assertThat(e.message.equals("complexity level cannot be updated: no service categories selected for this referral"))
+    }
+
+    @Test
+    fun `cant set complexity level for an invalid service category`() {
+      val serviceCategory1 = serviceCategoryFactory.create()
+      val serviceCategory2 = serviceCategoryFactory.create()
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory1))
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralComplexityLevel(
+          referral,
+          serviceCategory2.id,
+          UUID.randomUUID()
+        )
+      }
+
+      assertThat(e.message.equals("complexity level cannot be updated: specified service category not selected for this referral"))
+    }
+
+    @Test
+    fun `cant set complexity level when service category is not found`() {
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.empty())
+      val serviceCategory = serviceCategoryFactory.create()
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralComplexityLevel(
+          referral,
+          serviceCategory.id,
+          UUID.randomUUID()
+        )
+      }
+
+      assertThat(e.message.equals("complexity level cannot be updated: specified service category not found"))
+    }
+
+    @Test
+    fun `cant set complexity level when its invalid for the service category`() {
+      val complexityLevel = ComplexityLevel(UUID.randomUUID(), "title", "description")
+      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel))
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralComplexityLevel(
+          referral,
+          serviceCategory.id,
+          UUID.randomUUID()
+        )
+      }
+
+      assertThat(e.message.equals("complexity level cannot be updated: complexity level not valid for this service category"))
+    }
+
+    @Test
+    fun `can set complexity level for the first time`() {
+      val complexityLevel = ComplexityLevel(UUID.randomUUID(), "title", "description")
+      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel))
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
+
+      assertThat(referral.complexityLevelIds).isNull()
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
+
+      val updatedReferral = draftReferralService.updateDraftReferralComplexityLevel(
+        referral,
+        serviceCategory.id,
+        complexityLevel.id,
+      )
+
+      assertThat(updatedReferral.complexityLevelIds!!.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `can update an already selected complexity level`() {
+      val complexityLevel1 = ComplexityLevel(UUID.randomUUID(), "1", "description")
+      val complexityLevel2 = ComplexityLevel(UUID.randomUUID(), "2", "description")
+      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1, complexityLevel2))
+      val referral = referralFactory.createDraft(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        complexityLevelIds = mutableMapOf(serviceCategory.id to complexityLevel1.id)
+      )
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
+
+      val updatedReferral = draftReferralService.updateDraftReferralComplexityLevel(
+        referral,
+        serviceCategory.id,
+        complexityLevel2.id,
+      )
+
+      assertThat(updatedReferral.complexityLevelIds!![serviceCategory.id]).isEqualTo(complexityLevel2.id)
+    }
+  }
+
+  @Nested
+  inner class UpdateServiceCategories {
+
+    private val serviceCategoryIds = listOf(
+      UUID.fromString("8221a81c-08b2-4262-9c1a-0ab3c82cec8c"),
+      UUID.fromString("9556a399-3529-4993-8030-41db2090555e"),
+      UUID.fromString("b84f4eb7-4db0-477e-8c59-21027b3262c5"),
+      UUID.fromString("c036826e-f077-49a5-8b33-601dca7ad479")
+    )
+
+    @Test
+    fun `successfully update service categories`() {
+      val serviceCategories = setOf(
+        serviceCategoryFactory.create(id = UUID.fromString("8221a81c-08b2-4262-9c1a-0ab3c82cec8c"), name = "aaa"),
+        serviceCategoryFactory.create(id = UUID.fromString("9556a399-3529-4993-8030-41db2090555e"), name = "bbb"),
+        serviceCategoryFactory.create(id = UUID.fromString("b84f4eb7-4db0-477e-8c59-21027b3262c5"), name = "ccc"),
+        serviceCategoryFactory.create(id = UUID.fromString("c036826e-f077-49a5-8b33-601dca7ad479"), name = "ddd")
+      )
+
+      val contractType = contractTypeFactory.create(serviceCategories = serviceCategories.toSet())
+      val referral = referralFactory.createDraft(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            contractType = contractType
+          )
+        )
+      )
+
+      val update = DraftReferralDTO(serviceCategoryIds = serviceCategoryIds)
+      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+      whenever(draftReferralRepository.save(any())).thenReturn(referral)
+
+      draftReferralService.updateDraftReferral(referral, update)
+
+      val argument: ArgumentCaptor<DraftReferral> = ArgumentCaptor.forClass(DraftReferral::class.java)
+      verify(draftReferralRepository).save(argument.capture())
+      val savedActionPlan = argument.value
+      assertThat(savedActionPlan.selectedServiceCategories == serviceCategories)
+    }
+
+    @Test
+    fun `updating selected service category with new set removes desired outcome for existing service categories`() {
+
+      val serviceCategoryId1 = UUID.randomUUID()
+      val serviceCategoryId2 = UUID.randomUUID()
+      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId2)
+      val serviceCategory1 = serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome1))
+      val serviceCategory2 = serviceCategoryFactory.create(id = serviceCategoryId2, desiredOutcomes = listOf(desiredOutcome2))
+
+      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1, serviceCategory2))
+      val referral = referralFactory.createDraft(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            contractType = contractType
+          )
+        ),
+        selectedServiceCategories = mutableSetOf(serviceCategory1),
+        desiredOutcomes = listOf(desiredOutcome1)
+      )
+
+      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory2))
+      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+      whenever(draftReferralRepository.save(any())).thenReturn(referral)
+      val updatedReferral = draftReferralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategoryId2)))
+
+      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
+      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId2)
+      assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(0)
+    }
+
+    @Test
+    fun `updating selected service category with same set doesn't remove desired outcome for same service categories`() {
+
+      val serviceCategoryId1 = UUID.randomUUID()
+      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val serviceCategory1 = serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome1))
+
+      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1))
+      val referral = referralFactory.createDraft(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            contractType = contractType
+          )
+        ),
+        selectedServiceCategories = mutableSetOf(serviceCategory1),
+        desiredOutcomes = listOf(desiredOutcome1)
+      )
+
+      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory1))
+      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+      whenever(draftReferralRepository.save(any())).thenReturn(referral)
+
+      val updatedReferral = draftReferralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategoryId1)))
+
+      verify(draftReferralRepository).save(any())
+      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
+      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId1)
+      assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(1)
+      assertThat(updatedReferral.selectedDesiredOutcomes!!.elementAt(0).serviceCategoryId).isEqualTo(serviceCategoryId1)
+      assertThat(updatedReferral.selectedDesiredOutcomes!!.elementAt(0).desiredOutcomeId).isEqualTo(desiredOutcome1.id)
+    }
+
+    @Test
+    fun `updating selected service category with new set removes complexity level for existing service categories`() {
+
+      val complexityLevel1 = ComplexityLevel(UUID.randomUUID(), "title", "description")
+      val complexityLevel2 = ComplexityLevel(UUID.randomUUID(), "title", "description")
+      val serviceCategory1 = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1))
+      val serviceCategory2 = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel2))
+
+      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1, serviceCategory2))
+      val referral = referralFactory.createDraft(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            contractType = contractType
+          )
+        ),
+        selectedServiceCategories = mutableSetOf(serviceCategory1),
+        complexityLevelIds = mapOf(serviceCategory1.id to complexityLevel1.id).toMutableMap()
+      )
+
+      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory2))
+      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+      whenever(draftReferralRepository.save(any())).thenReturn(referral)
+      val updatedReferral = draftReferralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategory2.id)))
+
+      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
+      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategory2.id)
+      assertThat(updatedReferral.complexityLevelIds).hasSize(0)
+    }
+
+    @Test
+    fun `updating selected service category with same set doesn't remove complexity level for same service categories`() {
+
+      val complexityLevel1 = ComplexityLevel(UUID.randomUUID(), "title", "description")
+      val serviceCategory1 = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1))
+
+      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1))
+      val referral = referralFactory.createDraft(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            contractType = contractType
+          )
+        ),
+        selectedServiceCategories = mutableSetOf(serviceCategory1),
+        complexityLevelIds = mapOf(serviceCategory1.id to complexityLevel1.id).toMutableMap()
+      )
+
+      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory1))
+      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+      whenever(draftReferralRepository.save(any())).thenReturn(referral)
+      val updatedReferral = draftReferralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategory1.id)))
+
+      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
+      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategory1.id)
+      assertThat(updatedReferral.complexityLevelIds).hasSize(1)
+      assertThat(updatedReferral.complexityLevelIds!![serviceCategory1.id]).isEqualTo(complexityLevel1.id)
+    }
+
+    @Test
+    fun `fail to update referral with service category not part of contract type`() {
+      val serviceCategories = setOf(
+        serviceCategoryFactory.create(id = UUID.fromString("8221a81c-08b2-4262-9c1a-0ab3c82cec8c"), name = "aaa"),
+        serviceCategoryFactory.create(id = UUID.fromString("9556a399-3529-4993-8030-41db2090555e"), name = "bbb"),
+        serviceCategoryFactory.create(id = UUID.fromString("b84f4eb7-4db0-477e-8c59-21027b3262c5"), name = "ccc")
+      )
+
+      val contractType = contractTypeFactory.create(serviceCategories = serviceCategories)
+      val referral = referralFactory.createDraft(
+        intervention = interventionFactory.create(
+          contract = dynamicFrameworkContractFactory.create(
+            contractType = contractType
+          )
+        )
+      )
+
+      val update = DraftReferralDTO(serviceCategoryIds = serviceCategoryIds)
+      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+      whenever(draftReferralRepository.save(any())).thenReturn(referral)
+
+      val exception = Assertions.assertThrows(ValidationError::class.java) {
+        draftReferralService.updateDraftReferral(referral, update)
+      }
+      assertThat(exception.message).isEqualTo("draft referral update invalid")
+      assertThat(exception.errors[0]).isEqualTo(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT))
+    }
+  }
+
+  @Nested
+  inner class UpdateDraftReferralDesiredOutcomes {
+    @Test
+    fun `cant set desired outcomes to an empty list`() {
+      val referral = referralFactory.createDraft()
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralDesiredOutcomes(
+          referral,
+          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
+          listOf()
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be empty"))
+    }
+
+    @Test
+    fun `cant set desired outcomes when no service categories have been selected`() {
+      val referral = referralFactory.createDraft()
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralDesiredOutcomes(
+          referral,
+          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
+          listOf(UUID.randomUUID())
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be updated: no service categories selected for this referral"))
+    }
+
+    @Test
+    fun `cant set desired outcomes for an invalid service category`() {
+      val serviceCategory1 = serviceCategoryFactory.create()
+      val serviceCategory2 = serviceCategoryFactory.create()
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory1))
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralDesiredOutcomes(
+          referral,
+          serviceCategory2.id,
+          listOf(UUID.randomUUID())
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be updated: specified service category not selected for this referral"))
+    }
+
+    @Test
+    fun `cant set desired outcome when service category is not found`() {
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.empty())
+      val serviceCategory = serviceCategoryFactory.create()
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralDesiredOutcomes(
+          referral,
+          serviceCategory.id,
+          listOf(UUID.randomUUID())
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be updated: specified service category not found"))
+    }
+
+    @Test
+    fun `cant set desired outcomes when its invalid for the service category`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val serviceCategory =
+        serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = listOf(desiredOutcome))
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+
+      val e = assertThrows<ServerWebInputException> {
+        draftReferralService.updateDraftReferralDesiredOutcomes(
+          referral,
+          serviceCategory.id,
+          listOf(UUID.randomUUID())
+        )
+      }
+
+      assertThat(e.message.equals("desired outcomes cannot be updated: at least one desired outcome is not valid for this service category"))
+    }
+
+    @Test
+    fun `can set desired outcomes for the first time`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val serviceCategory =
+        serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = listOf(desiredOutcome))
+      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
+
+      assertThat(referral.selectedDesiredOutcomes).isEmpty()
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
+
+      val updatedReferral = draftReferralService.updateDraftReferralDesiredOutcomes(
+        referral,
+        serviceCategory.id,
+        listOf(desiredOutcome.id),
+      )
+
+      assertThat(updatedReferral.selectedDesiredOutcomes!!.size).isEqualTo(1)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome.id)
+    }
+
+    @Test
+    fun `can update an already selected desired outcome for service category`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
+      val serviceCategory = serviceCategoryFactory.create(
+        id = serviceCategoryId,
+        desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2)
+      )
+      val referral = referralFactory.createDraft(
+        selectedServiceCategories = mutableSetOf(serviceCategory),
+        desiredOutcomes = mutableListOf(desiredOutcome1)
+      )
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
+      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
+
+      val updatedReferral = draftReferralService.updateDraftReferralDesiredOutcomes(
+        referral,
+        serviceCategory.id,
+        listOf(desiredOutcome2.id),
+      )
+
+      assertThat(updatedReferral.selectedDesiredOutcomes!!.size).isEqualTo(1)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome2.id)
+    }
+
+    @Test
+    fun `can update an different selected desired outcome for a different service category`() {
+      val serviceCategoryId1 = UUID.randomUUID()
+      val serviceCategoryId2 = UUID.randomUUID()
+      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
+      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId2)
+      val serviceCategory1 =
+        serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome2))
+      val serviceCategory2 = serviceCategoryFactory.create(
+        id = serviceCategoryId2,
+        desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2)
+      )
+      val referral = referralFactory.createDraft(
+        selectedServiceCategories = mutableSetOf(serviceCategory1, serviceCategory2),
+        desiredOutcomes = mutableListOf(desiredOutcome1)
+      )
+
+      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory2))
+      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
+
+      val updatedReferral = draftReferralService.updateDraftReferralDesiredOutcomes(
+        referral,
+        serviceCategory2.id,
+        listOf(desiredOutcome2.id),
+      )
+
+      assertThat(updatedReferral.selectedDesiredOutcomes!!.size).isEqualTo(2)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory1.id)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome1.id)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![1].serviceCategoryId).isEqualTo(serviceCategory2.id)
+      assertThat(updatedReferral.selectedDesiredOutcomes!![1].desiredOutcomeId).isEqualTo(desiredOutcome2.id)
+    }
+  }
+
+  @Test
+  fun `cant send draft referral without risk information`() {
+    val referral = referralFactory.createDraft()
+    val authUser = authUserFactory.create()
+
+    val e = assertThrows<ServerWebInputException> {
+      draftReferralService.sendDraftReferral(referral, authUser)
+    }
+
+    assertThat(e.message).contains("can't submit a referral without risk information")
+  }
+
+  @Test
+  fun`draft referral risk information is deleted when referral is sent`() {
+    val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
+    val authUser = authUserFactory.create()
+
+    val referral = referralFactory.createSent(id = draftReferral.id)
+
+    whenever(referralRepository.save(any())).thenReturn(referral)
+
+    val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
+    assertThat(sentReferral.additionalRiskInformation).isNull()
+  }
+
+  @Test
+  fun `supplementaryRiskId is set when referral is sent`() {
+    val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
+    val authUser = authUserFactory.create()
+
+    val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+    whenever(referralRepository.save(any())).thenReturn(referral)
+    whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), any(), anyOrNull()))
+      .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+
+    val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
+    assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+  }
+
+  @Nested
+  inner class PostingOasysRiskInformation {
+    private val draftRisk = draftOasysRiskInformationFactory.create(
+      referralId = UUID.randomUUID(),
+      riskSummaryWhoIsAtRisk = "riskSummaryWhoIsAtRisk",
+      riskSummaryNatureOfRisk = "riskSummaryNatureOfRisk",
+      riskSummaryRiskImminence = "riskSummaryRiskImminence",
+      riskToSelfSuicide = "riskToSelfSuicide",
+      riskToSelfSelfHarm = "riskToSelfSelfHarm",
+      riskToSelfHostelSetting = "riskToSelfHostelSetting",
+      riskToSelfVulnerability = "riskToSelfVulnerability",
+      additionalInformation = "draftOasysAdditionalInformation",
+    )
+
+    @Test
+    fun `correct additional risk information is set if it exists as draft oasys risk information`() {
+      val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
+      val authUser = authUserFactory.create()
+
+      val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+      whenever(referralRepository.save(any())).thenReturn(referral)
+
+      whenever(assessRisksAndNeedsService.canPostFullRiskInformation()).thenReturn(true)
+      whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)).thenReturn(draftRisk)
+
+      whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), eq("draftOasysAdditionalInformation"), any()))
+        .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+
+      val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
+      assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+    }
+
+    @Test
+    fun `no exception thrown on empty additional risk if draft risk information exists`() {
+      val draftReferral = referralFactory.createDraft(additionalRiskInformation = null)
+      val authUser = authUserFactory.create()
+
+      val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+      whenever(referralRepository.save(any())).thenReturn(referral)
+
+      whenever(assessRisksAndNeedsService.canPostFullRiskInformation()).thenReturn(true)
+      whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)).thenReturn(draftRisk)
+
+      whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), any(), any()))
+        .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+
+      val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
+      assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+    }
+
+    @Test
+    fun `only original additional risk information is posted if posting full risk information is disabled`() {
+      val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
+      val authUser = authUserFactory.create()
+
+      val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+      whenever(referralRepository.save(any())).thenReturn(referral)
+
+      whenever(assessRisksAndNeedsService.canPostFullRiskInformation()).thenReturn(false)
+
+      whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), eq("something"), anyOrNull()))
+        .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+
+      val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
+      assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
+    }
+  }
+
+  @Test
+  fun `timestamp is stored when additionalRiskInformation is updated`() {
+    val referral = referralFactory.createDraft(additionalRiskInformation = "something")
+
+    whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
+    whenever(draftReferralRepository.save(any())).thenReturn(referral)
+
+    assertThat(referral.additionalRiskInformationUpdatedAt).isNull()
+    draftReferralService.updateDraftReferral(referral, DraftReferralDTO(additionalRiskInformation = "risk"))
+    assertThat(referral.additionalRiskInformationUpdatedAt).isNotNull()
+  }
+
+  @Test
+  fun `submitAdditionalRiskInformation uses appropriate referral fields`() {
+    val timestamp = OffsetDateTime.now()
+    val draftReferral = referralFactory.createDraft(
+      additionalRiskInformation = "something",
+      additionalRiskInformationUpdatedAt = timestamp
+    )
+    val authUser = authUserFactory.create()
+
+    val referral = referralFactory.createSent(id = draftReferral.id)
+
+    whenever(referralRepository.save(any())).thenReturn(referral)
+
+    draftReferralService.sendDraftReferral(draftReferral, authUser)
+    verify(assessRisksAndNeedsService, times(1))
+      .createSupplementaryRisk(referral.id, referral.serviceUserCRN, authUser, timestamp, "something")
+  }
+
+  @Test
+  fun `referral is sent to assessRisksAndNeeds before communityApi`() {
+    val timestamp = OffsetDateTime.now()
+    val draftReferral = referralFactory.createDraft(
+      additionalRiskInformation = "something",
+      additionalRiskInformationUpdatedAt = timestamp
+    )
+    val sentReferral = referralFactory.createSent(
+      id = draftReferral.id,
+      additionalRiskInformationUpdatedAt = timestamp
+    )
+    val authUser = authUserFactory.create()
+
+    whenever(referralRepository.save(any())).thenReturn(sentReferral)
+
+    val sendReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
+
+    val inOrder = inOrder(assessRisksAndNeedsService, communityAPIReferralService)
+    inOrder.verify(assessRisksAndNeedsService, times(1))
+      .createSupplementaryRisk(draftReferral.id, draftReferral.serviceUserCRN, authUser, timestamp, "something")
+    val eventCaptor = argumentCaptor<Referral>()
+
+    inOrder.verify(communityAPIReferralService, times(1)).send(eventCaptor.capture())
+    val capturedReferral = eventCaptor.firstValue
+    assertThat(capturedReferral.id).isEqualTo(sendReferral.id)
+  }
+
+  @Nested
+  inner class UpdateDraftReferralDetails {
+    @BeforeEach
+    fun setup() {
+      whenever(referralRepository.save(any())).thenAnswer { it.arguments[0] }
+    }
+
+    @Test
+    fun `new referral details have the same created time as the referral`() {
+      val draftReferral = referralFactory.createDraft()
+
+      // there is no existing referral details for this referral id
+      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(null)
+
+      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
+
+      draftReferralService.updateDraftReferral(
+        draftReferral,
+        DraftReferralDTO(
+          completionDeadline = LocalDate.of(3022, 3, 28)
+        )
+      )
+
+      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
+      verify(referralDetailsRepository).saveAndFlush(captor.capture())
+
+      val referralDetails = captor.value
+      assertThat(referralDetails.createdAt).isEqualTo(draftReferral.createdAt)
+    }
+
+    @Test
+    fun `updates to the referral details for draft referrals do not create new versions`() {
+      val draftReferral = referralFactory.createDraft()
+      val existingDetails = ReferralDetails(
+        UUID.randomUUID(),
+        null,
+        draftReferral.id,
+        draftReferral.createdAt,
+        draftReferral.createdBy.id,
+        "initial version",
+        LocalDate.of(2022, 3, 28),
+        null,
+        null,
+      )
+
+      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
+      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(existingDetails)
+      draftReferralService.updateDraftReferral(draftReferral, DraftReferralDTO(furtherInformation = "nothing to see here"))
+
+      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
+      verify(referralDetailsRepository).saveAndFlush(captor.capture())
+
+      val savedDetails = captor.value
+      assertThat(savedDetails.id).isEqualTo(existingDetails.id)
+      assertThat(savedDetails.createdAt).isEqualTo(existingDetails.createdAt)
+      assertThat(savedDetails.reasonForChange).isEqualTo(existingDetails.reasonForChange)
+    }
+
+    @Test
+    fun `updates to the referral details for draft referrals are saved in the existing version`() {
+      val draftReferral = referralFactory.createDraft()
+      val existingDetails = ReferralDetails(
+        UUID.randomUUID(),
+        null,
+        draftReferral.id,
+        draftReferral.createdAt,
+        draftReferral.createdBy.id,
+        "initial version",
+        LocalDate.of(2022, 3, 28),
+        null,
+        null,
+      )
+
+      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
+
+      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(existingDetails)
+      draftReferralService.updateDraftReferral(draftReferral, DraftReferralDTO(maximumEnforceableDays = 22))
+
+      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
+      verify(referralDetailsRepository).saveAndFlush(captor.capture())
+
+      val savedDetails = captor.value
+      assertThat(savedDetails.completionDeadline).isEqualTo(existingDetails.completionDeadline)
+      assertThat(savedDetails.maximumEnforceableDays).isEqualTo(22)
+    }
+
+    @Test
+    fun `all referral details fields are persisted`() {
+      val draftReferral = referralFactory.createDraft()
+
+      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(null)
+      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
+
+      draftReferralService.updateDraftReferral(
+        draftReferral,
+        DraftReferralDTO(
+          completionDeadline = LocalDate.of(3022, 3, 28),
+          furtherInformation = "nothing to see here",
+          maximumEnforceableDays = 25,
+        )
+      )
+
+      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
+      verify(referralDetailsRepository).saveAndFlush(captor.capture())
+
+      val referralDetails = captor.value
+      assertThat(referralDetails.completionDeadline).isEqualTo(LocalDate.of(3022, 3, 28))
+      assertThat(referralDetails.furtherInformation).isEqualTo("nothing to see here")
+      assertThat(referralDetails.maximumEnforceableDays).isEqualTo(25)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -2,41 +2,24 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import io.netty.handler.timeout.ReadTimeoutException
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.firstValue
-import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.secondValue
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ReferralAccessFilter
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceProviderAccessScopeMapper
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceUserAccessChecker
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserTypeChecker
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.Code
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.FieldError
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.ValidationError
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.DraftReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateReferralDetailsDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ComplexityLevel
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
@@ -51,16 +34,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Ser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.CancellationReasonFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ChangeLogFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ContractTypeFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DraftOasysRiskInformationFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFrameworkContractFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceCategoryFactory
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import java.util.Optional
 import java.util.UUID
 
 class ReferralServiceUnitTest {
@@ -71,42 +48,44 @@ class ReferralServiceUnitTest {
   private val interventionRepository: InterventionRepository = mock()
   private val referralEventPublisher: ReferralEventPublisher = mock()
   private val referralConcluder: ReferralConcluder = mock()
-  private val referralReferenceGenerator: ReferralReferenceGenerator = mock()
   private val cancellationReasonRepository: CancellationReasonRepository = mock()
   private val deliverySessionRepository: DeliverySessionRepository = mock()
   private val serviceCategoryRepository: ServiceCategoryRepository = mock()
   private val referralAccessChecker: ReferralAccessChecker = mock()
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper = mock()
   private val referralAccessFilter: ReferralAccessFilter = mock()
-  private val communityAPIReferralService: CommunityAPIReferralService = mock()
   private val userTypeChecker: UserTypeChecker = mock()
-  private val serviceUserAccessChecker: ServiceUserAccessChecker = mock()
-  private val assessRisksAndNeedsService: RisksAndNeedsService = mock()
   private val communityAPIOffenderService: CommunityAPIOffenderService = mock()
-  private val supplierAssessmentService: SupplierAssessmentService = mock()
   private val hmppsAuthService: HMPPSAuthService = mock()
   private val telemetryService: TelemetryService = mock()
-  private val draftOasysRiskInformationService: DraftOasysRiskInformationService = mock()
   private val referralDetailsRepository: ReferralDetailsRepository = mock()
   private val changeLogRepository: ChangelogRepository = mock()
 
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
   private val cancellationReasonFactory = CancellationReasonFactory()
-  private val serviceCategoryFactory = ServiceCategoryFactory()
-  private val contractTypeFactory = ContractTypeFactory()
-  private val interventionFactory = InterventionFactory()
-  private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
-  private val draftOasysRiskInformationFactory = DraftOasysRiskInformationFactory()
   private val changeLogFactory = ChangeLogFactory()
 
   private val referralService = ReferralService(
-    referralRepository, draftReferralRepository, sentReferralSummariesRepository, authUserRepository, interventionRepository, referralConcluder,
-    referralEventPublisher, referralReferenceGenerator, cancellationReasonRepository,
-    deliverySessionRepository, serviceCategoryRepository, referralAccessChecker, userTypeChecker,
-    serviceProviderAccessScopeMapper, referralAccessFilter, communityAPIReferralService, serviceUserAccessChecker,
-    assessRisksAndNeedsService, communityAPIOffenderService, supplierAssessmentService, hmppsAuthService,
-    telemetryService, draftOasysRiskInformationService, referralDetailsRepository, changeLogRepository
+    referralRepository,
+    draftReferralRepository,
+    sentReferralSummariesRepository,
+    authUserRepository,
+    interventionRepository,
+    referralConcluder,
+    referralEventPublisher,
+    cancellationReasonRepository,
+    deliverySessionRepository,
+    serviceCategoryRepository,
+    referralAccessChecker,
+    userTypeChecker,
+    serviceProviderAccessScopeMapper,
+    referralAccessFilter,
+    communityAPIOffenderService,
+    hmppsAuthService,
+    telemetryService,
+    referralDetailsRepository,
+    changeLogRepository
   )
 
   @Test
@@ -150,640 +129,6 @@ class ReferralServiceUnitTest {
     whenever(cancellationReasonRepository.findAll()).thenReturn(cancellationReasons)
     val result = referralService.getCancellationReasons()
     assertThat(result).isNotNull
-  }
-
-  @Nested
-  inner class UpdateDraftReferralComplexityLevel() {
-    @Test
-    fun `cant set complexity level when no service categories have been selected`() {
-      val referral = referralFactory.createDraft()
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralComplexityLevel(
-          referral,
-          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
-          UUID.randomUUID()
-        )
-      }
-
-      assertThat(e.message.equals("complexity level cannot be updated: no service categories selected for this referral"))
-    }
-
-    @Test
-    fun `cant set complexity level for an invalid service category`() {
-      val serviceCategory1 = serviceCategoryFactory.create()
-      val serviceCategory2 = serviceCategoryFactory.create()
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory1))
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralComplexityLevel(
-          referral,
-          serviceCategory2.id,
-          UUID.randomUUID()
-        )
-      }
-
-      assertThat(e.message.equals("complexity level cannot be updated: specified service category not selected for this referral"))
-    }
-
-    @Test
-    fun `cant set complexity level when service category is not found`() {
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.empty())
-      val serviceCategory = serviceCategoryFactory.create()
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralComplexityLevel(
-          referral,
-          serviceCategory.id,
-          UUID.randomUUID()
-        )
-      }
-
-      assertThat(e.message.equals("complexity level cannot be updated: specified service category not found"))
-    }
-
-    @Test
-    fun `cant set complexity level when its invalid for the service category`() {
-      val complexityLevel = ComplexityLevel(UUID.randomUUID(), "title", "description")
-      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel))
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
-
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralComplexityLevel(
-          referral,
-          serviceCategory.id,
-          UUID.randomUUID()
-        )
-      }
-
-      assertThat(e.message.equals("complexity level cannot be updated: complexity level not valid for this service category"))
-    }
-
-    @Test
-    fun `can set complexity level for the first time`() {
-      val complexityLevel = ComplexityLevel(UUID.randomUUID(), "title", "description")
-      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel))
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
-
-      assertThat(referral.complexityLevelIds).isNull()
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
-      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
-
-      val updatedReferral = referralService.updateDraftReferralComplexityLevel(
-        referral,
-        serviceCategory.id,
-        complexityLevel.id,
-      )
-
-      assertThat(updatedReferral.complexityLevelIds!!.size).isEqualTo(1)
-    }
-
-    @Test
-    fun `can update an already selected complexity level`() {
-      val complexityLevel1 = ComplexityLevel(UUID.randomUUID(), "1", "description")
-      val complexityLevel2 = ComplexityLevel(UUID.randomUUID(), "2", "description")
-      val serviceCategory = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1, complexityLevel2))
-      val referral = referralFactory.createDraft(
-        selectedServiceCategories = mutableSetOf(serviceCategory),
-        complexityLevelIds = mutableMapOf(serviceCategory.id to complexityLevel1.id)
-      )
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
-      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
-
-      val updatedReferral = referralService.updateDraftReferralComplexityLevel(
-        referral,
-        serviceCategory.id,
-        complexityLevel2.id,
-      )
-
-      assertThat(updatedReferral.complexityLevelIds!![serviceCategory.id]).isEqualTo(complexityLevel2.id)
-    }
-  }
-
-  @Nested
-  inner class UpdateServiceCategories {
-
-    private val serviceCategoryIds = listOf(
-      UUID.fromString("8221a81c-08b2-4262-9c1a-0ab3c82cec8c"),
-      UUID.fromString("9556a399-3529-4993-8030-41db2090555e"),
-      UUID.fromString("b84f4eb7-4db0-477e-8c59-21027b3262c5"),
-      UUID.fromString("c036826e-f077-49a5-8b33-601dca7ad479")
-    )
-
-    @Test
-    fun `successfully update service categories`() {
-      val serviceCategories = setOf(
-        serviceCategoryFactory.create(id = UUID.fromString("8221a81c-08b2-4262-9c1a-0ab3c82cec8c"), name = "aaa"),
-        serviceCategoryFactory.create(id = UUID.fromString("9556a399-3529-4993-8030-41db2090555e"), name = "bbb"),
-        serviceCategoryFactory.create(id = UUID.fromString("b84f4eb7-4db0-477e-8c59-21027b3262c5"), name = "ccc"),
-        serviceCategoryFactory.create(id = UUID.fromString("c036826e-f077-49a5-8b33-601dca7ad479"), name = "ddd")
-      )
-
-      val contractType = contractTypeFactory.create(serviceCategories = serviceCategories.toSet())
-      val referral = referralFactory.createDraft(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            contractType = contractType
-          )
-        )
-      )
-
-      val update = DraftReferralDTO(serviceCategoryIds = serviceCategoryIds)
-      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-      whenever(draftReferralRepository.save(any())).thenReturn(referral)
-
-      referralService.updateDraftReferral(referral, update)
-
-      val argument: ArgumentCaptor<DraftReferral> = ArgumentCaptor.forClass(DraftReferral::class.java)
-      verify(draftReferralRepository).save(argument.capture())
-      val savedActionPlan = argument.value
-      assertThat(savedActionPlan.selectedServiceCategories == serviceCategories)
-    }
-
-    @Test
-    fun `updating selected service category with new set removes desired outcome for existing service categories`() {
-
-      val serviceCategoryId1 = UUID.randomUUID()
-      val serviceCategoryId2 = UUID.randomUUID()
-      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
-      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId2)
-      val serviceCategory1 = serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome1))
-      val serviceCategory2 = serviceCategoryFactory.create(id = serviceCategoryId2, desiredOutcomes = listOf(desiredOutcome2))
-
-      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1, serviceCategory2))
-      val referral = referralFactory.createDraft(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            contractType = contractType
-          )
-        ),
-        selectedServiceCategories = mutableSetOf(serviceCategory1),
-        desiredOutcomes = listOf(desiredOutcome1)
-      )
-
-      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory2))
-      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-      whenever(draftReferralRepository.save(any())).thenReturn(referral)
-      val updatedReferral = referralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategoryId2)))
-
-      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
-      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId2)
-      assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(0)
-    }
-
-    @Test
-    fun `updating selected service category with same set doesn't remove desired outcome for same service categories`() {
-
-      val serviceCategoryId1 = UUID.randomUUID()
-      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
-      val serviceCategory1 = serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome1))
-
-      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1))
-      val referral = referralFactory.createDraft(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            contractType = contractType
-          )
-        ),
-        selectedServiceCategories = mutableSetOf(serviceCategory1),
-        desiredOutcomes = listOf(desiredOutcome1)
-      )
-
-      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory1))
-      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-      whenever(draftReferralRepository.save(any())).thenReturn(referral)
-
-      val updatedReferral = referralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategoryId1)))
-
-      verify(draftReferralRepository).save(any())
-      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
-      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategoryId1)
-      assertThat(updatedReferral.selectedDesiredOutcomes).hasSize(1)
-      assertThat(updatedReferral.selectedDesiredOutcomes!!.elementAt(0).serviceCategoryId).isEqualTo(serviceCategoryId1)
-      assertThat(updatedReferral.selectedDesiredOutcomes!!.elementAt(0).desiredOutcomeId).isEqualTo(desiredOutcome1.id)
-    }
-
-    @Test
-    fun `updating selected service category with new set removes complexity level for existing service categories`() {
-
-      val complexityLevel1 = ComplexityLevel(UUID.randomUUID(), "title", "description")
-      val complexityLevel2 = ComplexityLevel(UUID.randomUUID(), "title", "description")
-      val serviceCategory1 = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1))
-      val serviceCategory2 = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel2))
-
-      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1, serviceCategory2))
-      val referral = referralFactory.createDraft(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            contractType = contractType
-          )
-        ),
-        selectedServiceCategories = mutableSetOf(serviceCategory1),
-        complexityLevelIds = mapOf(serviceCategory1.id to complexityLevel1.id).toMutableMap()
-      )
-
-      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory2))
-      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-      whenever(draftReferralRepository.save(any())).thenReturn(referral)
-      val updatedReferral = referralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategory2.id)))
-
-      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
-      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategory2.id)
-      assertThat(updatedReferral.complexityLevelIds).hasSize(0)
-    }
-
-    @Test
-    fun `updating selected service category with same set doesn't remove complexity level for same service categories`() {
-
-      val complexityLevel1 = ComplexityLevel(UUID.randomUUID(), "title", "description")
-      val serviceCategory1 = serviceCategoryFactory.create(complexityLevels = listOf(complexityLevel1))
-
-      val contractType = contractTypeFactory.create(serviceCategories = setOf(serviceCategory1))
-      val referral = referralFactory.createDraft(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            contractType = contractType
-          )
-        ),
-        selectedServiceCategories = mutableSetOf(serviceCategory1),
-        complexityLevelIds = mapOf(serviceCategory1.id to complexityLevel1.id).toMutableMap()
-      )
-
-      whenever(serviceCategoryRepository.findByIdIn(any())).thenReturn(setOf(serviceCategory1))
-      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-      whenever(draftReferralRepository.save(any())).thenReturn(referral)
-      val updatedReferral = referralService.updateDraftReferral(referral, DraftReferralDTO(serviceCategoryIds = listOf(serviceCategory1.id)))
-
-      assertThat(updatedReferral.selectedServiceCategories).hasSize(1)
-      assertThat(updatedReferral.selectedServiceCategories!!.elementAt(0).id).isEqualTo(serviceCategory1.id)
-      assertThat(updatedReferral.complexityLevelIds).hasSize(1)
-      assertThat(updatedReferral.complexityLevelIds!![serviceCategory1.id]).isEqualTo(complexityLevel1.id)
-    }
-
-    @Test
-    fun `fail to update referral with service category not part of contract type`() {
-      val serviceCategories = setOf(
-        serviceCategoryFactory.create(id = UUID.fromString("8221a81c-08b2-4262-9c1a-0ab3c82cec8c"), name = "aaa"),
-        serviceCategoryFactory.create(id = UUID.fromString("9556a399-3529-4993-8030-41db2090555e"), name = "bbb"),
-        serviceCategoryFactory.create(id = UUID.fromString("b84f4eb7-4db0-477e-8c59-21027b3262c5"), name = "ccc")
-      )
-
-      val contractType = contractTypeFactory.create(serviceCategories = serviceCategories)
-      val referral = referralFactory.createDraft(
-        intervention = interventionFactory.create(
-          contract = dynamicFrameworkContractFactory.create(
-            contractType = contractType
-          )
-        )
-      )
-
-      val update = DraftReferralDTO(serviceCategoryIds = serviceCategoryIds)
-      whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-      whenever(draftReferralRepository.save(any())).thenReturn(referral)
-
-      val exception = Assertions.assertThrows(ValidationError::class.java) {
-        referralService.updateDraftReferral(referral, update)
-      }
-      assertThat(exception.message).isEqualTo("draft referral update invalid")
-      assertThat(exception.errors[0]).isEqualTo(FieldError(field = "serviceCategoryIds", error = Code.INVALID_SERVICE_CATEGORY_FOR_CONTRACT))
-    }
-  }
-
-  @Nested
-  inner class UpdateDraftReferralDesiredOutcomes() {
-
-    @Test
-    fun `cant set desired outcomes to an empty list`() {
-      val referral = referralFactory.createDraft()
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralDesiredOutcomes(
-          referral,
-          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
-          listOf()
-        )
-      }
-
-      assertThat(e.message.equals("desired outcomes cannot be empty"))
-    }
-
-    @Test
-    fun `cant set desired outcomes when no service categories have been selected`() {
-      val referral = referralFactory.createDraft()
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralDesiredOutcomes(
-          referral,
-          referral.intervention.dynamicFrameworkContract.contractType.serviceCategories.first().id,
-          listOf(UUID.randomUUID())
-        )
-      }
-
-      assertThat(e.message.equals("desired outcomes cannot be updated: no service categories selected for this referral"))
-    }
-
-    @Test
-    fun `cant set desired outcomes for an invalid service category`() {
-      val serviceCategory1 = serviceCategoryFactory.create()
-      val serviceCategory2 = serviceCategoryFactory.create()
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory1))
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralDesiredOutcomes(
-          referral,
-          serviceCategory2.id,
-          listOf(UUID.randomUUID())
-        )
-      }
-
-      assertThat(e.message.equals("desired outcomes cannot be updated: specified service category not selected for this referral"))
-    }
-
-    @Test
-    fun `cant set desired outcome when service category is not found`() {
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.empty())
-      val serviceCategory = serviceCategoryFactory.create()
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralDesiredOutcomes(
-          referral,
-          serviceCategory.id,
-          listOf(UUID.randomUUID())
-        )
-      }
-
-      assertThat(e.message.equals("desired outcomes cannot be updated: specified service category not found"))
-    }
-
-    @Test
-    fun `cant set desired outcomes when its invalid for the service category`() {
-      val serviceCategoryId = UUID.randomUUID()
-      val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
-      val serviceCategory =
-        serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = listOf(desiredOutcome))
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
-
-      val e = assertThrows<ServerWebInputException> {
-        referralService.updateDraftReferralDesiredOutcomes(
-          referral,
-          serviceCategory.id,
-          listOf(UUID.randomUUID())
-        )
-      }
-
-      assertThat(e.message.equals("desired outcomes cannot be updated: at least one desired outcome is not valid for this service category"))
-    }
-
-    @Test
-    fun `can set desired outcomes for the first time`() {
-      val serviceCategoryId = UUID.randomUUID()
-      val desiredOutcome = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
-      val serviceCategory =
-        serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = listOf(desiredOutcome))
-      val referral = referralFactory.createDraft(selectedServiceCategories = mutableSetOf(serviceCategory))
-
-      assertThat(referral.selectedDesiredOutcomes).isEmpty()
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
-      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
-
-      val updatedReferral = referralService.updateDraftReferralDesiredOutcomes(
-        referral,
-        serviceCategory.id,
-        listOf(desiredOutcome.id),
-      )
-
-      assertThat(updatedReferral.selectedDesiredOutcomes!!.size).isEqualTo(1)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome.id)
-    }
-
-    @Test
-    fun `can update an already selected desired outcome for service category`() {
-      val serviceCategoryId = UUID.randomUUID()
-      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
-      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId)
-      val serviceCategory = serviceCategoryFactory.create(
-        id = serviceCategoryId,
-        desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2)
-      )
-      val referral = referralFactory.createDraft(
-        selectedServiceCategories = mutableSetOf(serviceCategory),
-        desiredOutcomes = mutableListOf(desiredOutcome1)
-      )
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory))
-      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
-
-      val updatedReferral = referralService.updateDraftReferralDesiredOutcomes(
-        referral,
-        serviceCategory.id,
-        listOf(desiredOutcome2.id),
-      )
-
-      assertThat(updatedReferral.selectedDesiredOutcomes!!.size).isEqualTo(1)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory.id)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome2.id)
-    }
-
-    @Test
-    fun `can update an different selected desired outcome for a different service category`() {
-      val serviceCategoryId1 = UUID.randomUUID()
-      val serviceCategoryId2 = UUID.randomUUID()
-      val desiredOutcome1 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId1)
-      val desiredOutcome2 = DesiredOutcome(UUID.randomUUID(), "title", serviceCategoryId = serviceCategoryId2)
-      val serviceCategory1 =
-        serviceCategoryFactory.create(id = serviceCategoryId1, desiredOutcomes = listOf(desiredOutcome2))
-      val serviceCategory2 = serviceCategoryFactory.create(
-        id = serviceCategoryId2,
-        desiredOutcomes = listOf(desiredOutcome1, desiredOutcome2)
-      )
-      val referral = referralFactory.createDraft(
-        selectedServiceCategories = mutableSetOf(serviceCategory1, serviceCategory2),
-        desiredOutcomes = mutableListOf(desiredOutcome1)
-      )
-
-      whenever(serviceCategoryRepository.findById(any())).thenReturn(Optional.of(serviceCategory2))
-      whenever(draftReferralRepository.save(referral)).thenReturn(referral)
-
-      val updatedReferral = referralService.updateDraftReferralDesiredOutcomes(
-        referral,
-        serviceCategory2.id,
-        listOf(desiredOutcome2.id),
-      )
-
-      assertThat(updatedReferral.selectedDesiredOutcomes!!.size).isEqualTo(2)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![0].serviceCategoryId).isEqualTo(serviceCategory1.id)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![0].desiredOutcomeId).isEqualTo(desiredOutcome1.id)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![1].serviceCategoryId).isEqualTo(serviceCategory2.id)
-      assertThat(updatedReferral.selectedDesiredOutcomes!![1].desiredOutcomeId).isEqualTo(desiredOutcome2.id)
-    }
-  }
-
-  @Test
-  fun `cant send draft referral without risk information`() {
-    val referral = referralFactory.createDraft()
-    val authUser = authUserFactory.create()
-
-    val e = assertThrows<ServerWebInputException> {
-      referralService.sendDraftReferral(referral, authUser)
-    }
-
-    assertThat(e.message).contains("can't submit a referral without risk information")
-  }
-
-  @Test
-  fun`draft referral risk information is deleted when referral is sent`() {
-    val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
-    val authUser = authUserFactory.create()
-
-    val referral = referralFactory.createSent(id = draftReferral.id)
-
-    whenever(referralRepository.save(any())).thenReturn(referral)
-
-    val sentReferral = referralService.sendDraftReferral(draftReferral, authUser)
-    assertThat(sentReferral.additionalRiskInformation).isNull()
-  }
-
-  @Test
-  fun `supplementaryRiskId is set when referral is sent`() {
-    val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
-    val authUser = authUserFactory.create()
-
-    val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-    whenever(referralRepository.save(any())).thenReturn(referral)
-    whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), any(), anyOrNull()))
-      .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-
-    val sentReferral = referralService.sendDraftReferral(draftReferral, authUser)
-    assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-  }
-
-  @Nested
-  inner class PostingOasysRiskInformation {
-
-    val draftRisk = draftOasysRiskInformationFactory.create(
-      referralId = UUID.randomUUID(),
-      riskSummaryWhoIsAtRisk = "riskSummaryWhoIsAtRisk",
-      riskSummaryNatureOfRisk = "riskSummaryNatureOfRisk",
-      riskSummaryRiskImminence = "riskSummaryRiskImminence",
-      riskToSelfSuicide = "riskToSelfSuicide",
-      riskToSelfSelfHarm = "riskToSelfSelfHarm",
-      riskToSelfHostelSetting = "riskToSelfHostelSetting",
-      riskToSelfVulnerability = "riskToSelfVulnerability",
-      additionalInformation = "draftOasysAdditionalInformation",
-    )
-
-    @Test
-    fun `correct additional risk information is set if it exists as draft oasys risk information`() {
-      val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
-      val authUser = authUserFactory.create()
-
-      val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-      whenever(referralRepository.save(any())).thenReturn(referral)
-
-      whenever(assessRisksAndNeedsService.canPostFullRiskInformation()).thenReturn(true)
-      whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)).thenReturn(draftRisk)
-
-      whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), eq("draftOasysAdditionalInformation"), any()))
-        .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-
-      val sentReferral = referralService.sendDraftReferral(draftReferral, authUser)
-      assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-    }
-
-    @Test
-    fun `no exception thrown on empty additional risk if draft risk information exists`() {
-      val draftReferral = referralFactory.createDraft(additionalRiskInformation = null)
-      val authUser = authUserFactory.create()
-
-      val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-      whenever(referralRepository.save(any())).thenReturn(referral)
-
-      whenever(assessRisksAndNeedsService.canPostFullRiskInformation()).thenReturn(true)
-      whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(referral.id)).thenReturn(draftRisk)
-
-      whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), any(), any()))
-        .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-
-      val sentReferral = referralService.sendDraftReferral(draftReferral, authUser)
-      assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-    }
-
-    @Test
-    fun `only original additional risk information is posted if posting full risk information is disabled`() {
-      val draftReferral = referralFactory.createDraft(additionalRiskInformation = "something")
-      val authUser = authUserFactory.create()
-
-      val referral = referralFactory.createSent(id = draftReferral.id, supplementaryRiskId = UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-      whenever(referralRepository.save(any())).thenReturn(referral)
-
-      whenever(assessRisksAndNeedsService.canPostFullRiskInformation()).thenReturn(false)
-
-      whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(referral.id), any(), any(), anyOrNull(), eq("something"), anyOrNull()))
-        .thenReturn(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-
-      val sentReferral = referralService.sendDraftReferral(draftReferral, authUser)
-      assertThat(sentReferral.supplementaryRiskId).isEqualTo(UUID.fromString("05320402-1e4b-4bdf-8db3-cde991359ba2"))
-    }
-  }
-
-  @Test
-  fun `timestamp is stored when additionalRiskInformation is updated`() {
-    val referral = referralFactory.createDraft(additionalRiskInformation = "something")
-
-    whenever(draftReferralRepository.saveAndFlush(any())).thenReturn(referral)
-    whenever(draftReferralRepository.save(any())).thenReturn(referral)
-
-    assertThat(referral.additionalRiskInformationUpdatedAt).isNull()
-    referralService.updateDraftReferral(referral, DraftReferralDTO(additionalRiskInformation = "risk"))
-    assertThat(referral.additionalRiskInformationUpdatedAt).isNotNull()
-  }
-
-  @Test
-  fun `submitAdditionalRiskInformation uses appropriate referral fields`() {
-    val timestamp = OffsetDateTime.now()
-    val draftReferral = referralFactory.createDraft(
-      additionalRiskInformation = "something",
-      additionalRiskInformationUpdatedAt = timestamp
-    )
-    val authUser = authUserFactory.create()
-
-    val referral = referralFactory.createSent(id = draftReferral.id)
-
-    whenever(referralRepository.save(any())).thenReturn(referral)
-
-    referralService.sendDraftReferral(draftReferral, authUser)
-    verify(assessRisksAndNeedsService, times(1))
-      .createSupplementaryRisk(referral.id, referral.serviceUserCRN, authUser, timestamp, "something")
-  }
-
-  @Test
-  fun `referral is sent to assessRisksAndNeeds before communityApi`() {
-    val timestamp = OffsetDateTime.now()
-    val draftReferral = referralFactory.createDraft(
-      additionalRiskInformation = "something",
-      additionalRiskInformationUpdatedAt = timestamp
-    )
-    val sentReferral = referralFactory.createSent(
-      id = draftReferral.id,
-      additionalRiskInformationUpdatedAt = timestamp
-    )
-    val authUser = authUserFactory.create()
-
-    whenever(referralRepository.save(any())).thenReturn(sentReferral)
-
-    val sendReferral = referralService.sendDraftReferral(draftReferral, authUser)
-
-    val inOrder = inOrder(assessRisksAndNeedsService, communityAPIReferralService)
-    inOrder.verify(assessRisksAndNeedsService, times(1))
-      .createSupplementaryRisk(draftReferral.id, draftReferral.serviceUserCRN, authUser, timestamp, "something")
-    val eventCaptor = argumentCaptor<Referral>()
-
-    inOrder.verify(communityAPIReferralService, times(1)).send(eventCaptor.capture())
-    val capturedReferral = eventCaptor.firstValue
-    assertThat(capturedReferral.id).isEqualTo(sendReferral.id)
   }
 
   @Test
@@ -833,118 +178,6 @@ class ReferralServiceUnitTest {
 
     assertThat(response).isSameAs(sentReferral)
     verify(referralRepository).findByIdAndSentAtIsNotNull(sentReferral.id)
-  }
-
-  @Nested
-  inner class UpdateDraftReferralDetails {
-    @BeforeEach
-    fun setup() {
-      whenever(referralRepository.save(any())).thenAnswer { it.arguments[0] }
-    }
-
-    @Test
-    fun `new referral details have the same created time as the referral`() {
-      val draftReferral = referralFactory.createDraft()
-
-      // there is no existing referral details for this referral id
-      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(null)
-
-      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
-
-      referralService.updateDraftReferral(
-        draftReferral,
-        DraftReferralDTO(
-          completionDeadline = LocalDate.of(3022, 3, 28)
-        )
-      )
-
-      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
-      verify(referralDetailsRepository).saveAndFlush(captor.capture())
-
-      val referralDetails = captor.value
-      assertThat(referralDetails.createdAt).isEqualTo(draftReferral.createdAt)
-    }
-
-    @Test
-    fun `updates to the referral details for draft referrals do not create new versions`() {
-      val draftReferral = referralFactory.createDraft()
-      val existingDetails = ReferralDetails(
-        UUID.randomUUID(),
-        null,
-        draftReferral.id,
-        draftReferral.createdAt,
-        draftReferral.createdBy.id,
-        "initial version",
-        LocalDate.of(2022, 3, 28),
-        null,
-        null,
-      )
-
-      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
-      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(existingDetails)
-      referralService.updateDraftReferral(draftReferral, DraftReferralDTO(furtherInformation = "nothing to see here"))
-
-      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
-      verify(referralDetailsRepository).saveAndFlush(captor.capture())
-
-      val savedDetails = captor.value
-      assertThat(savedDetails.id).isEqualTo(existingDetails.id)
-      assertThat(savedDetails.createdAt).isEqualTo(existingDetails.createdAt)
-      assertThat(savedDetails.reasonForChange).isEqualTo(existingDetails.reasonForChange)
-    }
-
-    @Test
-    fun `updates to the referral details for draft referrals are saved in the existing version`() {
-      val draftReferral = referralFactory.createDraft()
-      val existingDetails = ReferralDetails(
-        UUID.randomUUID(),
-        null,
-        draftReferral.id,
-        draftReferral.createdAt,
-        draftReferral.createdBy.id,
-        "initial version",
-        LocalDate.of(2022, 3, 28),
-        null,
-        null,
-      )
-
-      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
-
-      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(existingDetails)
-      referralService.updateDraftReferral(draftReferral, DraftReferralDTO(maximumEnforceableDays = 22))
-
-      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
-      verify(referralDetailsRepository).saveAndFlush(captor.capture())
-
-      val savedDetails = captor.value
-      assertThat(savedDetails.completionDeadline).isEqualTo(existingDetails.completionDeadline)
-      assertThat(savedDetails.maximumEnforceableDays).isEqualTo(22)
-    }
-
-    @Test
-    fun `all referral details fields are persisted`() {
-      val draftReferral = referralFactory.createDraft()
-
-      whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(null)
-      whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
-
-      referralService.updateDraftReferral(
-        draftReferral,
-        DraftReferralDTO(
-          completionDeadline = LocalDate.of(3022, 3, 28),
-          furtherInformation = "nothing to see here",
-          maximumEnforceableDays = 25,
-        )
-      )
-
-      val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
-      verify(referralDetailsRepository).saveAndFlush(captor.capture())
-
-      val referralDetails = captor.value
-      assertThat(referralDetails.completionDeadline).isEqualTo(LocalDate.of(3022, 3, 28))
-      assertThat(referralDetails.furtherInformation).isEqualTo("nothing to see here")
-      assertThat(referralDetails.maximumEnforceableDays).isEqualTo(25)
-    }
   }
 
   @Nested inner class UpdateSentReferralDetails {


### PR DESCRIPTION
## What does this pull request do?

♻️ Split ReferralService into draft and non-draft services, including tests
🗑️ Also removes deprecated `legacyUpdateReferralDetails`

No other changes.

## What is the intent behind these changes?

I wanted to add some telemetry to drafts and decided I don’t want to add more stuff into an 802-line long `ReferralService` (now `DraftReferralService` is “only” 467 lines long). This PR only contains the refactor.

So that each distinct area has its namespace, reducing clutter and increasing cohesion.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1526295/189916473-23085add-1dba-4ed3-b023-a756847594fe.png">
