### PR TITLE
changing the branch name validator from dependabot to renovate

### DIFF
--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: '^(no-ticket|dependabot|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'dependabot' or 'IPB-NUMBER/'
+          regex: '^(no-ticket|renovate|IPB-[0-9]+)/' # start branch with either 'no-ticket/' or 'IPB-NUMBER/', allowing for bots
           ignore: main


### PR DESCRIPTION
## What does this pull request do?

updates the branch name validator to refer to renovate

## What is the intent behind these changes?

The dependency library updates framework has been changed to renovate. Hence we need to change the branch name validator
