### PR TITLE
Ipb 4/check for location on draft referral update

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -195,7 +195,7 @@ class DraftReferralService(
   }
 
   fun updatePersonCurrentLocation(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    update.personCurrentLocationType?.let{
+    update.personCurrentLocationType?.let {
       draftReferral.personCurrentLocationType = it
       draftReferral.personCustodyPrisonId = if (it == PersonCurrentLocationType.CUSTODY) update.personCustodyPrisonId else null
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -195,8 +195,10 @@ class DraftReferralService(
   }
 
   fun updatePersonCurrentLocation(draftReferral: DraftReferral, update: DraftReferralDTO) {
-    draftReferral.personCurrentLocationType = update.personCurrentLocationType
-    draftReferral.personCustodyPrisonId = update.personCustodyPrisonId
+    update.personCurrentLocationType?.let{
+      draftReferral.personCurrentLocationType = it
+      draftReferral.personCustodyPrisonId = if (it == PersonCurrentLocationType.CUSTODY) update.personCustodyPrisonId else null
+    }
   }
 
   private fun updateServiceUserNeeds(draftReferral: DraftReferral, update: DraftReferralDTO) {


### PR DESCRIPTION
## What does this pull request do?

Checks if the location type is included in the update before updating the draft referral.

## What is the intent behind these changes?

Stops the draft referral locationtype and prisonId being overwritten with null values on other parts of the draft referral form


