### PR TITLE
Show slowest API requests by frequency

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1666785737464,
+  "iteration": 1668605071782,
   "links": [],
   "panels": [
     {
@@ -961,7 +961,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(10, quantile(0.99, increase(http_server_requests_seconds_sum{namespace='$namespace'}[5m])) by (uri))",
+          "expr": "topk(3,\n  quantile(0.99, \n    increase(http_server_requests_seconds_sum{namespace='$namespace'}[5m])\n    /increase(http_server_requests_seconds_count{namespace='$namespace'}[5m])\n  ) by (uri)\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -973,7 +973,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Longest API requests (99th percentile)",
+      "title": "Slowest API requests (99th percentile)",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
## What does this pull request do?

Previously `increase(http_server_requests_seconds_sum{})` plotted the overall time spent on these requests.

Now, `sum/count` will correctly identify infrequent API requests that take a long time.

**Before**
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/1526295/202195420-f1dc08ed-c88d-4c4b-8187-f0a06b813e9b.png">

**After**
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/1526295/202195356-7f3dfe2f-5ea4-49ce-866d-ef6b17f4cf0a.png">



## What is the intent behind these changes?

To correctly plot slow requests.