### PR TITLE
including dependabot branch name to branch name validator

### DIFF
--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: '^(no-ticket|dependabot|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'IPB-NUMBER/'
+          regex: '^(no-ticket|dependabot|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'dependabot' or 'IPB-NUMBER/'
           ignore: main

--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: '^(no-ticket|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'IPB-NUMBER/'
+          regex: '^(no-ticket|dependabot|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'IPB-NUMBER/'
           ignore: main


### PR DESCRIPTION
## What does this pull request do?

includes dependabot branch name for the branch name validator

## What is the intent behind these changes?

There are dependabot PR's whose name will fail the current branch-name-validator rule. So, it needs to be fixed
