### PR TITLE
Reduce awssdk dependency update volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
   open-pull-requests-limit: 10
   schedule:
     interval: "daily"
+  ignore:
+    - dependency-name: "software.amazon.awssdk:*"
+      update-types: ["version-update:semver-patch"]
 - package-ecosystem: docker
   directory: "/script"
   schedule:


### PR DESCRIPTION
## What does this pull request do?

Reduce awssdk dependency update volume by ignoring patch version changes.

## What is the intent behind these changes?

All of the AWS SDK libraries get updated simultaneously, and most of the time, the updates are irrelevant.

Any relevant updates will be posted via minor version changes.

Reimplements 3c7151d891748075b84a0723881259689d7e2418.
This "ignore" was removed when we moved to weekly updates.
Since we have moved back to daily updates for quicker plugin updates, this has become relevant again.