### PR TITLE
Upgrade to hibernate-types-55 to match hibernate version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.hibernate:hibernate-core:5.6.14.Final")
-  implementation("com.vladmihalcea:hibernate-types-52:2.20.0")
+  implementation("com.vladmihalcea:hibernate-types-55:2.20.0")
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql:42.5.0")
 


### PR DESCRIPTION
## What does this pull request do?

According to https://github.com/vladmihalcea/hibernate-types,

- `hibernate-types-52` is for Hibernate 5.4, 5.3 and 5.2
- `hibernate-types-55` is for Hibernate 5.6 and 5.5

We are on Hibernate 5.6.x.

## What is the intent behind these changes?

Better compatibility across the board.