### PR TITLE
🐛 Disable EoSR for in-progress delivery, with first substantive appointment (FSA)

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -1,24 +1,36 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.firstValue
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcludedState.CANCELLED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcludedState.COMPLETED
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcludedState.PREMATURELY_ENDED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.stream.Stream
 
 internal class ReferralConcluderTest {
   private val referralRepository: ReferralRepository = mock()
@@ -29,247 +41,177 @@ internal class ReferralConcluderTest {
   private val actionPlanFactory = ActionPlanFactory()
   private val endOfServiceReportFactory = EndOfServiceReportFactory()
 
-  private val referralConcluder = ReferralConcluder(
+  private val concluder = ReferralConcluder(
     referralRepository, deliverySessionRepository, referralEventPublisher
   )
 
-  private fun createReferralWithSessions(totalSessions: Int, attendedOrLate: Int, didNotAttend: Int): Referral {
-    assertThat(attendedOrLate + didNotAttend).isLessThanOrEqualTo(totalSessions)
-      .withFailMessage("test setup error: the sum of attended and did not attend sessions must not be greater than the total sessions")
+  data class WhenInState(val attendedOrLate: Int, val notAttended: Int, val notStarted: Int)
+  data class ExpectThat(
+    val requiresEoSR: Boolean,
+    val endingWith: ReferralConcludedState? = null,
+    val concludesWith: ReferralConcludedState? = null,
+  )
+  data class Example(
+    val state: WhenInState,
+    val beforeCancel: ExpectThat,
+    val afterCancel: ExpectThat,
+    val afterEoSR: ExpectThat? = null,
+  )
+
+  companion object {
+    @JvmStatic
+    fun examples(): Stream<Arguments> = Stream.of(
+      arguments(
+        named(
+          "no sessions have any attendance",
+          Example(
+            state = WhenInState(attendedOrLate = 0, notAttended = 0, notStarted = 1),
+            beforeCancel = ExpectThat(requiresEoSR = false),
+            afterCancel = ExpectThat(requiresEoSR = false, endingWith = CANCELLED, concludesWith = CANCELLED),
+          )
+        )
+      ),
+      arguments(
+        named(
+          "finished delivery, without first substantive appointment (FSA)",
+          Example(
+            state = WhenInState(attendedOrLate = 0, notAttended = 1, notStarted = 0),
+            beforeCancel = ExpectThat(requiresEoSR = false),
+            afterCancel = ExpectThat(requiresEoSR = false, endingWith = CANCELLED, concludesWith = CANCELLED),
+          )
+        )
+      ),
+      arguments(
+        named(
+          "in-progress delivery, without first substantive appointment (FSA)",
+          Example(
+            state = WhenInState(attendedOrLate = 0, notAttended = 1, notStarted = 1),
+            beforeCancel = ExpectThat(requiresEoSR = false),
+            afterCancel = ExpectThat(requiresEoSR = false, endingWith = CANCELLED, concludesWith = CANCELLED),
+          )
+        )
+      ),
+      arguments(
+        named(
+          "in-progress delivery, with first substantive appointment (FSA)",
+          Example(
+            state = WhenInState(attendedOrLate = 1, notAttended = 0, notStarted = 1),
+            beforeCancel = ExpectThat(requiresEoSR = false),
+            afterCancel = ExpectThat(requiresEoSR = true, endingWith = PREMATURELY_ENDED),
+            afterEoSR = ExpectThat(requiresEoSR = false, endingWith = PREMATURELY_ENDED, concludesWith = PREMATURELY_ENDED),
+          )
+        )
+      ),
+      arguments(
+        named(
+          "finished delivery, some missed sessions, with first substantive appointment (FSA)",
+          Example(
+            state = WhenInState(attendedOrLate = 1, notAttended = 1, notStarted = 0),
+            beforeCancel = ExpectThat(requiresEoSR = true),
+            afterCancel = ExpectThat(requiresEoSR = true, endingWith = COMPLETED),
+            afterEoSR = ExpectThat(requiresEoSR = false, endingWith = COMPLETED, concludesWith = COMPLETED),
+          )
+        )
+      ),
+      arguments(
+        named(
+          "finished delivery, fully attended delivery",
+          Example(
+            state = WhenInState(attendedOrLate = 2, notAttended = 0, notStarted = 0),
+            beforeCancel = ExpectThat(requiresEoSR = true),
+            afterCancel = ExpectThat(requiresEoSR = true, endingWith = COMPLETED),
+            afterEoSR = ExpectThat(requiresEoSR = false, endingWith = COMPLETED, concludesWith = COMPLETED),
+          )
+        )
+      ),
+    )
+  }
+
+  private fun createReferralWithSessions(state: WhenInState): Referral {
+    val totalSessions = state.attendedOrLate + state.notAttended + state.notStarted
 
     val actionPlan = actionPlanFactory.createApproved(numberOfSessions = totalSessions)
     val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(referral.id)).thenReturn(attendedOrLate)
-    whenever(deliverySessionRepository.countNumberOfSessionsWithAttendanceRecord(referral.id)).thenReturn(attendedOrLate + didNotAttend)
+    whenever(deliverySessionRepository.countNumberOfAttendedSessions(referral.id))
+      .thenReturn(state.attendedOrLate)
+    whenever(deliverySessionRepository.countNumberOfSessionsWithAttendanceRecord(referral.id))
+      .thenReturn(state.attendedOrLate + state.notAttended)
     return referral
   }
 
-  @Test
-  fun `signals end, concludes referral as cancelled without an action plan`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = referralFactory.createSent()
+  @ParameterizedTest(name = "{displayName} {index}: {0}")
+  @MethodSource("examples")
+  fun `in-progress referral EoSR check`(example: Example) {
+    val referral = createReferralWithSessions(example.state)
 
-    referralConcluder.concludeIfEligible(referral)
-
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.CANCELLED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.CANCELLED)
+    assertThat(concluder.requiresEndOfServiceReportCreation(referral)).isEqualTo(example.beforeCancel.requiresEoSR)
   }
 
-  @Test
-  fun `signals end, concludes referral as cancelled without any recorded attendances`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 0, didNotAttend = 0)
+  @ParameterizedTest(name = "{displayName} {index}: {0}")
+  @MethodSource("examples")
+  fun `cancelled referrals EoSR check`(example: Example) {
+    val referral = createReferralWithSessions(example.state)
+    // not great -- this should be a service for atomic operation
+    referral.endRequestedAt = OffsetDateTime.now()
+    referral.endRequestedBy = AuthUser.interventionsServiceUser
+    referral.endRequestedReason = CancellationReason("TST", "Test")
 
-    referralConcluder.concludeIfEligible(referral)
-
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.CANCELLED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.CANCELLED)
+    assertThat(concluder.requiresEndOfServiceReportCreation(referral)).isEqualTo(example.afterCancel.requiresEoSR)
   }
 
-  @Test
-  fun `signals end, concludes a referral as cancelled without substantive delivery (only did not attend sessions)`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 0, didNotAttend = 2)
+  @ParameterizedTest(name = "{displayName} {index}: {0}")
+  @MethodSource("examples")
+  fun `cancelled referrals event check`(example: Example) {
+    val referral = createReferralWithSessions(example.state)
+    // not great -- this should be a service for atomic operation
+    referral.endRequestedAt = OffsetDateTime.now()
+    referral.endRequestedBy = AuthUser.interventionsServiceUser
+    referral.endRequestedReason = CancellationReason("TST", "Test")
 
-    referralConcluder.concludeIfEligible(referral)
-
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.CANCELLED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.CANCELLED)
+    concluder.concludeIfEligible(referral)
+    verifyEndingWith(referral, example.afterCancel.endingWith)
+    verifyConcludesWith(referral, example.afterCancel.concludesWith)
   }
 
-  @Test
-  fun `signals end, concludes a referral as prematurely ended with substantive delivery, partial delivery, submitted end-of-service report`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0).also {
-      it.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+  @ParameterizedTest(name = "{displayName} {index}: {0}")
+  @MethodSource("examples")
+  fun `referrals with submitted end-of-service reports`(example: Example) {
+    if (example.afterEoSR == null) {
+      return
     }
 
-    referralConcluder.concludeIfEligible(referral)
+    val referral = createReferralWithSessions(example.state)
+    referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral, submittedAt = OffsetDateTime.now())
 
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.PREMATURELY_ENDED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.PREMATURELY_ENDED)
+    assertThat(concluder.requiresEndOfServiceReportCreation(referral)).isEqualTo(example.afterEoSR.requiresEoSR)
+    concluder.concludeIfEligible(referral)
+    verifyEndingWith(referral, example.afterEoSR.endingWith)
+    verifyConcludesWith(referral, example.afterEoSR.concludesWith)
   }
 
-  @Test
-  fun `signals end, concludes a referral as completed with substantive delivery, full delivery with no-show, submitted end-of-service report`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1).also {
-      it.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+  private fun verifyEndingWith(referral: Referral, endingWith: ReferralConcludedState?) {
+    if (endingWith != null) {
+      verify(referralEventPublisher).referralEndingEvent(same(referral), eq(endingWith))
+    } else {
+      verify(referralEventPublisher, never()).referralEndingEvent(same(referral), any())
     }
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.COMPLETED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.COMPLETED)
   }
 
-  @Test
-  fun `signals end, concludes a referral as completed with substantive delivery, full delivery, submitted end-of-service report`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 2, didNotAttend = 0).also {
-      it.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
+  private fun verifyConcludesWith(referral: Referral, concludesWith: ReferralConcludedState?) {
+    if (concludesWith != null) {
+      verifySaveWithConcludedAtSet(referral)
     }
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.COMPLETED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.COMPLETED)
-  }
-
-  @Test
-  fun `signals end, concludes referral as completed when all sessions are attended, even if there is an action plan revision with more sessions`() {
-    val timeAtStart = OffsetDateTime.now()
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 2, didNotAttend = 0).also {
-      it.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = OffsetDateTime.now())
-      it.actionPlans?.add(actionPlanFactory.createSubmitted(numberOfSessions = 10, referral = it))
+    if (concludesWith != null) {
+      verify(referralEventPublisher).referralConcludedEvent(same(referral), eq(concludesWith))
+    } else {
+      verify(referralEventPublisher, never()).referralConcludedEvent(same(referral), any())
     }
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifySaveWithConcludedAtSet(referral, timeAtStart)
-    verifyEndingEventPublished(referral, ReferralConcludedState.COMPLETED)
-    verifyConcludedEventPublished(referral, ReferralConcludedState.COMPLETED)
   }
 
-  @Test
-  fun `signals end, does not conclude a referral with substantive delivery, partial delivery, started end-of-service report`() {
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0).also {
-      it.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    }
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifyNoInteractions(referralRepository)
-    verifyEndingEventPublished(referral, ReferralConcludedState.PREMATURELY_ENDED)
-    verifyNoMoreInteractions(referralEventPublisher)
-  }
-
-  @Test
-  fun `signals end, does not conclude a referral with substantive delivery, full delivery with no-show, started end-of-service report`() {
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1).also {
-      it.endOfServiceReport = endOfServiceReportFactory.create(submittedAt = null)
-    }
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifyNoInteractions(referralRepository)
-    verifyEndingEventPublished(referral, ReferralConcludedState.COMPLETED)
-    verifyNoMoreInteractions(referralEventPublisher)
-  }
-
-  @Test
-  fun `signals end, does not conclude a referral with substantive delivery, partial delivery, missing end-of-service report`() {
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 0)
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifyNoInteractions(referralRepository)
-    verifyEndingEventPublished(referral, ReferralConcludedState.PREMATURELY_ENDED)
-    verifyNoMoreInteractions(referralEventPublisher)
-  }
-
-  @Test
-  fun `signals end, does not conclude a referral with substantive delivery, full delivery, missing end-of-service report`() {
-    val referral = createReferralWithSessions(totalSessions = 2, attendedOrLate = 1, didNotAttend = 1)
-
-    referralConcluder.concludeIfEligible(referral)
-
-    verifyNoInteractions(referralRepository)
-    verifyEndingEventPublished(referral, ReferralConcludedState.COMPLETED)
-    verifyNoMoreInteractions(referralEventPublisher)
-  }
-
-  @Test
-  fun `should not flag end of service report as required when one has already been created`() {
-    val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 2)
-    val endOfServiceReport = endOfServiceReportFactory.create()
-    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = endOfServiceReport)
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeSessionsWithAttendanceRecord.id)).thenReturn(1)
-
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
-
-    assertThat(endOfServiceReportCreationRequired).isFalse
-    verifyNoInteractions(referralRepository, referralEventPublisher)
-  }
-
-  @Test
-  fun `should flag end of service report as required if it doesn't exist and when all sessions have been attended`() {
-    val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeSessionsWithAttendanceRecord.id)).thenReturn(2)
-
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
-
-    assertThat(endOfServiceReportCreationRequired).isTrue
-    verifyNoInteractions(referralRepository, referralEventPublisher)
-  }
-
-  @Test
-  fun `should flag end of service report as required if it doesn't exist and when at least one session has been attended and end has been requested`() {
-
-    val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createEnded(actionPlans = mutableListOf(actionPlan), endOfServiceReport = null)
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(referralWithActionPlanAndSomeSessionsWithAttendanceRecord.id)).thenReturn(1)
-
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
-
-    assertThat(endOfServiceReportCreationRequired).isTrue
-    verifyNoInteractions(referralRepository, referralEventPublisher)
-  }
-
-  @Test
-  fun `should not flag end of service report as required when action plan is missing`() {
-    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createSent(actionPlans = null)
-
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
-
-    assertThat(endOfServiceReportCreationRequired).isFalse
-    verifyNoInteractions(deliverySessionRepository, referralRepository, referralEventPublisher)
-  }
-
-  @Test
-  fun `should not flag end of service report as required when no sessions have been attended`() {
-    val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
-
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
-
-    assertThat(endOfServiceReportCreationRequired).isFalse
-    verifyNoInteractions(referralRepository, referralEventPublisher)
-  }
-
-  @Test
-  fun `should not flag end of service report as required when having only non-attended sessions`() {
-    val actionPlan = actionPlanFactory.createApproved(numberOfSessions = 2)
-    val referralWithActionPlanAndSomeSessionsWithAttendanceRecord = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(actionPlan.id)).thenReturn(0)
-    whenever(deliverySessionRepository.countNumberOfSessionsWithAttendanceRecord(actionPlan.id)).thenReturn(1)
-
-    val endOfServiceReportCreationRequired = referralConcluder.requiresEndOfServiceReportCreation(referralWithActionPlanAndSomeSessionsWithAttendanceRecord)
-
-    assertThat(endOfServiceReportCreationRequired).isFalse
-    verifyNoInteractions(referralRepository, referralEventPublisher)
-  }
-
-  private fun verifyEndingEventPublished(referral: Referral, value: ReferralConcludedState) {
-    verify(referralEventPublisher).referralEndingEvent(same(referral), eq(value))
-  }
-
-  private fun verifyConcludedEventPublished(referral: Referral, value: ReferralConcludedState) {
-    verify(referralEventPublisher).referralConcludedEvent(same(referral), eq(value))
-  }
-
-  private fun verifySaveWithConcludedAtSet(referralWithNoActionPlan: Referral, timeAtStart: OffsetDateTime?) {
+  private fun verifySaveWithConcludedAtSet(referral: Referral) {
     val argumentCaptor: ArgumentCaptor<Referral> = ArgumentCaptor.forClass(Referral::class.java)
     verify(referralRepository).save(argumentCaptor.capture())
-    assertThat(argumentCaptor.firstValue).isSameAs(referralWithNoActionPlan)
-    assertThat(argumentCaptor.firstValue.concludedAt).isAfter(timeAtStart)
+    assertThat(argumentCaptor.firstValue).isSameAs(referral)
+    assertThat(argumentCaptor.firstValue.concludedAt).isCloseToUtcNow(within(1, ChronoUnit.MINUTES))
   }
 }


### PR DESCRIPTION
## What does this pull request do?

IPB-84: Fixes regression caused by #1377:

Given

- There are two delivery sessions
- And the 1st is "completed" (attended or late)
- And the 2nd is "not scheduled" (does not have any attendance)

Then the expected behaviour is

- The delivery is still in progress
- SPs cannot start an end-of-service report

The actual behaviour was

- ✅ The delivery is still in progress
- ❌ SPs **can** start an end-of-service report

## What is the main change?

There is now a list of examples detailing

- in which referral state (function name)
- in what delivery state (first argument)
- what is expected

```kotlin
fun inProgressExamples(): Stream<Arguments> = Stream.of(
  arguments(notStarted, ExpectThat(requiresEoSR = false)),
  arguments(allSessionsHaveOutcomeNoFSA, ExpectThat(requiresEoSR = false)),
  arguments(inProgressNoFSA, ExpectThat(requiresEoSR = false)),
  arguments(inProgressWithFSA, ExpectThat(requiresEoSR = false)),
  arguments(allSessionsHaveOutcomeSomeDNAWithFSA, ExpectThat(requiresEoSR = true)),
  arguments(allSessionsHaveOutcomeAllAttendedWithFSA, ExpectThat(requiresEoSR = true)),
)

fun afterCancelExamples(): Stream<Arguments> = Stream.of(
  arguments(notStarted, ExpectThat(requiresEoSR = false, endingWith = CANCELLED, concludesWith = CANCELLED)),
  arguments(allSessionsHaveOutcomeNoFSA, ExpectThat(requiresEoSR = false, endingWith = CANCELLED, concludesWith = CANCELLED)),
  arguments(inProgressNoFSA, ExpectThat(requiresEoSR = false, endingWith = CANCELLED, concludesWith = CANCELLED)),
  arguments(inProgressWithFSA, ExpectThat(requiresEoSR = true, endingWith = PREMATURELY_ENDED)),
  arguments(allSessionsHaveOutcomeSomeDNAWithFSA, ExpectThat(requiresEoSR = true, endingWith = COMPLETED)),
  arguments(allSessionsHaveOutcomeAllAttendedWithFSA, ExpectThat(requiresEoSR = true, endingWith = COMPLETED)),
)

fun afterEoSRSubmittedExamples(): Stream<Arguments> = Stream.of(
  arguments(inProgressWithFSA, ExpectThat(requiresEoSR = false, endingWith = PREMATURELY_ENDED, concludesWith = PREMATURELY_ENDED)),
  arguments(allSessionsHaveOutcomeSomeDNAWithFSA, ExpectThat(requiresEoSR = false, endingWith = COMPLETED, concludesWith = COMPLETED)),
  arguments(allSessionsHaveOutcomeAllAttendedWithFSA, ExpectThat(requiresEoSR = false, endingWith = COMPLETED, concludesWith = COMPLETED)),
)
```

## What is the intent behind these changes?

1. Fix the regression
2. Define a truth table in tests so we can always test any transition