### PR TITLE
add flag for running migrate changelog

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-migrate-referral-details-to-changelog-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-migrate-referral-details-to-changelog-report.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.env_details.migrate_change_log -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -21,3 +22,4 @@ spec:
           volumes:
             - name: heap-dumps
               emptyDir: {}
+{{- end }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ ingress:
 
 env_details:
   contains_live_data: false
+  migrate_change_log: true
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,6 +20,7 @@ ingress:
 
 env_details:
   contains_live_data: true
+  migrate_change_log: true
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,6 +18,7 @@ ingress:
 env_details:
   contains_live_data: true
   production_env: true
+  migrate_change_log: false
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION
## What does this pull request do?

Adds a flag based to decide if to run the change log migration cronjob based on environment. 

## What is the intent behind these changes?

Allows us to control when the cron job is run.
