### PR TITLE
Switch the dev environment to use PostgreSQL14

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,7 @@ ingress:
 
 env_details:
   contains_live_data: false
-  postgres_secret: postgres
+  postgres_secret: postgres14
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION
## What does this pull request do?

Switch the dev environment to use PostgreSQL 14

- Set up by https://github.com/ministryofjustice/cloud-platform-environments/pull/8809
- Migration script in https://github.com/ministryofjustice/hmpps-interventions-ops/pull/2

## What is the intent behind these changes?

We are migrating from PostgreSQL 10 (end of life in November 2022) to PostgreSQL 14 by switching to a new instance.

This step reconfigures the service so that it uses the new database configuration.