### PR TITLE
Stop testing against old version of PostgreSQL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,6 @@ _db_docker_config: &db_docker_config
       POSTGRES_PASSWORD: password
       POSTGRES_DB: interventions_ci
 
-_db_docker_config_postgres10: &db_docker_config_postgres10
-  - image: cimg/openjdk:17.0
-    environment:
-      POSTGRES_DB: interventions_ci
-  - image: circleci/postgres:10-alpine-ram
-    environment:
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: interventions_ci
-
 jobs:
   validate:
     executor:
@@ -58,59 +49,6 @@ jobs:
       name: hmpps/java
       tag: "17"
     docker: *db_docker_config
-    steps:
-      - checkout
-      - run:
-          name: Setup flyway and psql
-          command: |
-            wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/7.7.0/flyway-commandline-7.7.0-linux-x64.tar.gz | \
-              tar xvz && sudo ln -s `pwd`/flyway-7.7.0/flyway /usr/local/bin
-            sudo apt update
-            sudo apt install postgresql-client
-      - run:
-          name: Run main migrations then branch migrations to detect clashes
-          command: |
-            flyway clean -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password"
-            git reset --hard origin/main
-            flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration"
-            git reset --hard "$CIRCLE_SHA1"
-            flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration"
-      - run:
-          name: Run migrations and local seeds
-          command: |
-            flyway clean -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password"
-            flyway migrate -url="jdbc:postgresql://localhost:5432/$POSTGRES_DB" -user="postgres" -password="password" -locations="src/main/resources/db/migration,src/main/resources/db/local"
-      - run:
-          name: Validate metadata
-          command: |
-            PGPASSWORD="$POSTGRES_PASSWORD" script/validate-metadata.sh
-
-  validate_postgres10:
-    executor:
-      name: hmpps/java
-      tag: "17"
-    docker: *db_docker_config_postgres10
-    environment:
-      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=true -Dkotlin.compiler.execution.strategy=in-process
-    steps:
-      - checkout
-      - gradle/with_cache:
-          cache_checksum_file: "build.gradle.kts"
-          cache_key: v2
-          steps:
-            - run: ./gradlew check jacocoTestCoverageVerification
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/reports/tests
-      - store_artifacts:
-          path: build/reports/jacoco/test
-
-  validate_db_postgres10:
-    executor:
-      name: hmpps/java
-      tag: "17"
-    docker: *db_docker_config_postgres10
     steps:
       - checkout
       - run:
@@ -249,8 +187,6 @@ workflows:
   build_test_and_deploy:
     unless: << pipeline.parameters.only_pacts >>
     jobs:
-      - validate_postgres10
-      - validate_db_postgres10
       - validate
       - validate_db
       - publish_data:
@@ -288,8 +224,6 @@ workflows:
               only:
                 - main
           requires:
-            - validate_postgres10
-            - validate_db_postgres10
             - validate
             - validate_db
             - publish_data

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -33,25 +33,25 @@ env:
   - name: POSTGRES_URI
     valueFrom:
       secretKeyRef:
-        name: {{ .Values.env_details.postgres_secret }}
+        name: postgres14
         key: rds_instance_endpoint
 
   - name: POSTGRES_DB
     valueFrom:
       secretKeyRef:
-        name: {{ .Values.env_details.postgres_secret }}
+        name: postgres14
         key: database_name
 
   - name: POSTGRES_USERNAME
     valueFrom:
       secretKeyRef:
-        name: {{ .Values.env_details.postgres_secret }}
+        name: postgres14
         key: database_username
 
   - name: POSTGRES_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: {{ .Values.env_details.postgres_secret }}
+        name: postgres14
         key: database_password
 
   - name: AWS_SNS_ACCESSKEYID

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -18,22 +18,22 @@ spec:
               - name: PGHOST
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.env_details.postgres_secret }}
+                    name: postgres14
                     key: rds_instance_address
               - name: PGDATABASE
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.env_details.postgres_secret }}
+                    name: postgres14
                     key: database_name
               - name: PGUSER
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.env_details.postgres_secret }}
+                    name: postgres14
                     key: database_username
               - name: PGPASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.env_details.postgres_secret }}
+                    name: postgres14
                     key: database_password
               - name: S3_DESTINATION
                 valueFrom:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -36,7 +36,7 @@ spec:
             runAsUser: 999
           containers:
             - name: dbrefresh
-              image: "postgres:10"
+              image: "postgres:14"
               command:
                 - /bin/entrypoint.sh
               volumeMounts:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -48,42 +48,42 @@ spec:
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_secret }}
+                      name: postgres14
                       key: database_name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_secret }}
+                      name: postgres14
                       key: database_username
                 - name: DB_PASS
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_secret }}
+                      name: postgres14
                       key: database_password
                 - name: DB_HOST
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_secret }}
+                      name: postgres14
                       key: rds_instance_address
                 - name: DB_NAME_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_preprod_refresh_secret }}-preprod
+                      name: postgres14-preprod
                       key: database_name
                 - name: DB_USER_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_preprod_refresh_secret }}-preprod
+                      name: postgres14-preprod
                       key: database_username
                 - name: DB_PASS_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_preprod_refresh_secret }}-preprod
+                      name: postgres14-preprod
                       key: database_password
                 - name: DB_HOST_PREPROD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.env_details.postgres_preprod_refresh_secret }}-preprod
+                      name: postgres14-preprod
                       key: rds_instance_address
           restartPolicy: "Never"
           volumes:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,6 @@ ingress:
 
 env_details:
   contains_live_data: false
-  postgres_secret: postgres14
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,7 +20,6 @@ ingress:
 
 env_details:
   contains_live_data: true
-  postgres_secret: postgres14
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,8 +18,6 @@ ingress:
 env_details:
   contains_live_data: true
   production_env: true
-  postgres_secret: postgres14
-  postgres_preprod_refresh_secret: postgres14
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION
## What does this pull request do?

Stops testing against the old version of PostgreSQL (v10).

## What is the intent behind these changes?

We have completed the switchover to PostgreSQL 14. We no longer need to prove we work on v10.