### PR TITLE
add timestamp incremented to job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/migration/ChangelogMigrationJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/migration/ChangelogMigrationJobConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Changelog
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
 
 @Configuration
 @EnableBatchProcessing
@@ -49,6 +50,7 @@ class ChangelogMigrationJobConfiguration(
   @Bean
   fun changelogMigrationJob(migrateChangelogStep: Step): Job {
     return jobBuilderFactory["changelogMigrationJob"]
+      .incrementer(TimestampIncrementer())
       .listener(jobListener)
       .start(migrateChangelogStep)
       .build()


### PR DESCRIPTION
## What does this pull request do?

Adds a timestamp incrementer to the change log migration job

## What is the intent behind these changes?

Allows every job run to be given a unique name
