### PR TITLE
Make frequency of requests visible on heatmaps

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -169,10 +169,10 @@
       "color": {
         "cardColor": "#FADE2A",
         "colorScale": "sqrt",
-        "colorScheme": "interpolateMagma",
+        "colorScheme": "interpolateSpectral",
         "exponent": 0.2,
         "min": null,
-        "mode": "opacity"
+        "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
       "datasource": null,
@@ -188,7 +188,7 @@
         "y": 1
       },
       "heatmap": {},
-      "hideZeroBuckets": false,
+      "hideZeroBuckets": true,
       "highlightCards": true,
       "id": 18,
       "legend": {
@@ -365,10 +365,10 @@
       "color": {
         "cardColor": "#B877D9",
         "colorScale": "sqrt",
-        "colorScheme": "interpolateMagma",
+        "colorScheme": "interpolateSpectral",
         "exponent": 0.2,
         "min": null,
-        "mode": "opacity"
+        "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
       "datasource": null,
@@ -384,7 +384,7 @@
         "y": 9
       },
       "heatmap": {},
-      "hideZeroBuckets": false,
+      "hideZeroBuckets": true,
       "highlightCards": true,
       "id": 20,
       "legend": {
@@ -606,10 +606,10 @@
       "color": {
         "cardColor": "#FF9830",
         "colorScale": "sqrt",
-        "colorScheme": "interpolateMagma",
+        "colorScheme": "interpolateSpectral",
         "exponent": 0.2,
         "min": null,
-        "mode": "opacity"
+        "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
       "datasource": null,
@@ -625,7 +625,7 @@
         "y": 17
       },
       "heatmap": {},
-      "hideZeroBuckets": false,
+      "hideZeroBuckets": true,
       "highlightCards": true,
       "id": 19,
       "legend": {


### PR DESCRIPTION

## What does this pull request do?

Changes heatmap from a single-colour scheme with a square root scale (good for showing if anything is happening) to a spectral colour scheme (good for identifying is something happens often or not).

Also, it hides zero values -- which will remove the "background" image and only render colour if there is a value.

| Before | After |
| --- | --- |
| <img width="851" alt="image" src="https://user-images.githubusercontent.com/1526295/198032227-51ffeb26-260d-4a4b-bef4-a8ef63309587.png"> | <img width="848" alt="image" src="https://user-images.githubusercontent.com/1526295/198032073-f9a09d77-3979-43e4-b3db-2812fa0c5b3f.png"> |


## What is the intent behind these changes?

To better visualise how often something happens.