### PR TITLE
pde-2118: use python script instead of bash script 

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-data-extractor-analytics.yaml
@@ -13,7 +13,7 @@ spec:
           - name: data-extractor-analytics
             image: ministryofjustice/data-engineering-data-extractor:v1
             imagePullPolicy: Always
-            args: ["extract_psql_all_tables_to_jsonl.sh && transfer_local_to_s3.sh"]
+            args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
             env:
               - name: PGHOST
                 valueFrom:


### PR DESCRIPTION
## What does this pull request do?

This change is related to the Data Extractor, I have changed which script is used to extract data from the data and move to the AP. 

The python scrip originally had memory issues this has now been resolved, so we want all consumers of the application to use the python script and it has better error handling - we want to decommission the bash script

## What is the intent behind these changes?

The python script has better error handling compared to the bash script.
