### PR TITLE
Switch the preprod environment to use PostgreSQL14

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,7 +20,7 @@ ingress:
 
 env_details:
   contains_live_data: true
-  postgres_secret: postgres
+  postgres_secret: postgres14
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,7 +19,7 @@ env_details:
   contains_live_data: true
   production_env: true
   postgres_secret: postgres
-  postgres_preprod_refresh_secret: postgres
+  postgres_preprod_refresh_secret: postgres14
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION

## What does this pull request do?

Switch the preprod environment to use PostgreSQL14

Also, switch the Sunday database refresh job to copy into the new preprod database, not the old

- Set up by https://github.com/ministryofjustice/cloud-platform-environments/pull/8810
- Migration script in https://github.com/ministryofjustice/hmpps-interventions-ops/commit/73ef83cb4f43949a0819fa2ccad5c7305f14f5cd
- Related: #1237 

## What is the intent behind these changes?

We are migrating from PostgreSQL 10 (end of life in November 2022) to PostgreSQL 14 by switching to a new instance.

This step reconfigures the service so that it uses the new database configuration