### PR TITLE
Save into auth table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -164,7 +164,7 @@ class DraftReferralService(
         null,
         referral.id,
         referral.createdAt,
-        actor.id,
+        authUserRepository.save(actor).id,
         update.reasonForChange,
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -224,7 +224,7 @@ class ReferralService(
       null,
       referral.id,
       OffsetDateTime.now(),
-      actor.id,
+      authUserRepository.save(actor).id,
       update.reasonForChange,
       existingDetails?.completionDeadline,
       existingDetails?.furtherInformation,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
@@ -710,7 +710,7 @@ class DraftReferralServiceUnitTest {
 
       // there is no existing referral details for this referral id
       whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(null)
-
+      whenever(authUserRepository.save(draftReferral.createdBy)).thenReturn(draftReferral.createdBy)
       whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
 
       draftReferralService.updateDraftReferral(
@@ -789,6 +789,7 @@ class DraftReferralServiceUnitTest {
 
       whenever(referralDetailsRepository.findLatestByReferralId(draftReferral.id)).thenReturn(null)
       whenever(draftReferralRepository.save(any())).thenReturn(draftReferral)
+      whenever(authUserRepository.save(draftReferral.createdBy)).thenReturn(draftReferral.createdBy)
 
       draftReferralService.updateDraftReferral(
         draftReferral,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -209,6 +209,7 @@ class ReferralServiceUnitTest {
       )
 
       whenever(referralDetailsRepository.findLatestByReferralId(referral.id)).thenReturn(existingDetails)
+      whenever(authUserRepository.save(referral.createdBy)).thenReturn(referral.createdBy)
 
       val returnedValue = referralService.updateReferralDetails(
         referral,


### PR DESCRIPTION
## What does this pull request do?

Saves into the auth table whenever we are creating a referral detail object. (This is the result of having no foreign key on this table)

## What is the intent behind these changes?

Enforced that there is always a row in the auth table for users performing actions regarding refferal details.
