### PR TITLE
Deprecate action plan usage in delivery sessions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
@@ -9,9 +9,17 @@ interface DeliverySessionRepository : JpaRepository<DeliverySession, UUID> {
   fun findAllByReferralId(referralId: UUID): List<DeliverySession>
   fun findByReferralIdAndSessionNumber(referralId: UUID, sessionNumber: Int): DeliverySession?
 
+  @Deprecated(
+    "looking up by action plan ID is no longer necessary",
+    ReplaceWith("findByReferralIdAndSessionNumber(referralId, sessionNumber")
+  )
   @Query("select aps from DeliverySession aps left join ActionPlan ap on ap.referral = aps.referral where ap.id = :actionPlanId and aps.sessionNumber = :sessionNumber")
   fun findAllByActionPlanIdAndSessionNumber(actionPlanId: UUID, sessionNumber: Int): DeliverySession?
 
+  @Deprecated(
+    "looking up by action plan ID is no longer necessary",
+    ReplaceWith("findAllByReferralId(referralId")
+  )
   @Query("select ds from DeliverySession ds left join ActionPlan ap on ap.referral = ds.referral where ap.id = :actionPlanId")
   fun findAllByActionPlanId(actionPlanId: UUID): List<DeliverySession>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -420,6 +420,10 @@ class DeliverySessionService(
     }
   }
 
+  @Deprecated(
+    "looking up by action plan ID is no longer necessary",
+    ReplaceWith("getDeliverySessionOrThrowException(referralId, sessionNumber)")
+  )
   fun getDeliverySessionByActionPlanIdOrThrowException(actionPlanId: UUID, sessionNumber: Int): DeliverySession =
     getDeliverySessionByActionPlanId(actionPlanId, sessionNumber)
       ?: throw EntityNotFoundException("Action plan session not found [actionPlanId=$actionPlanId, sessionNumber=$sessionNumber]")
@@ -431,6 +435,10 @@ class DeliverySessionService(
   private fun getDeliverySession(referralId: UUID, sessionNumber: Int) =
     deliverySessionRepository.findByReferralIdAndSessionNumber(referralId, sessionNumber)
 
+  @Deprecated(
+    "looking up by action plan ID is no longer necessary",
+    ReplaceWith("getDeliverySession(referralId, sessionNumber)")
+  )
   private fun getDeliverySessionByActionPlanId(actionPlanId: UUID, sessionNumber: Int) =
     deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)
 


### PR DESCRIPTION
## What does this pull request do?

IPB-116: Our initial data models used a referral → action plan → sessions chain.

If I recall correctly when we implemented action plan revisions, it enabled "extending" the number of sessions, so we had to tie the session counts to the referral instead.

This means all of the `actionPlanId` looks are deprecated and should be removed.

## What is the intent behind these changes?

To avoid building on outdated abstractions.