### PR TITLE
Refactor: inline creating send-related fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -352,11 +352,7 @@ class DraftReferralService(
   }
 
   fun sendDraftReferral(draftReferral: DraftReferral, user: AuthUser): Referral {
-    val referral = createReferral(draftReferral)
-    referral.sentAt = OffsetDateTime.now()
-    referral.sentBy = authUserRepository.save(user)
-
-    referral.referenceNumber = generateReferenceNumber(draftReferral)
+    val referral = createSentReferral(draftReferral, user)
 
     /*
      * This is a temporary solution until a robust asynchronous link is created between Interventions
@@ -376,7 +372,8 @@ class DraftReferralService(
     return sentReferral
   }
 
-  private fun createReferral(draftReferral: DraftReferral): Referral {
+  private fun createSentReferral(draftReferral: DraftReferral, sentByUser: AuthUser): Referral {
+    val sentBy = authUserRepository.save(sentByUser)
     return Referral(
       id = draftReferral.id,
       furtherInformation = draftReferral.furtherInformation,
@@ -395,6 +392,9 @@ class DraftReferralService(
       createdBy = draftReferral.createdBy,
       createdAt = draftReferral.createdAt,
       referralDetailsHistory = draftReferral.referralDetailsHistory,
+      referenceNumber = generateReferenceNumber(draftReferral),
+      sentAt = OffsetDateTime.now(),
+      sentBy = sentBy,
     )
   }
 


### PR DESCRIPTION

## What does this pull request do?

Creating the new "sent" referral creates the object and the send-related fields.

However, this is one semantic operation: we can do it in the function responsible for creating the "sent" referral.

## What is the intent behind these changes?

To improve cohesion by grouping related activities under a single function.