### PR TITLE
Update community-api error mapping with new types of NSI errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
@@ -47,6 +47,9 @@ class CommunityApiCallError(val httpStatus: HttpStatus, causeMessage: String, va
         category.contains("Cannot find NSI for CRN: _ Sentence: _ and ContractType".toRegex()) -> {
           "This update has not been possible. This is because there's been a change to the referral in non-structured interventions in nDelius. Ask the probation practitioner if anything has changed with the referral or the person on probation"
         }
+        category.contains("Multiple existing URN NSIs found".toRegex()) -> {
+          "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support"
+        }
         category.contains("Multiple existing matching NSIs found".toRegex()) -> {
           "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support"
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
@@ -31,6 +31,9 @@ class CommunityApiCallError(val httpStatus: HttpStatus, causeMessage: String, va
   RuntimeException(
     exception
   ) {
+  private val uuidRegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}".toRegex()
+  private val identifiersRegex = "[A-Z]*[0-9]+".toRegex()
+
   val category = errorCategoryByRemovingIdentifiers(causeMessage)
   val userMessage = when {
     httpStatus.is4xxClientError -> {
@@ -70,6 +73,8 @@ class CommunityApiCallError(val httpStatus: HttpStatus, causeMessage: String, va
   }
 
   private fun errorCategoryByRemovingIdentifiers(message: String): String {
-    return "[A-Z]*[0-9]+".toRegex().replace(message, "_")
+    return message
+      .let { uuidRegex.replace(it, "_") }
+      .let { identifiersRegex.replace(it, "_") }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallError.kt
@@ -17,16 +17,7 @@ res.body={"status":400,"developerMessage":"Cannot find NSI for CRN: M190420 Sent
 res.body=409 Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/E188275/sentence/1503090023/appointments/context/commissioned-rehabilitation-services
 6) Reschedule appointment conflict
 res.body=409 Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/D889766/appointments/1761440075/reschedule/context/commissioned-rehabilitation-services
-
-Error categories after (Replace [A-Z]*[0-9]+ with _ and Replace '[A-Z0-9]*' with '_')
-=====================================================================================
-1) Contact type '_' requires an outcome type as the contact date is in the past '_-_-_'
-2) Validation failure: startTime endTime must be after or equal to startTime, endTime endTime must be after or equal to startTime"
-3) CRN: _ EventId: _ has multiple referral requirements
-4) Cannot find NSI for CRN: _ Sentence: _ and ContractType ACC
-5) _ Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/_/sentence/_/appointments/context/commissioned-rehabilitation-services
-6) _ Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/_/appointments/_/reschedule/context/commissioned-rehabilitation-services*/
-
+*/
 class CommunityApiCallError(val httpStatus: HttpStatus, causeMessage: String, val responseBody: String, val exception: Throwable) :
   RuntimeException(
     exception

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
@@ -46,14 +46,14 @@ internal class CommunityApiCallErrorTest {
       ),
       Example(
         response = BAD_REQUEST,
-        causeMessage = "Multiple existing URN NSIs found",
-        expectedCategory = "Multiple existing URN NSIs found",
+        causeMessage = "Multiple existing URN NSIs found for referral: e2eb5e02-6e6f-4c34-8be9-b0525ea78c5a, NSI IDs: [3182407, 3182408]",
+        expectedCategory = "Multiple existing URN NSIs found for referral: _, NSI IDs: [_, _]",
         expectedUserMessage = "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support",
       ),
       Example(
         response = BAD_REQUEST,
-        causeMessage = "Multiple existing matching NSIs found",
-        expectedCategory = "Multiple existing matching NSIs found",
+        causeMessage = "Multiple existing matching NSIs found for referral: e2eb5e02-6e6f-4c34-8be9-b0525ea78c5a, NSI IDs: [3182407, 3182408]",
+        expectedCategory = "Multiple existing matching NSIs found for referral: _, NSI IDs: [_, _]",
         expectedUserMessage = "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support",
       ),
       Example(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
@@ -51,6 +51,15 @@ internal class CommunityApiCallErrorTest {
     assertThat(
       CommunityApiCallError(
         BAD_REQUEST,
+        "Multiple existing URN NSIs found",
+        "{}",
+        RuntimeException()
+      ).userMessage
+    ).isEqualTo("There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support")
+
+    assertThat(
+      CommunityApiCallError(
+        BAD_REQUEST,
         "Multiple existing matching NSIs found",
         "{}",
         RuntimeException()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/exception/CommunityApiCallErrorTest.kt
@@ -2,104 +2,91 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.GONE
 import org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE
 
 internal class CommunityApiCallErrorTest {
+  data class Example(
+    val response: HttpStatus,
+    val causeMessage: String,
+    val expectedCategory: String,
+    val expectedUserMessage: String
+  )
 
   @Test
-  fun `maps user message to category`() {
+  fun `maps incoming community-api errors into normalised categories and user messages`() {
+    // TODO: user message resolution does not belong to a system-facing API; give 'translatable' codes instead
+    val examples = listOf(
+      Example(
+        response = BAD_REQUEST,
+        causeMessage = "Contact type 'CRSSAA' requires an outcome type as the contact date is in the past '2021-06-29'",
+        expectedCategory = "Contact type 'CRSSAA' requires an outcome type as the contact date is in the past '_-_-_'",
+        expectedUserMessage = "Delius requires an appointment to only be made for today or in the future. Please amend and try again",
+      ),
+      Example(
+        response = BAD_REQUEST,
+        causeMessage = "Validation failure: startTime endTime must be after or equal to startTime, endTime endTime must be after or equal to startTime",
+        expectedCategory = "Validation failure: startTime endTime must be after or equal to startTime, endTime endTime must be after or equal to startTime",
+        expectedUserMessage = "Delius requires that an appointment must end on the same day it starts. Please amend and try again",
+      ),
+      Example(
+        response = BAD_REQUEST,
+        causeMessage = "CRN: E376578 EventId: 1502929161 has multiple referral requirements",
+        expectedCategory = "CRN: _ EventId: _ has multiple referral requirements",
+        expectedUserMessage = "The Service User Sentence must not contain more than one active rehabilitation activity requirement. Please correct in Delius and try again",
+      ),
+      Example(
+        response = BAD_REQUEST,
+        causeMessage = "Cannot find NSI for CRN: M190420 Sentence: 1503032340 and ContractType ACC",
+        expectedCategory = "Cannot find NSI for CRN: _ Sentence: _ and ContractType ACC",
+        expectedUserMessage = "This update has not been possible. This is because there's been a change to the referral in non-structured interventions in nDelius. Ask the probation practitioner if anything has changed with the referral or the person on probation",
+      ),
+      Example(
+        response = BAD_REQUEST,
+        causeMessage = "Multiple existing URN NSIs found",
+        expectedCategory = "Multiple existing URN NSIs found",
+        expectedUserMessage = "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support",
+      ),
+      Example(
+        response = BAD_REQUEST,
+        causeMessage = "Multiple existing matching NSIs found",
+        expectedCategory = "Multiple existing matching NSIs found",
+        expectedUserMessage = "There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support",
+      ),
+      Example(
+        response = CONFLICT,
+        causeMessage = "409 Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/E188275/sentence/1503090023/appointments/context/commissioned-rehabilitation-services",
+        expectedCategory = "_ Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/_/sentence/_/appointments/context/commissioned-rehabilitation-services",
+        expectedUserMessage = "The appointment conflicts with another. Please contact the service user's probation practitioner for an available slot and try again",
+      ),
+      Example(
+        response = CONFLICT,
+        causeMessage = "409 Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/D889766/appointments/1761440075/reschedule/context/commissioned-rehabilitation-services",
+        expectedCategory = "_ Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/_/appointments/_/reschedule/context/commissioned-rehabilitation-services",
+        expectedUserMessage = "The appointment conflicts with another. Please contact the service user's probation practitioner for an available slot and try again",
+      ),
+      Example(
+        response = GONE,
+        causeMessage = "An unrecognised issue 'A123' and 234566",
+        expectedCategory = "An unrecognised issue '_' and _",
+        expectedUserMessage = "Delius reported \"An unrecognised issue 'A123' and 234566\". Please correct, if possible, otherwise contact support",
+      ),
+      Example(
+        response = SERVICE_UNAVAILABLE,
+        causeMessage = "Any message",
+        expectedCategory = "Any message",
+        expectedUserMessage = "System is experiencing issues. Please try again later and if the issue persists contact Support",
+      ),
+    )
 
-    assertThat(
-      CommunityApiCallError(
-        BAD_REQUEST,
-        "Contact type 'CRSSAA' requires an outcome type as the contact date is in the past '2021-06-29'",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("Delius requires an appointment to only be made for today or in the future. Please amend and try again")
+    examples.forEach { example ->
+      val error = CommunityApiCallError(example.response, example.causeMessage, "{}", RuntimeException())
 
-    assertThat(
-      CommunityApiCallError(
-        BAD_REQUEST,
-        "Validation failure: startTime endTime must be after or equal to startTime, endTime endTime must be after or equal to startTime",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("Delius requires that an appointment must end on the same day it starts. Please amend and try again")
-
-    assertThat(
-      CommunityApiCallError(
-        BAD_REQUEST,
-        "CRN: E376578 EventId: 1502929161 has multiple referral requirements",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("The Service User Sentence must not contain more than one active rehabilitation activity requirement. Please correct in Delius and try again")
-
-    assertThat(
-      CommunityApiCallError(
-        BAD_REQUEST,
-        "Cannot find NSI for CRN: M190420 Sentence: 1503032340 and ContractType ACC",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("This update has not been possible. This is because there's been a change to the referral in non-structured interventions in nDelius. Ask the probation practitioner if anything has changed with the referral or the person on probation")
-
-    assertThat(
-      CommunityApiCallError(
-        BAD_REQUEST,
-        "Multiple existing URN NSIs found",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support")
-
-    assertThat(
-      CommunityApiCallError(
-        BAD_REQUEST,
-        "Multiple existing matching NSIs found",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("There has been an error during creating the Delius NSI. We are aware of this issue. For follow-up, please contact support")
-
-    assertThat(
-      CommunityApiCallError(
-        CONFLICT,
-        "409 Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/E188275/sentence/1503090023/appointments/context/commissioned-rehabilitation-services",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("The appointment conflicts with another. Please contact the service user's probation practitioner for an available slot and try again")
-
-    assertThat(
-      CommunityApiCallError(
-        CONFLICT,
-        "409 Conflict from POST https://community-api-secure.probation.service.justice.gov.uk/secure/offenders/crn/D889766/appointments/1761440075/reschedule/context/commissioned-rehabilitation-services",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("The appointment conflicts with another. Please contact the service user's probation practitioner for an available slot and try again")
-
-    assertThat(
-      CommunityApiCallError(
-        GONE,
-        "An unrecognised issue 'A123' and 234566",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("Delius reported \"An unrecognised issue 'A123' and 234566\". Please correct, if possible, otherwise contact support")
-
-    assertThat(
-      CommunityApiCallError(
-        SERVICE_UNAVAILABLE,
-        "Any message",
-        "{}",
-        RuntimeException()
-      ).userMessage
-    ).isEqualTo("System is experiencing issues. Please try again later and if the issue persists contact Support")
+      assertThat(error.userMessage).isEqualTo(example.expectedUserMessage)
+      assertThat(error.category).isEqualTo(example.expectedCategory)
+    }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Update community-api error mapping with new types of NSI errors.

https://github.com/ministryofjustice/community-api/pull/753 changed duplicate NSI errors:

| Before | After |
| --- | --- |
| `Multiple existing matching NSIs found` | `Multiple existing matching NSIs found for referral: 13e65790-afc4-4059-a0af-3424d58eb3d2, NSI IDs: [3162979, 3163339]` |
| did not exist before | `Multiple existing URN NSIs found for referral: e2eb5e02-6e6f-4c34-8be9-b0525ea78c5a, NSI IDs: [3182407, 3182408] ` |

This PR adds the mapping for these changes.

## What is the intent behind these changes?

1. Provide the same user message as the previous duplicate NSI message.
2. Change Sentry errors:
    - from: `Call to community api failed [Multiple existing URN NSIs found for referral: e_eb_e_-_e_f-_c_-_be_-b_ea_c_a, NSI IDs: [_, _]]`
    - to: `Call to community api failed [Multiple existing URN NSIs found for referral: _, NSI IDs: [_, _]]`