### PR TITLE
Plot a smoothed 5m average over database CPU

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1666606677633,
+  "iteration": 1666785737464,
   "links": [],
   "panels": [
     {
@@ -547,6 +547,24 @@
           "namespace": "AWS/RDS",
           "period": "",
           "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        },
+        {
+          "alias": "prod_v14_5m_avg",
+          "dimensions": {
+            "DBInstanceIdentifier": "cloud-platform-d6224bbb698ff221"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "matchExact": true,
+          "metricName": "CPUUtilization",
+          "namespace": "AWS/RDS",
+          "period": "5m",
+          "refId": "C",
           "region": "default",
           "statistics": [
             "Average"


### PR DESCRIPTION
## What does this pull request do?

Plot a smoothed 5m average over the database CPU

**Before**
<img width="849" alt="image" src="https://user-images.githubusercontent.com/1526295/198022481-3894685f-85eb-4edd-9ff2-d57999619577.png">

**After**
<img width="840" alt="image" src="https://user-images.githubusercontent.com/1526295/198022608-1b351e93-131b-4b1c-b31d-6f97d2877b50.png">


## What is the intent behind these changes?

To better observe typical usage over longer periods (removes most spikes in load).
