### PR TITLE
Fix flaky action plan integration test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -19,6 +19,7 @@ import javax.persistence.ManyToMany
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.OneToOne
+import javax.persistence.OrderBy
 import javax.persistence.PrePersist
 import javax.persistence.PrimaryKeyJoinColumn
 import javax.persistence.Table
@@ -66,7 +67,8 @@ class Referral(
 
   var relevantSentenceId: Long? = null,
 
-  @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "referral_id") var actionPlans: MutableList<ActionPlan>? = null,
+  @OneToMany(fetch = FetchType.LAZY) @OrderBy("createdAt")
+  @JoinColumn(name = "referral_id") var actionPlans: MutableList<ActionPlan>? = null,
 
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(


### PR DESCRIPTION
## What does this pull request do?

Fix flaky action plan integration test by asserting default order.

Example: https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/10919/workflows/bad59c19-8c2a-4c10-9412-9f27ae4cf556/jobs/44835

```
org.opentest4j.AssertionFailedError:
expected: ActionPlan(referralId=c5b2261b-282f-42d3-a887-2a6109c34a1f, numberOfSessions=null, activities=[], createdBy=AuthUser(id=608955ae-52ed-44cc-884c-011597a77949, authSource=auth, userName=AUTH_USER, deleted=null), createdAt=2023-01-03T13:07:45.735009475Z, submittedBy=null, submittedAt=null, id=b81350e2-6ec9-46f8-a5fc-117fca878ca3)
 but was: ActionPlan(referralId=c5b2261b-282f-42d3-a887-2a6109c34a1f, numberOfSessions=10, activities=[], createdBy=AuthUser(id=608955ae-52ed-44cc-884c-011597a77949, authSource=auth, userName=AUTH_USER, deleted=null), createdAt=2023-01-03T13:07:45.783125Z, submittedBy=null, submittedAt=null, id=76fc7dec-995d-4803-98c3-d0db107af258)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base@17.0.5/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base@17.0.5/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at app//uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.service.ActionPlanServiceIntegrationTest.can store multiple action plans on a referral and their creation order is preserved(ActionPlanServiceIntegrationTest.kt:49)
```

The test code contains

```
49:    assertThat(updatedReferral.actionPlans?.first()).isEqualTo(firstActionPlan)
50:    assertThat(updatedReferral.actionPlans?.last()).isEqualTo(lastActionPlan)
```

So in the test code `updatedReferral.actionPlans?.first()` returned `createdAt=2023-01-03T13:07:45.783125Z`, while `firstActionPlan` had `createdAt=2023-01-03T13:07:45.735009475Z`. **The order of `actionPlans` is wrong.**

The `actionPlans` field makes no assertion on default sort order. By using creation order as the default sort order, this test should stop being flaky.

## What is the intent behind these changes?

Flaky tests are the devil. They delay genuine changes and usually hide bugs. Fix them.