### PR TITLE
Upgrading to the latest version of gradle spring boot

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -32,3 +32,6 @@ CVE-2022-42889
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for spring-web 5.3.24 as bundled with spring boot
+#   can be suppressed as we are not using java serialization and deserialization explicitly
+CVE-2016-1000027

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.1-beta-1"
   kotlin("plugin.spring") version "1.8.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.8.0"
   id("jacoco")


### PR DESCRIPTION
## What does this pull request do?

Upgrades the latest gradle spring boot to 4.8.1-beta-1 and updates the trivy ignore for supressing CVE-2016-1000027

## What is the intent behind these changes?

This is to fix the vulnerability scan issue of CVE-2016-1000027
