### PR TITLE
Make changelog migration job callable by CronJob

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/migration/ChangelogMigrationJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/migration/ChangelogMigrationJobConfiguration.kt
@@ -12,8 +12,10 @@ import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
 
@@ -23,8 +25,13 @@ class ChangelogMigrationJobConfiguration(
   private val jobBuilderFactory: JobBuilderFactory,
   private val stepBuilderFactory: StepBuilderFactory,
   private val jobListener: ChangelogMigrationJobListener,
+  private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
   @Value("\${spring.batch.jobs.migration.changelog.chunk-size}") private val chunkSize: Int
 ) {
+  @Bean
+  fun changelogMigrationJobLauncher(changelogMigrationJob: Job): ApplicationRunner {
+    return onStartupJobLauncherFactory.makeBatchLauncher(changelogMigrationJob)
+  }
 
   @Bean
   @JobScope


### PR DESCRIPTION

## What does this pull request do?

Fixes #1286's job launching


## What is the intent behind these changes?

This hook was missing, causing the
`migrate-referral-details-to-changelog` cronjob (instead of exiting with error!) to spin up the API instead and get stuck.
