### PR TITLE
Allow adding groups for upcoming contracts ahead-of-time

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/GetServiceProviderReferralsSummaryEndPoint.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/GetServiceProviderReferralsSummaryEndPoint.kt
@@ -165,8 +165,6 @@ class GetServiceProviderReferralsSummaryEndPoint : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "unidentified provider 'HOME_TRUST': group does not exist in the reference data",
-      "unidentified contract '0999': group does not exist in the reference data",
       "no valid service provider groups associated with user",
       "no valid contract groups associated with user"
       ]}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/ListReferralEndpoints.kt
@@ -166,8 +166,6 @@ class ListReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "unidentified provider 'HOME_TRUST': group does not exist in the reference data",
-      "unidentified contract '0999': group does not exist in the reference data",
       "no valid service provider groups associated with user",
       "no valid contract groups associated with user"
       ]}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/SingleReferralEndpoints.kt
@@ -220,8 +220,6 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "unidentified provider 'BETTER_LTD': group does not exist in the reference data",
-      "unidentified contract '0002': group does not exist in the reference data",
       "no valid service provider groups associated with user",
       "no valid contract groups associated with user"
       ]}
@@ -334,7 +332,6 @@ class SingleReferralEndpoints : IntegrationTestBase() {
     response.expectBody().json(
       """
       {"accessErrors": [
-      "unidentified contract '0002': group does not exist in the reference data",
       "no valid contract groups associated with user"
       ]}
       """.trimIndent()


### PR DESCRIPTION
## What does this pull request do?

Do not block authorisation on unrecognised groups.
This allows adding groups for upcoming contracts ahead of release.

Splits `WorkingScope` into `warnings` and `errors` to allow tracking of the severity of problems.

`resolveProviders` and `resolveContracts` will produce `warnings`, as an `INT_SP_WHATEVER` should not affect someone's ability to log in, as long as they have valid other groups.

Tracks warnings produced during login via a new `InterventionsAuthorizationWarning` telemetry event.

## What is the intent behind these changes?

We added user groups ahead of adding the provider and contract data live.

The unintended consequence was that these **users with unrecognised groups could not log in**, with similar errors: `[unidentified provider 'TEST': group does not exist in the reference data, unidentified contract 'PRJ_1234_X': group does not exist in the reference data]`

Extra (unused) groups should not affect anyone's login.

## References

- Discussion: https://mojdt.slack.com/archives/C035X1KC03U/p1669823578028399