### PR TITLE
Update DraftReferralDTO with referral location fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -87,6 +87,8 @@ data class DraftReferralDTO(
           ?.sorted(),
         interventionId = referral.intervention.id,
         contractTypeName = referral.intervention.dynamicFrameworkContract.contractType.name,
+        personCurrentLocationType = referral.personCurrentLocationType,
+        personCustodyPrisonId = referral.personCustodyPrisonId
       )
     }
     @Deprecated("deprecated as we will be using from(referral: DraftReferral) in the future")


### PR DESCRIPTION
## What does this pull request do?

Populates DraftReferralDTO with referral location details from Draft Referral

## What is the intent behind these changes?

To return the fields for the current location form in the UI