### PR TITLE
Persist auth user within user mapper

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/UserMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/authorization/UserMapper.kt
@@ -33,7 +33,7 @@ class UserMapper(
       throw AccessDeniedException("could not map auth token to user: $errors")
     }
 
-    return AuthUser(id = userID, authSource = authSource, userName = userName)
+    return authUserRepository.save(AuthUser(id = userID, authSource = authSource, userName = userName))
   }
 
   fun fromId(id: String): AuthUser {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
@@ -45,6 +45,7 @@ class CaseNoteControllerTest {
       val referralId = caseNote.referral.id
       val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body")
 
+      whenever(authUserRepository.save(any())).thenReturn(user)
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(referralFactory.createSent(id = referralId))
       whenever(caseNoteService.createCaseNote(referralId = referralId, subject = "subject", body = "body", sentByUser = user)).thenReturn(caseNote)
 
@@ -59,6 +60,7 @@ class CaseNoteControllerTest {
       val referralId = caseNote.referral.id
       val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body")
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(null)
+      whenever(authUserRepository.save(any())).thenReturn(user)
       val e = assertThrows<ResponseStatusException> {
         caseNoteController.createCaseNote(createCaseNoteDTO, userToken)
       }
@@ -78,6 +80,7 @@ class CaseNoteControllerTest {
       val caseNote = caseNoteFactory.create(subject = "subject", body = "body")
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(referralFactory.createSent(id = referralId))
       whenever(caseNoteService.findByReferral(referralId, pageable = pageable)).thenReturn(PageImpl(listOf(caseNote)))
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val caseNotes = caseNoteController.getCaseNotes(pageable, referralId = referralId, authentication = userToken)
       assertThat(caseNotes.numberOfElements).isEqualTo(1)
@@ -94,6 +97,7 @@ class CaseNoteControllerTest {
       val referralId = UUID.randomUUID()
 
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(null)
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val e = assertThrows<ResponseStatusException> {
         caseNoteController.getCaseNotes(Pageable.ofSize(1), referralId = referralId, authentication = userToken)
@@ -109,6 +113,7 @@ class CaseNoteControllerTest {
     fun `can get an individual case note`() {
       val id = UUID.randomUUID()
       val caseNote = caseNoteFactory.create(id = id, subject = "subject", body = "body")
+      whenever(authUserRepository.save(any())).thenReturn(authUserFactory.create())
       whenever(caseNoteService.getCaseNoteForUser(id, caseNote.sentBy)).thenReturn(caseNote)
 
       val caseNoteDTO = caseNoteController.getCaseNote(id, tokenFactory.create(caseNote.sentBy))
@@ -118,6 +123,7 @@ class CaseNoteControllerTest {
     @Test
     fun `returns not found when the case note does not exist`() {
       whenever(caseNoteService.getCaseNoteForUser(any(), any())).thenReturn(null)
+      whenever(authUserRepository.save(any())).thenReturn(authUserFactory.create())
 
       val e = assertThrows<EntityNotFoundException> {
         caseNoteController.getCaseNote(UUID.randomUUID(), tokenFactory.create(authUserFactory.createSP()))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.AdditionalAnswers
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -14,6 +15,7 @@ import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CaseNoteDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.CreateCaseNoteDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CaseNoteService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
@@ -113,7 +115,7 @@ class CaseNoteControllerTest {
     fun `can get an individual case note`() {
       val id = UUID.randomUUID()
       val caseNote = caseNoteFactory.create(id = id, subject = "subject", body = "body")
-      whenever(authUserRepository.save(any())).thenReturn(authUserFactory.create())
+      whenever(authUserRepository.save(any())).then(AdditionalAnswers.returnsFirstArg<AuthUser>())
       whenever(caseNoteService.getCaseNoteForUser(id, caseNote.sentBy)).thenReturn(caseNote)
 
       val caseNoteDTO = caseNoteController.getCaseNote(id, tokenFactory.create(caseNote.sentBy))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.web.server.ResponseStatusException
@@ -65,6 +66,7 @@ internal class DeliverySessionControllerTest {
 
       val updateAppointmentDTO = UpdateAppointmentDTO(OffsetDateTime.now(), 10, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null)
 
+      whenever(authUserRepository.save(any())).thenReturn(authUserFactory.create())
       whenever(
         sessionsService.getDeliverySessionByActionPlanIdOrThrowException(
           actionPlanId,
@@ -107,6 +109,7 @@ internal class DeliverySessionControllerTest {
       val behaviourDTO = RecordAppointmentBehaviourDTO("behaviour", false)
       val updateAppointmentDTO = UpdateAppointmentDTO(OffsetDateTime.now(), 10, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, attendanceDTO, behaviourDTO)
 
+      whenever(authUserRepository.save(any())).thenReturn(authUserFactory.create())
       whenever(
         sessionsService.getDeliverySessionByActionPlanIdOrThrowException(
           actionPlanId,
@@ -158,6 +161,7 @@ internal class DeliverySessionControllerTest {
         referral = deliverySession.referral,
       )
       deliverySession.appointments.add(newAppointment)
+      whenever(authUserRepository.save(any())).thenReturn(authUserFactory.create())
       whenever(sessionsService.getDeliverySessionByActionPlanIdOrThrowException(actionPlanId, sessionNumber)).thenReturn(deliverySession)
       whenever(
         sessionsService.updateSessionAppointment(
@@ -214,6 +218,7 @@ internal class DeliverySessionControllerTest {
 
       whenever(referralService.getSentReferral(referralId)).thenReturn(deliverySession.referral)
       whenever(sessionsService.getSessions(referralId)).thenReturn(listOf(deliverySession))
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val sessionResponse = sessionsController.getDeliverySessionAppointment(referralId, appointmentId, userToken)
 
@@ -227,6 +232,7 @@ internal class DeliverySessionControllerTest {
       val appointmentId = deliverySession.id
 
       whenever(referralService.getSentReferral(referralId)).thenReturn(null)
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val e = assertThrows<ResponseStatusException> { sessionsController.getDeliverySessionAppointment(referralId, appointmentId, userToken) }
       assertThat(e.reason).contains("sent referral not found")
@@ -241,6 +247,7 @@ internal class DeliverySessionControllerTest {
 
       whenever(referralService.getSentReferral(referralId)).thenReturn(deliverySession.referral)
       whenever(sessionsService.getSessions(referralId)).thenReturn(listOf(deliverySession))
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val e = assertThrows<EntityNotFoundException> { sessionsController.getDeliverySessionAppointment(referralId, appointmentId, userToken) }
       assertThat(e.message).contains("Delivery session appointment not found")
@@ -258,6 +265,7 @@ internal class DeliverySessionControllerTest {
 
       whenever(referralService.getSentReferral(referralId)).thenReturn(deliverySession.referral)
       whenever(sessionsService.getSessions(referralId)).thenReturn(listOf(deliverySession))
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val sessionsResponse = sessionsController.getDeliverySessionAppointments(referralId, userToken)
 
@@ -270,6 +278,7 @@ internal class DeliverySessionControllerTest {
       val referralId = UUID.randomUUID()
 
       whenever(referralService.getSentReferral(referralId)).thenReturn(null)
+      whenever(authUserRepository.save(any())).thenReturn(user)
 
       val e = assertThrows<ResponseStatusException> { sessionsController.getDeliverySessionAppointments(referralId, userToken) }
       assertThat(e.reason).contains("sent referral not found")
@@ -311,6 +320,8 @@ internal class DeliverySessionControllerTest {
         update.additionalAttendanceInformation
       )
     ).thenReturn(updatedSession)
+
+    whenever(authUserRepository.save(any())).thenReturn(user)
 
     val sessionResponse = sessionsController.recordAttendance(actionPlan.id, sessionNumber, update, userToken)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/service/ActionPlanServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/service/ActionPlanServiceIntegrationTest.kt
@@ -3,9 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.servi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.ActionPlanValidator
@@ -14,7 +12,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.Integr
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DeliverySessionService
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 
 class ActionPlanServiceIntegrationTest @Autowired constructor(
   val actionPlanValidator: ActionPlanValidator,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/service/ActionPlanServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/service/ActionPlanServiceIntegrationTest.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.servi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.ActionPlanValidator
@@ -12,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.Integr
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DeliverySessionService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 
 class ActionPlanServiceIntegrationTest @Autowired constructor(
   val actionPlanValidator: ActionPlanValidator,


### PR DESCRIPTION
## What does this pull request do?

Always save the user.

## What is the intent behind these changes?

We have had issues where actions have been performed without saving the current user to the auth table. This has caused issues later on with null values being present when other actions have been performed. This change will ensure that one of the first actions that happens in the controller(user mapper) is to save the user into the auth table to prevent this issue happening in the future.
