### PR TITLE
Enable daily updates of dependencies again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,6 @@ version: 2
 updates:
 - package-ecosystem: gradle
   directory: "/"
-  schedule:
-    interval: weekly
-    day: monday
-    time: "03:00"
-    timezone: Europe/London
   open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/script"


### PR DESCRIPTION

## What does this pull request do?

Enable daily updates of dependencies again

## What is the intent behind these changes?

Our `dps-gradle-spring-boot` dependency gets updated with security fixes. This happens more often than once a week.

We need those updates to unblock the continuous integration pipeline.
