### PR TITLE
Switch the prod environment to use PostgreSQL14

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,7 +18,7 @@ ingress:
 env_details:
   contains_live_data: true
   production_env: true
-  postgres_secret: postgres
+  postgres_secret: postgres14
   postgres_preprod_refresh_secret: postgres14
 
 env:


### PR DESCRIPTION
**🚫 Please do not merge without coordinating in the dev Slack channel. 🚫** 

## What does this pull request do?

Switch the prod environment to use PostgreSQL14

- Set up by https://github.com/ministryofjustice/cloud-platform-environments/pull/8811
- Migration script in https://github.com/ministryofjustice/hmpps-interventions-ops/commit/73ef83cb4f43949a0819fa2ccad5c7305f14f5cd
- Related: #1259

## What is the intent behind these changes?

We are migrating from PostgreSQL 10 (end of life in November 2022) to PostgreSQL 14 by switching to a new instance.

This step reconfigures the service so that it uses the new database configuration