### PR TITLE
Show all database versions in grafana

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1657529551498,
+  "iteration": 1666606677633,
   "links": [],
   "panels": [
     {
@@ -482,11 +482,65 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "",
+          "alias": "prod_v10",
           "dimensions": {
             "DBInstanceIdentifier": "cloud-platform-e4573fa1c83bbbb9"
           },
           "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "CPUUtilization",
+          "namespace": "AWS/RDS",
+          "period": "",
+          "refId": "prod_v10",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        },
+        {
+          "alias": "prod_v14",
+          "dimensions": {
+            "DBInstanceIdentifier": "cloud-platform-d6224bbb698ff221"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "matchExact": true,
+          "metricName": "CPUUtilization",
+          "namespace": "AWS/RDS",
+          "period": "",
+          "refId": "prod_v14",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        },
+        {
+          "alias": "preprod_v10",
+          "dimensions": {
+            "DBInstanceIdentifier": "cloud-platform-a326b0ca8eb97132"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "matchExact": true,
+          "metricName": "CPUUtilization",
+          "namespace": "AWS/RDS",
+          "period": "",
+          "refId": "B",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        },
+        {
+          "alias": "preprod_v14",
+          "dimensions": {
+            "DBInstanceIdentifier": "cloud-platform-6a9cfbef8ecc3a97"
+          },
+          "expression": "",
+          "hide": false,
           "id": "",
           "matchExact": true,
           "metricName": "CPUUtilization",
@@ -503,7 +557,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Production database CPU usage",
+      "title": "Database CPU usage",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
## What does this pull request do?

Show all database versions in [grafana](https://grafana.live.cloud-platform.service.justice.gov.uk/d/PyQ91ARnk/hmpps-refer-and-monitor-an-intervention?orgId=1).

**Before**: only PostgreSQL10 production database CPU is visible.
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/1526295/197505744-d41b0b6c-f59e-477b-b8d9-f46e5ccd9c88.png">


**After**: show all instances for preprod/prod and v10/v14 PostgreSQL.
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/1526295/197505686-4cc74eea-4fa8-4588-941c-4880e48e5195.png">


## What is the intent behind these changes?

So we can see and compare the usage of new/old PostgreSQL versions.