### PR TITLE
Pin postgres/java major versions differently

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ministryofjustice/hmpps-renovate-config:base"],
-  "major": {
-    "ignoreDeps": [
-      "cimg/openjdk",
-      "cimg/postgres",
-      "eclipse-temurin",
-      "postgres"
-    ]
-  },
   "packageRules": [
     {
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "all gradle dependencies"
+    },
+    {
+      "matchPackageNames": ["cimg/openjdk", "eclipse-temurin"],
+      "allowedVersions": "<=17"
+    },
+    {
+      "matchPackageNames": ["cimg/postgres", "postgres"],
+      "allowedVersions": "<=14"
     }
   ]
 }


### PR DESCRIPTION


## What does this pull request do?

Pin postgres/java major versions differently in Renovate.

## What is the intent behind these changes?

`major.ignoreDeps` does not seem to be working. Try the `packageRules` way.
