### PR TITLE
Check pull request branch names conform to policy

### DIFF
--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -1,0 +1,13 @@
+name: branch-name-validator
+
+on: [pull_request]
+
+jobs:
+  check-jira-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: deepakputhraya/action-branch-name@master
+        with:
+          regex: '^(no-ticket|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'IPB-NUMBER/'
+          ignore: main

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -6,7 +6,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           target: minor


### PR DESCRIPTION
## What does this pull request do?

On 12 Jan 2023, as a team we decided to prefix Jira ticket numbers to branch names.

This change enforces that policy on pull requests.

The' no-ticket' prefix is allowed to allow for emergency or quick work.

These are valid:

- `no-ticket/this-pr`
- `IPB-99999/sample-thing`

These are not:

- `no-ticket-sample`
- `IPB-not-valid`

Blocking build is tested in #1396.

## What is the intent behind these changes?

Enforce our decisions.
