### PR TITLE
Define the mapping between Referral and ReferralLocation entities. Up…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -26,6 +27,8 @@ class SentReferralDTO(
   val supplementaryRiskId: UUID,
   val endOfServiceReportCreationRequired: Boolean,
   val createdBy: AuthUserDTO,
+  val personCurrentLocationType: PersonCurrentLocationType?,
+  val personCustodyPrisonId: String?
 ) {
   companion object {
     fun from(referral: Referral, endOfServiceReportRequired: Boolean, draftReferral: DraftReferral? = null): SentReferralDTO {
@@ -49,6 +52,8 @@ class SentReferralDTO(
         concludedAt = referral.concludedAt,
         supplementaryRiskId = referral.supplementaryRiskId!!,
         endOfServiceReportCreationRequired = endOfServiceReportRequired,
+        personCurrentLocationType = referral.referralLocation?.let { it.type },
+        personCustodyPrisonId = referral.referralLocation?.let { it.prisonId },
         createdBy = AuthUserDTO.from(referral.createdBy)
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -91,6 +91,7 @@ class Referral(
 
   @OneToOne(mappedBy = "referral") @Fetch(JOIN) var endOfServiceReport: EndOfServiceReport? = null,
   @OneToOne(mappedBy = "referral") @Fetch(JOIN) var supplierAssessment: SupplierAssessment? = null,
+  @OneToOne(mappedBy = "referral") @Fetch(JOIN) var referralLocation: ReferralLocation? = null,
 
   @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "referral_id")
   private val referralDetailsHistory: Set<ReferralDetails>? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralLocation.kt
@@ -7,12 +7,14 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.Id
+import javax.persistence.OneToOne
 
 @Entity
 data class ReferralLocation(
   @Id val id: UUID,
-  @NotNull @Column(name = "referral_id") val referralId: UUID,
+  @OneToOne(fetch = FetchType.LAZY) val referral: Referral,
   @Type(type = "person_current_location_type") @Enumerated(EnumType.STRING) @NotNull @Column(name = "type") val type: PersonCurrentLocationType,
   @Column(name = "prison_id") val prisonId: String?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -389,7 +389,7 @@ class DraftReferralService(
     communityAPIReferralService.send(referral)
 
     val sentReferral = referralRepository.save(referral)
-    createReferralLocation(draftReferral)
+    createReferralLocation(draftReferral, sentReferral)
     eventPublisher.referralSentEvent(sentReferral)
     supplierAssessmentService.createSupplierAssessment(referral)
     return sentReferral
@@ -421,17 +421,18 @@ class DraftReferralService(
     )
   }
 
-  private fun createReferralLocation(draftReferral: DraftReferral) {
+  private fun createReferralLocation(draftReferral: DraftReferral, referral: Referral) {
     if (currentLocationEnabled) {
-      referralLocationRepository.save(
+      referral.referralLocation = referralLocationRepository.save(
         ReferralLocation(
           id = UUID.randomUUID(),
-          referralId = draftReferral.id,
+          referral = referral,
           type = draftReferral.personCurrentLocationType
             ?: throw ServerWebInputException("can't submit a referral without current location"),
           prisonId = draftReferral.personCustodyPrisonId
         )
       )
+      referralRepository.save(referral)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
@@ -9,6 +9,8 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.boot.test.json.JacksonTester
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralLocation
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -237,6 +239,28 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
         "endRequestedComments": null,
         "endOfServiceReportCreationRequired": false,
         "concludedAt": "2021-01-13T21:57:13Z"
+      }
+    }
+    """
+    )
+  }
+
+  @Test
+  fun `sent referral DTO includes referral location fields`() {
+    val referral = referralFactory.createSent()
+    referral.referralLocation = ReferralLocation(
+      id = UUID.randomUUID(),
+      referral = referral,
+      type = PersonCurrentLocationType.CUSTODY,
+      prisonId = "ABC"
+    )
+
+    val out = json.write(SentReferralDTO.from(referral, false))
+    Assertions.assertThat(out).isEqualToJson(
+      """
+      {
+        "personCurrentLocationType": "CUSTODY",
+        "personCustodyPrisonId": "ABC"
       }
     }
     """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -408,9 +408,26 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.personCustodyPrisonId = personCustodyPrisonId
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
-      assertThat(referralLocationRepository.findByReferralId(sentReferral.id)?.referralId).isEqualTo(sentReferral.id)
+      assertThat(referralLocationRepository.findByReferralId(sentReferral.id)?.referral).isEqualTo(sentReferral)
       assertThat(referralLocationRepository.findByReferralId(sentReferral.id)?.prisonId).isEqualTo(personCustodyPrisonId)
       assertThat(referralLocationRepository.findByReferralId(sentReferral.id)?.type).isEqualTo(personCurrentLocationType)
+    }
+
+    @Test
+    fun `sending a draft referral creates a referral with referral location`() {
+      val user = AuthUser("user_id", "delius", "user_name")
+      val draftReferral = draftReferralService.createDraftReferral(user, "X123456", sampleIntervention.id)
+      draftReferral.additionalRiskInformation = "risk"
+      draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
+
+      val personCurrentLocationType = PersonCurrentLocationType.CUSTODY
+      val personCustodyPrisonId = "ABC"
+      draftReferral.personCurrentLocationType = personCurrentLocationType
+      draftReferral.personCustodyPrisonId = personCustodyPrisonId
+
+      val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
+      assertThat(referralRepository.findById(sentReferral.id).get().referralLocation?.prisonId).isEqualTo(personCustodyPrisonId)
+      assertThat(referralRepository.findById(sentReferral.id).get().referralLocation?.type).isEqualTo(personCurrentLocationType)
     }
 
     @Test


### PR DESCRIPTION
…date SentReferralDTO to include referral location fields

## What does this pull request do?

Defines the mapping between the Referral and ReferralLocation entities and updates the SentReferralDTO to include referral location fields.

## What is the intent behind these changes?

To expose the person current location fields in the getSentReferral() endpoint so that they can be consumed by the front-end and displayed in the referral details page.
