### PR TITLE
Refresh the new preprod database, not the old

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -68,22 +68,22 @@ spec:
                 - name: DB_NAME_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: postgres-preprod
+                      name: postgres14-preprod
                       key: database_name
                 - name: DB_USER_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: postgres-preprod
+                      name: postgres14-preprod
                       key: database_username
                 - name: DB_PASS_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: postgres-preprod
+                      name: postgres14-preprod
                       key: database_password
                 - name: DB_HOST_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: postgres-preprod
+                      name: postgres14-preprod
                       key: rds_instance_address
           restartPolicy: "Never"
           volumes:


### PR DESCRIPTION
## What does this pull request do?

Refresh the new preprod database, not the old

## What is the intent behind these changes?

This will directly test our preprod is operational on PostgreSQL14 and tests the data can be migrated smoothly.

## Depends on

- https://github.com/ministryofjustice/cloud-platform-environments/pull/8810
