### PR TITLE
Reduce frequency for gradle updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,15 +5,17 @@
     {
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "all gradle dependencies"
+      "groupName": "all gradle dependencies",
     },
     {
+      // upgrading these is a team decision
       "matchPackageNames": ["cimg/openjdk", "eclipse-temurin"],
-      "allowedVersions": "<=17"
+      "allowedVersions": "<=17",
     },
     {
+      // match to production postgres version in https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
       "matchPackageNames": ["cimg/postgres", "postgres"],
-      "allowedVersions": "<=14"
-    }
+      "allowedVersions": "<=14",
+    },
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,7 @@
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "all gradle dependencies",
+      "schedule": ["before 7am on Monday"],
     },
     {
       // upgrading these is a team decision


### PR DESCRIPTION
## What does this pull request do?

[Update all dependencies once before work on Monday](https://github.com/ministryofjustice/hmpps-interventions-service/commit/82036e3c414723bd25dd2df0afd0c679cfbbe168) 
So that we can handle and merge it Monday first thing.

## What is the intent behind these changes?

Reduce PR frequency (predominantly AWS dependencies).

Security updates will be raised independently by dependabot.