### PR TITLE
Upgrade hmpps orb to keep builds running after 11 Oct 2022

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: main
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.14
+  hmpps: ministryofjustice/hmpps@6
   gradle: circleci/gradle@2.2.0
   mem: circleci/rememborb@0.0.1
 
@@ -33,7 +33,9 @@ _db_docker_config_postgres10: &db_docker_config_postgres10
 
 jobs:
   validate:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17"
     docker: *db_docker_config
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=true -Dkotlin.compiler.execution.strategy=in-process
@@ -52,7 +54,9 @@ jobs:
           path: build/reports/jacoco/test
 
   validate_db:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17"
     docker: *db_docker_config
     steps:
       - checkout
@@ -82,7 +86,9 @@ jobs:
             PGPASSWORD="$POSTGRES_PASSWORD" script/validate-metadata.sh
 
   validate_postgres10:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17"
     docker: *db_docker_config_postgres10
     environment:
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=true -Dkotlin.compiler.execution.strategy=in-process
@@ -101,7 +107,9 @@ jobs:
           path: build/reports/jacoco/test
 
   validate_db_postgres10:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17"
     docker: *db_docker_config_postgres10
     steps:
       - checkout
@@ -131,7 +139,9 @@ jobs:
             PGPASSWORD="$POSTGRES_PASSWORD" script/validate-metadata.sh
 
   publish_data:
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17"
     docker: *db_docker_config
     steps:
       - checkout
@@ -171,7 +181,9 @@ jobs:
       PACTBROKER_HOST: "pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACTBROKER_AUTH_USERNAME: "interventions"
       _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
-    executor: hmpps/java
+    executor:
+      name: hmpps/java
+      tag: "17"
     docker: *db_docker_config
     steps:
       - checkout
@@ -195,7 +207,9 @@ jobs:
     environment:
       PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
       PACT_BROKER_USERNAME: "interventions"
-    executor: hmpps/node
+    executor:
+      name: hmpps/node
+      tag: "16.17"
     parameters:
       tag:
         type: string
@@ -208,7 +222,9 @@ jobs:
               --broker-base-url="$PACT_BROKER_BASE_URL" --broker-username="$PACT_BROKER_USERNAME" --broker-password="$PACT_BROKER_PASSWORD"
 
   validate_helm:
-    executor: hmpps/default_small
+    executor:
+      name: hmpps/default_small
+      tag: "3.10"
     steps:
       - checkout
       - hmpps/k8s_setup


### PR DESCRIPTION
## What does this pull request do?

Upgrade hmpps orb for new setup_remote_docker syntax

## What is the intent behind these changes?

From CircleCI:

> To keep users as current as possible, CircleCI is in the process of
> updating the underlying architecture for the setup_remote_docker
> feature, as well as other benefits. Old versions of Docker when combined
> with a newer Docker image in rare cases may have incompatibility issues
> with a custom script in a run command.
>
> **In order to avoid possible job failures, please update your config by**
> **Tuesday, Oct. 11** to use the default version of Docker in
> `setup_remote_docker jobs`. This can be achieved by eliminating the
> version flag specified in each job that uses setup_remote_docker.
>
> The default Docker version in jobs that use setup_remote_docker was
> updated to version 20.10.17. The default is now being updated regularly.

This commit brings it those changes from the `ministryofjustice/hmpps@6` orb.

<details>
<summary>CircleCI config diff</summary>

```diff
diff --git a/circleci-before.yaml b/circleci-after.yaml
index 0acaea38..526572b6 100644
--- a/circleci-before.yaml
+++ b/circleci-after.yaml
@@ -1,11 +1,11 @@
-# Orb 'ministryofjustice/hmpps@3.14' resolved to 'ministryofjustice/hmpps@3.14.7'
+# Orb 'ministryofjustice/hmpps@6' resolved to 'ministryofjustice/hmpps@6.0.0'
 # Orb 'circleci/gradle@2.2.0' resolved to 'circleci/gradle@2.2.0'
 # Orb 'circleci/rememborb@0.0.1' resolved to 'circleci/rememborb@0.0.1'
 version: 2
 jobs:
   deploy_dev:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: small
     working_directory: ~/app
     steps:
@@ -278,6 +278,15 @@ jobs:
           DEPLOYMENT_CHANGELOG="$(<.deployment_changelog)"
           echo "export DEPLOYMENT_CHANGELOG_JSON=$(echo -n "$DEPLOYMENT_CHANGELOG" | tr '"' "'" | jq -Rs)" >> $BASH_ENV
         name: Store deployment changelog
+    - attach_workspace:
+        at: /tmp/circleci_remember
+    - run:
+        name: Recall APP_VERSION
+        command: |
+          exporter=$(cat /tmp/circleci_remember/.circleci_remember/APP_VERSION)
+          $exporter
+          echo $exporter >> $BASH_ENV
+          echo Recalled APP_VERSION = ${APP_VERSION}
     - deploy:
         command: |
           #!/usr/bin/env bash
@@ -430,14 +439,13 @@ jobs:
         path: build/reports/jacoco/test
   build_and_publish_docker:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: medium
     working_directory: ~/app
     steps:
     - checkout
     - setup_remote_docker:
         docker_layer_caching: true
-        version: 20.10.6
     - run:
         command: |
           DATE=$(date '+%Y-%m-%d')
@@ -502,14 +510,13 @@ jobs:
         name: Publish image to repository
   build_docker:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: medium
     working_directory: ~/app
     steps:
     - checkout
     - setup_remote_docker:
         docker_layer_caching: true
-        version: 20.10.6
     - run:
         command: |
           DATE=$(date '+%Y-%m-%d')
@@ -566,13 +573,12 @@ jobs:
         root: ~/app
   vulnerability_scan:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: medium
     working_directory: ~/app
     steps:
     - checkout
-    - setup_remote_docker:
-        version: 20.10.6
+    - setup_remote_docker
     - attach_workspace:
         at: ~/app
     - run:
@@ -738,7 +744,7 @@ jobs:
     - _JAVA_OPTIONS: -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
   tag_pact_version_preprod:
     docker:
-    - image: cimg/node:14.16-browsers
+    - image: cimg/node:16.17
     resource_class: medium
     working_directory: ~/app
     environment:
@@ -830,7 +836,7 @@ jobs:
     - _JAVA_OPTIONS: -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
   validate_helm:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: small
     working_directory: ~/app
     steps:
@@ -919,7 +925,7 @@ jobs:
         working_directory: helm_deploy
   deploy_preprod:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: small
     working_directory: ~/app
     steps:
@@ -1192,6 +1198,15 @@ jobs:
           DEPLOYMENT_CHANGELOG="$(<.deployment_changelog)"
           echo "export DEPLOYMENT_CHANGELOG_JSON=$(echo -n "$DEPLOYMENT_CHANGELOG" | tr '"' "'" | jq -Rs)" >> $BASH_ENV
         name: Store deployment changelog
+    - attach_workspace:
+        at: /tmp/circleci_remember
+    - run:
+        name: Recall APP_VERSION
+        command: |
+          exporter=$(cat /tmp/circleci_remember/.circleci_remember/APP_VERSION)
+          $exporter
+          echo $exporter >> $BASH_ENV
+          echo Recalled APP_VERSION = ${APP_VERSION}
     - deploy:
         command: |
           #!/usr/bin/env bash
@@ -1311,7 +1326,7 @@ jobs:
         when: always
   deploy_prod:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: small
     working_directory: ~/app
     steps:
@@ -1584,6 +1599,15 @@ jobs:
           DEPLOYMENT_CHANGELOG="$(<.deployment_changelog)"
           echo "export DEPLOYMENT_CHANGELOG_JSON=$(echo -n "$DEPLOYMENT_CHANGELOG" | tr '"' "'" | jq -Rs)" >> $BASH_ENV
         name: Store deployment changelog
+    - attach_workspace:
+        at: /tmp/circleci_remember
+    - run:
+        name: Recall APP_VERSION
+        command: |
+          exporter=$(cat /tmp/circleci_remember/.circleci_remember/APP_VERSION)
+          $exporter
+          echo $exporter >> $BASH_ENV
+          echo Recalled APP_VERSION = ${APP_VERSION}
     - deploy:
         command: |
           #!/usr/bin/env bash
@@ -1703,7 +1727,7 @@ jobs:
         when: always
   tag_pact_version_dev:
     docker:
-    - image: cimg/node:14.16-browsers
+    - image: cimg/node:16.17
     resource_class: medium
     working_directory: ~/app
     environment:
@@ -1718,7 +1742,7 @@ jobs:
             --broker-base-url="$PACT_BROKER_BASE_URL" --broker-username="$PACT_BROKER_USERNAME" --broker-password="$PACT_BROKER_PASSWORD"
   tag_pact_version_prod:
     docker:
-    - image: cimg/node:14.16-browsers
+    - image: cimg/node:16.17
     resource_class: medium
     working_directory: ~/app
     environment:
@@ -1733,16 +1757,16 @@ jobs:
             --broker-base-url="$PACT_BROKER_BASE_URL" --broker-username="$PACT_BROKER_USERNAME" --broker-password="$PACT_BROKER_PASSWORD"
   hmpps/veracode_policy_scan:
     docker:
-    - image: cimg/node:14.16-browsers
+    - image: cimg/openjdk:17.0
     resource_class: medium
     working_directory: ~/app
     steps:
     - setup_remote_docker:
         docker_layer_caching: true
-        version: 20.10.6
     - checkout
     - run:
         command: |
+          export DOCKER_BUILDKIT=1
           IMAGE_ID=$(docker build -q . --build-arg BUILD_NUMBER=$CIRCLE_SHA1 --build-arg GIT_REF=$CIRCLE_SHA1)
           docker cp $(docker create --rm ${IMAGE_ID}):/app ./temp_app
         name: Build temp docker image and copy app files
@@ -1813,15 +1837,16 @@ jobs:
           success_tagged_deploy_1: {snip}
         name: Slack - Sending Notification
         when: always
+    environment:
+    - _JAVA_OPTIONS: -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
   hmpps/trivy_latest_scan:
     docker:
-    - image: cimg/python:3.9
+    - image: cimg/python:3.10
     resource_class: medium
     working_directory: ~/app
     steps:
     - checkout
-    - setup_remote_docker:
-        version: 20.10.6
+    - setup_remote_docker
     - run:
         command: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp
@@ -1923,7 +1948,7 @@ jobs:
         when: always
   hmpps/gradle_owasp_dependency_check:
     docker:
-    - image: cimg/openjdk:11.0
+    - image: cimg/openjdk:17.0
     resource_class: medium
     working_directory: ~/app
     steps:
```
</details>

