### PR TITLE
Move counting delivery sessions closer to its home

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ActionPlanRepository.kt
@@ -1,25 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ActionPlan
 import java.util.UUID
 
 interface ActionPlanRepository : JpaRepository<ActionPlan, UUID> {
   fun findByIdAndSubmittedAtIsNull(id: UUID): ActionPlan?
   fun findAllByReferralIdAndApprovedAtIsNotNull(referralId: UUID): List<ActionPlan>
-
-  @Query(
-    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
-      "where sesh.referral.id = :referralId and appt.attended is not null " +
-      "and appt.appointmentFeedbackSubmittedAt is not null and appt.superseded is false"
-  )
-  fun countNumberOfSessionsWithAttendanceRecord(referralId: UUID): Int
-
-  @Query(
-    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
-      "where sesh.referral.id = :referralId and appt.attended in ('YES', 'LATE') " +
-      "and appt.appointmentFeedbackSubmittedAt is not null"
-  )
-  fun countNumberOfAttendedSessions(referralId: UUID): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
@@ -14,4 +14,18 @@ interface DeliverySessionRepository : JpaRepository<DeliverySession, UUID> {
 
   @Query("select ds from DeliverySession ds left join ActionPlan ap on ap.referral = ds.referral where ap.id = :actionPlanId")
   fun findAllByActionPlanId(actionPlanId: UUID): List<DeliverySession>
+
+  @Query(
+    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
+      "where sesh.referral.id = :referralId and appt.attended is not null " +
+      "and appt.appointmentFeedbackSubmittedAt is not null and appt.superseded is false"
+  )
+  fun countNumberOfSessionsWithAttendanceRecord(referralId: UUID): Int
+
+  @Query(
+    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
+      "where sesh.referral.id = :referralId and appt.attended in ('YES', 'LATE') " +
+      "and appt.appointmentFeedbackSubmittedAt is not null"
+  )
+  fun countNumberOfAttendedSessions(referralId: UUID): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.COMPLETED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.PREMATURELY_ENDED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import java.time.OffsetDateTime
 import java.util.Objects.nonNull
@@ -18,7 +18,7 @@ import javax.transaction.Transactional
 @Transactional
 class ReferralConcluder(
   val referralRepository: ReferralRepository,
-  val actionPlanRepository: ActionPlanRepository,
+  val deliverySessionRepository: DeliverySessionRepository,
   val referralEventPublisher: ReferralEventPublisher,
 ) {
   companion object {
@@ -79,11 +79,11 @@ class ReferralConcluder(
   }
 
   private fun countSessionsWithAttendanceRecord(referral: Referral): Int {
-    return actionPlanRepository.countNumberOfSessionsWithAttendanceRecord(referral.id)
+    return deliverySessionRepository.countNumberOfSessionsWithAttendanceRecord(referral.id)
   }
 
   private fun countSessionsAttended(referral: Referral): Int {
-    return actionPlanRepository.countNumberOfAttendedSessions(referral.id)
+    return deliverySessionRepository.countNumberOfAttendedSessions(referral.id)
   }
 
   private fun deliveredFirstSubstantiveAppointment(referral: Referral): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/service/ReferralConcludeIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/service/ReferralConcludeIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Attended
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ActionPlanRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
@@ -24,7 +23,6 @@ import java.time.OffsetDateTime
 class ReferralConcludeIntegrationTest @Autowired constructor(
   val entityManager: TestEntityManager,
   val referralRepository: ReferralRepository,
-  val actionPlanRepository: ActionPlanRepository,
   val deliverySessionRepository: DeliverySessionRepository,
   val authUserRepository: AuthUserRepository,
   val appointmentRepository: AppointmentRepository,
@@ -37,14 +35,13 @@ class ReferralConcludeIntegrationTest @Autowired constructor(
 
   @AfterEach
   fun `clear referrals`() {
-    actionPlanRepository.deleteAll()
     referralRepository.deleteAll()
     deliverySessionRepository.deleteAll()
   }
 
   @Test
   fun `an action plan number of sessions should be the same even with more than one appointment`() {
-    val referralConcludeCheck = ReferralConcluder(referralRepository, actionPlanRepository, referralEventPublisher)
+    val referralConcludeCheck = ReferralConcluder(referralRepository, deliverySessionRepository, referralEventPublisher)
     val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 1)
     actionPlan.referral.actionPlans = mutableListOf(actionPlan)
 


### PR DESCRIPTION
## What does this pull request do?

IPB-116: These two functions were not even using `ActionPlan` in the `@Query` definitions.

Moved from `ActionPlanRepository` to `DeliverySessionRepository`


## What is the intent behind these changes?

Avoid misleading and out-of-date abstractions.