### PR TITLE
upgrade hmpps gradle spring boot to 4.5.5 to resolve vulnerability issue

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -20,3 +20,6 @@ CVE-2022-42003
 # Suppression for jackson databind 2.13.3 as bundled with application insights
 #   Can be suppressed as don't parse untrusted json in application insights
 CVE-2022-42004
+# Suppression for apache common-text 1.9 as bundled with application insights
+#   can be suppressed for the time being as it will be fixed in next version of application insights
+CVE-2022-42889

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.5"
   kotlin("plugin.spring") version "1.7.10"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.7.10"
   id("jacoco")


### PR DESCRIPTION
## What does this pull request do?

Upgrades hmpps gradle spring boot to the latest version of 4.5.5

## What is the intent behind these changes?

To suppress a vulnerability issue caused by apache common-text present in application insights
