### PR TITLE
fixing flyway db error in DB

### DIFF
--- a/src/main/resources/db/migration/V1_121__remove_duplicates_in_desired_outcomes_for_FBD.sql
+++ b/src/main/resources/db/migration/V1_121__remove_duplicates_in_desired_outcomes_for_FBD.sql
@@ -1,3 +1,5 @@
+DELETE from referral_desired_outcome where desired_outcome_id = 'af1d6c9c-bcdd-4e9f-a778-5c1a1e90163c';
+
 DELETE from desired_outcome where id in (
 'af1d6c9c-bcdd-4e9f-a778-5c1a1e90163c',
 'ff927255-28df-4a1d-8076-9ce18d959442',


### PR DESCRIPTION
## What does this pull request do?

- deletes one of the dependant rows from the referral desired outcomes table 

## What is the intent behind these changes?

- The flyway db migration is failing due to dependant row not being deleted. So we need to delete the row from the table

The problem here is we tried to delete some data from the desired outcomes table which are duplicates using the following query.

`DELETE from desired_outcome where id in ( 'af1d6c9c-bcdd-4e9f-a778-5c1a1e90163c', 'ff927255-28df-4a1d-8076-9ce18d959442', '8ec86c5f-0788-446a-bc4b-108e1c83dc25', '7058935b-cc4d-43a9-8bf5-a0ef4575d746', 'f869b53d-14d6-48bf-842f-f988ef845ee6', 'd8fb1e8d-43db-4a42-abda-0c64116ab441', '86656efa-de29-4a58-b7d0-25c8ac1a15b4');`

and one of the ids `'af1d6c9c-bcdd-4e9f-a778-5c1a1e90163c',` is referred in referral_desired_outcome table and was throwing foreign key constraint violation error. This id will be present in preprod and prod as well.

So we need to delete this row from referral_desired_outcome table before we run the previous delete command. So, I added the below command to the same file

`V1_121__remove_duplicates_in_desired_outcomes_for_FBD`

`DELETE from referral_desired_outcome where desired_outcome_id = 'af1d6c9c-bcdd-4e9f-a778-5c1a1e90163c';`

This is causing the flyway migration as the checksum failed. Is there any way to repair this in circle ci
  
