### PR TITLE
Renamed CountSessionsAttempted to CountSessionsWithAttendanceRecord

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -14,7 +14,7 @@ interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
       "where sesh.referral.id = :referralId and appt.attended is not null " +
       "and appt.appointmentFeedbackSubmittedAt is not null and appt.superseded is false"
   )
-  fun countNumberOfAttemptedSessions(referralId: UUID): Int
+  fun countNumberOfSessionsWithAttendanceRecord(referralId: UUID): Int
 
   @Query(
     "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -47,8 +47,8 @@ class ReferralConcluder(
     if (deliveredFirstSubstantiveAppointment(referral) && endRequested)
       return true
 
-    val numberOfAttemptedSessions = countSessionsAttempted(referral)
-    val allSessionsHaveAttendance = totalNumberOfSessions == numberOfAttemptedSessions
+    val numberOfSessionsWithAttendanceRecord = countSessionsWithAttendanceRecord(referral)
+    val allSessionsHaveAttendance = totalNumberOfSessions == numberOfSessionsWithAttendanceRecord
     if (allSessionsHaveAttendance)
       return true
 
@@ -63,10 +63,10 @@ class ReferralConcluder(
     if (!deliveredFirstSubstantiveAppointment(referral))
       return CANCELLED
 
-    val numberOfAttemptedSessions = countSessionsAttempted(referral)
+    val numberOfSessionsWithAttendanceRecord = countSessionsWithAttendanceRecord(referral)
     val totalNumberOfSessions = referral.currentActionPlan?.numberOfSessions ?: 0
-    val someSessionsHaveNoAttendance = totalNumberOfSessions > numberOfAttemptedSessions
-    val allSessionsHaveAttendance = totalNumberOfSessions == numberOfAttemptedSessions
+    val someSessionsHaveNoAttendance = totalNumberOfSessions > numberOfSessionsWithAttendanceRecord
+    val allSessionsHaveAttendance = totalNumberOfSessions == numberOfSessionsWithAttendanceRecord
     val hasSubmittedEndOfServiceReport = referral.endOfServiceReport?.submittedAt?.let { true } ?: false
 
     if (someSessionsHaveNoAttendance && hasSubmittedEndOfServiceReport)
@@ -78,8 +78,8 @@ class ReferralConcluder(
     return null
   }
 
-  private fun countSessionsAttempted(referral: Referral): Int {
-    return actionPlanRepository.countNumberOfAttemptedSessions(referral.id)
+  private fun countSessionsWithAttendanceRecord(referral: Referral): Int {
+    return actionPlanRepository.countNumberOfSessionsWithAttendanceRecord(referral.id)
   }
 
   private fun countSessionsAttended(referral: Referral): Int {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepositoryTest.kt
@@ -24,7 +24,7 @@ class ActionPlanRepositoryTest @Autowired constructor(
   private val referralFactory = ReferralFactory(entityManager)
 
   @Test
-  fun `count number of attempted appointments`() {
+  fun `count number of appointments with recorded attendances`() {
     val referral1 = referralFactory.createSent()
     (1..4).forEach {
       deliverySessionFactory.createAttended(referral = referral1, sessionNumber = it)
@@ -32,8 +32,8 @@ class ActionPlanRepositoryTest @Autowired constructor(
     val referral2 = referralFactory.createSent()
     deliverySessionFactory.createAttended(referral = referral2)
 
-    assertThat(actionPlanRepository.countNumberOfAttemptedSessions(referral1.id)).isEqualTo(4)
-    assertThat(actionPlanRepository.countNumberOfAttemptedSessions(referral2.id)).isEqualTo(1)
+    assertThat(actionPlanRepository.countNumberOfSessionsWithAttendanceRecord(referral1.id)).isEqualTo(4)
+    assertThat(actionPlanRepository.countNumberOfSessionsWithAttendanceRecord(referral2.id)).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -40,7 +40,7 @@ internal class ReferralConcluderTest {
     val actionPlan = actionPlanFactory.create(numberOfSessions = totalSessions)
     val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     whenever(actionPlanRepository.countNumberOfAttendedSessions(referral.id)).thenReturn(attendedOrLate)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(referral.id)).thenReturn(attendedOrLate + didNotAttend)
+    whenever(actionPlanRepository.countNumberOfSessionsWithAttendanceRecord(referral.id)).thenReturn(attendedOrLate + didNotAttend)
     return referral
   }
 
@@ -56,106 +56,106 @@ internal class ReferralConcluderTest {
   }
 
   @Test
-  fun `concludes referral as cancelled when ending a referral with no sessions attempted`() {
+  fun `concludes referral as cancelled when ending a referral with no sessions with recorded attendances`() {
     val timeAtStart = OffsetDateTime.now()
-    val referralWithActionPlanAndNoAttemptedSessions =
+    val referralWithActionPlanAndNoSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 0, didNotAttend = 0)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoSessionsWithAttendanceRecord)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoAttemptedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndNoAttemptedSessions, ReferralEventType.CANCELLED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoSessionsWithAttendanceRecord, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndNoSessionsWithAttendanceRecord, ReferralEventType.CANCELLED)
   }
 
   @Test
   fun `concludes referral as cancelled when ending a referral without a substantive appointment (only not attended sessions)`() {
     val timeAtStart = OffsetDateTime.now()
-    val referralWithActionPlanAndNoAttemptedSessions =
+    val referralWithActionPlanAndNoSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 0, didNotAttend = 2)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndNoSessionsWithAttendanceRecord)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoAttemptedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndNoAttemptedSessions, ReferralEventType.CANCELLED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndNoSessionsWithAttendanceRecord, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndNoSessionsWithAttendanceRecord, ReferralEventType.CANCELLED)
   }
 
   @Test
   fun `concludes referral as prematurely ended when ending a referral with a substantive appointment and an end of service report submitted`() {
     val timeAtStart = OffsetDateTime.now()
-    val referralWithActionPlanAndSomeAttemptedSessions =
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
-    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    referralWithActionPlanAndSomeSessionsWithAttendanceRecord.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttemptedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndSomeAttemptedSessions, ReferralEventType.PREMATURELY_ENDED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeSessionsWithAttendanceRecord, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeSessionsWithAttendanceRecord, ReferralEventType.PREMATURELY_ENDED)
   }
 
   @Test
   fun `concludes referral as completed when ending a referral when all sessions have some kind of attendance and has an end service report submitted`() {
     val timeAtStart = OffsetDateTime.now()
-    val referralWithActionPlanAndSomeAttemptedSessions =
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
-    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    referralWithActionPlanAndSomeSessionsWithAttendanceRecord.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttemptedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndSomeAttemptedSessions, ReferralEventType.COMPLETED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeSessionsWithAttendanceRecord, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeSessionsWithAttendanceRecord, ReferralEventType.COMPLETED)
   }
 
   @Test
   fun `concludes referral as completed when ending a referral when all sessions have been attended and has an end service report submitted`() {
     val timeAtStart = OffsetDateTime.now()
-    val referralWithActionPlanAndSomeAttemptedSessions =
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 2, didNotAttend = 0)
-    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+    referralWithActionPlanAndSomeSessionsWithAttendanceRecord.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
-    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeAttemptedSessions, timeAtStart)
-    verifyEventPublished(referralWithActionPlanAndSomeAttemptedSessions, ReferralEventType.COMPLETED)
+    verifySaveWithConcludedAtSet(referralWithActionPlanAndSomeSessionsWithAttendanceRecord, timeAtStart)
+    verifyEventPublished(referralWithActionPlanAndSomeSessionsWithAttendanceRecord, ReferralEventType.COMPLETED)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with some sessions attempted and an end of service report has not been submitted`() {
-    val referralWithActionPlanAndSomeAttemptedSessions =
+  fun `does not conclude a referral when ending a referral with some sessions with recorded attendances and an end of service report has not been submitted`() {
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
-    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
+    referralWithActionPlanAndSomeSessionsWithAttendanceRecord.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report has not been submitted`() {
-    val referralWithActionPlanAndSomeAttemptedSessions =
+  fun `does not conclude a referral when ending a referral with all sessions with recorded attendances and an end of service report has not been submitted`() {
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
-    referralWithActionPlanAndSomeAttemptedSessions.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
+    referralWithActionPlanAndSomeSessionsWithAttendanceRecord.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with some sessions attempted and an end of service report does not exist`() {
-    val referralWithActionPlanAndSomeAttemptedSessions =
+  fun `does not conclude a referral when ending a referral with some sessions with recorded attendances and an end of service report does not exist`() {
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
 
   @Test
-  fun `does not conclude a referral when ending a referral with all sessions attempted and an end of service report does not exist`() {
-    val referralWithActionPlanAndSomeAttemptedSessions =
+  fun `does not conclude a referral when ending a referral with all sessions with recorded attendances and an end of service report does not exist`() {
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord =
       createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
 
-    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeAttemptedSessions)
+    referralConcluder.concludeIfEligible(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     verifyNoInteractions(referralRepository, referralEventPublisher)
   }
@@ -165,10 +165,10 @@ internal class ReferralConcluderTest {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
     val endOfServiceReport = endOfServiceReportFactory.create()
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = endOfServiceReport)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = endOfServiceReport)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeSessionsWithAttendanceRecord.id)).thenReturn(1)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -178,10 +178,10 @@ internal class ReferralConcluderTest {
   fun `should flag end of service report as required if it doesn't exist and when all sessions have been attended`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(2)
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeSessionsWithAttendanceRecord.id)).thenReturn(2)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     assertThat(endOfServiceReportCreationRequired).isTrue
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -191,10 +191,10 @@ internal class ReferralConcluderTest {
   fun `should flag end of service report as required if it doesn't exist and when at least one session has been attended and end has been requested`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeAttemptedSessions.id)).thenReturn(1)
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
+    whenever(actionPlanRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeSessionsWithAttendanceRecord.id)).thenReturn(1)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     assertThat(endOfServiceReportCreationRequired).isTrue
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -203,9 +203,9 @@ internal class ReferralConcluderTest {
   @Test
   fun `should not flag end of service report as required when action plan is missing`() {
 
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = null)
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createSent(actionPlans = null)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(actionPlanRepository, referralRepository, referralEventPublisher)
@@ -215,10 +215,10 @@ internal class ReferralConcluderTest {
   fun `should not flag end of service report as required when no sessions have been attended`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(referralRepository, referralEventPublisher)
@@ -228,11 +228,11 @@ internal class ReferralConcluderTest {
   fun `should not flag end of service report as required when having only non-attended sessions`() {
 
     val actionPlan = actionPlanFactory.create(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeAttemptedSessions = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
+    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
     whenever(actionPlanRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
-    whenever(actionPlanRepository.countNumberOfAttemptedSessions(actionPlan.id)).thenReturn(1)
+    whenever(actionPlanRepository.countNumberOfSessionsWithAttendanceRecord(actionPlan.id)).thenReturn(1)
 
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeAttemptedSessions)
+    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
 
     assertThat(endOfServiceReportCreationRequired).isFalse
     verifyNoInteractions(referralRepository, referralEventPublisher)


### PR DESCRIPTION
## What does this pull request do?

Renames CountSessionsAttempted variables to CountSessionsWithAttendanceRecord

## What is the intent behind these changes?

Clarifies the meaning of sessions attempted
