### PR TITLE
Create inconsistency issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/inconsistency-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/inconsistency-issue-template.md
@@ -1,0 +1,20 @@
+---
+name: Inconsistency issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: inconsistency
+assignees: ''
+
+---
+
+## Short problem statement; why is this a problem?
+
+(please describe what is the source of inconsistency)
+
+## Link to different approaches
+
+(add links here to codebase, pressing <kbd>Y</kbd> to lock it to a fixed commit)
+
+## Do you have a proposed solution? Why?
+
+(please describe if you have a proposal or list of options and why those are preferred)


### PR DESCRIPTION
## What does this pull request do?

Adds an issue template for tracking inconsistencies in code.

Makes it simpler to open issues like https://github.com/ministryofjustice/hmpps-interventions-service/issues/1208

## What is the intent behind these changes?

So we can have a documented list of problems we haven't solved yet.

We can use the template to track deprecated endpoints and different ways of doing the same thing.