### PR TITLE
Restore old ingress (to allow migration of new ingress to different version)

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
@@ -17,7 +17,11 @@ metadata:
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
 spec:
+  {{- if .Values.env_details.contains_live_data }}
   ingressClassName: modsec
+  {{- else }}
+  ingressClassName: default
+  {{- end }}
   tls:
   {{- range .Values.ingress.hosts }}
   - hosts:

--- a/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress.yaml
@@ -1,0 +1,56 @@
+{{- $fullName := include "app.name" . -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-{{ .Values.ingress.migration.colour }}
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    {{- if .Values.env_details.contains_live_data }}
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-transaction-id: "$request_id"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
+    {{- else }}
+    kubernetes.io/ingress.class: "nginx"
+    {{- end }}
+spec:
+  tls:
+  {{- range .Values.ingress.hosts }}
+  - hosts:
+    - {{ .host }}
+    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          - path: /prometheus
+            backend:
+              serviceName: default-http-backend
+              servicePort: 80
+          - path: /sent-referrals
+            backend:
+              serviceName: {{ $fullName }}-dashboard
+              servicePort: http
+          - path: /reports/service-provider/performance
+            backend:
+              serviceName: {{ $fullName }}-performance-report
+              servicePort: http
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}-api
+              servicePort: http
+          - path: /meta/schema
+            backend:
+              serviceName: {{ $fullName }}-data-dictionary
+              servicePort: http
+  {{- end }}


### PR DESCRIPTION
## What does this pull request do?

Restores the old ingress.

It also turns off ModSecurity in the development environment.

## What is the intent behind these changes?

The new Ingress resource must have `apiVersion: networking.k8s.io/v1`.

Restoring the old ingress ensures there will be one ingress up when the migration to the new version happens.