### PR TITLE
Disable online POM scanning for trivy temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ workflows:
               ignore: [main]
       - hmpps/trivy_pipeline_scan:
           name: vulnerability_scan
-          additional_args: --debug --timeout 20m
+          additional_args: --debug --offline-scan
           requires: [build_docker, build_and_publish_docker]
       - hmpps/deploy_env:
           name: deploy_dev
@@ -294,7 +294,7 @@ workflows:
             - veracode-credentials
       - hmpps/trivy_latest_scan:
           slack_channel: "interventions-dev-notifications"
-          additional_args: --debug --timeout 20m
+          additional_args: --debug --timeout 30m
           context: [hmpps-common-vars]
       - hmpps/gradle_owasp_dependency_check:
           cache_key: "v2-bump"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,7 @@ workflows:
               ignore: [main]
       - hmpps/trivy_pipeline_scan:
           name: vulnerability_scan
+          additional_args: --debug --timeout 10m
           requires: [build_docker, build_and_publish_docker]
       - hmpps/deploy_env:
           name: deploy_dev
@@ -293,6 +294,7 @@ workflows:
             - veracode-credentials
       - hmpps/trivy_latest_scan:
           slack_channel: "interventions-dev-notifications"
+          additional_args: --debug --timeout 10m
           context: [hmpps-common-vars]
       - hmpps/gradle_owasp_dependency_check:
           cache_key: "v2-bump"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ workflows:
               ignore: [main]
       - hmpps/trivy_pipeline_scan:
           name: vulnerability_scan
-          additional_args: --debug --timeout 10m
+          additional_args: --debug --timeout 20m
           requires: [build_docker, build_and_publish_docker]
       - hmpps/deploy_env:
           name: deploy_dev
@@ -294,7 +294,7 @@ workflows:
             - veracode-credentials
       - hmpps/trivy_latest_scan:
           slack_channel: "interventions-dev-notifications"
-          additional_args: --debug --timeout 10m
+          additional_args: --debug --timeout 20m
           context: [hmpps-common-vars]
       - hmpps/gradle_owasp_dependency_check:
           cache_key: "v2-bump"


### PR DESCRIPTION
## What does this pull request do?

We are getting

`FATAL image scan error: scan error: scan failed: failed analysis: analyze error: timeout: context deadline exceeded`

during our trivy jobs.

Running it locally with `--debug` says:

```
2023-01-13T10:08:57.153Z	DEBUG	Parsing Java artifacts...	{"file": "app/agent.jar"}
2023-01-13T10:08:57.171Z	DEBUG	Parsing Java artifacts...	{"file": "app/app.jar"}
2023-01-13T10:08:57.173Z	DEBUG	Parsing Java artifacts...	{"file": "BOOT-INF/lib/kotlin-logging-jvm-3.0.4.jar"}
2023-01-13T10:08:57.672Z	DEBUG	Parsing Java artifacts...	{"file": "BOOT-INF/lib/kotlin-stdlib-jdk8-1.8.0.jar"}
2023-01-13T10:09:57.775Z	DEBUG	retrying request	\
{"request": "GET https://search.maven.org/solrsearch/select?q=1%3A%22ed04f49e186a116753ad70d34f0ac2925d1d8020%22&rows=1&wt=json \
(status: 504)", "timeout": "20s", "remaining": 5}
2023-01-13T10:10:17.898Z	DEBUG	Parsing Java artifacts...	{"file": "BOOT-INF/lib/guava-31.1-jre.jar"}
2023-01-13T10:10:17.902Z	DEBUG	Parsing Java artifacts...	{"file": "BOOT-INF/lib/applicationinsights-spring-boot-starter-2.6.4.jar"}
2023-01-13T10:11:18.054Z	DEBUG	retrying request	\
{"request": "GET https://search.maven.org/solrsearch/select?q=1%3A%22e0977670a9468ab55b48c2782490c2511758abc7%22&rows=1&wt=json \
(status: 504)", "timeout": "20s", "remaining": 5}
```

We have quite a few JARs, so if this 20 seconds timeout occurs for enough of them, the default 5-minute overall timeout will be too little.

There is no option to set the "Parsing Java artifacts" (dependency check) timeout individually.

~~So let's enable this detailed view and also increase the timeout (add `--debug` and `--timeout 10m`)~~

The alternative would be to turn on `--offline-scan`, but let's try a more comprehensive scan first.

Edit: we decided to use the pipeline scan. Even 20 minutes were not enough today.

## What is the intent behind these changes?

Make the trivy check more reliable even if maven is having issues.