### PR TITLE
Add end-to-end test to the daily NDMIS export job

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,4 +105,5 @@ dependencies {
   testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
   testImplementation("org.mockito:mockito-inline:5.1.1")
+  testImplementation("org.springframework.batch:spring-batch-test")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
@@ -8,7 +8,6 @@ import org.springframework.batch.core.JobParametersBuilder
 import org.springframework.batch.core.JobParametersIncrementer
 import org.springframework.batch.core.step.skip.SkipPolicy
 import org.springframework.batch.item.ItemProcessor
-import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.file.FlatFileHeaderCallback
 import org.springframework.batch.item.file.FlatFileItemWriter
 import org.springframework.batch.item.file.builder.FlatFileItemWriterBuilder
@@ -26,7 +25,6 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.Date
 import kotlin.io.path.createTempDirectory
-import kotlin.io.path.name
 import kotlin.io.path.pathString
 
 @Component
@@ -98,14 +96,6 @@ interface SentReferralProcessor<T> : ItemProcessor<Referral, T> {
   }
 }
 
-class LoggingWriter<T> : ItemWriter<T> {
-  companion object : KLogging()
-
-  override fun write(items: MutableList<out T>) {
-    logger.info(items.toString())
-  }
-}
-
 class TimestampIncrementer : JobParametersIncrementer {
   override fun getNext(inputParams: JobParameters?): JobParameters {
     val params = inputParams ?: JobParameters()
@@ -156,8 +146,9 @@ class CsvLineAggregator<T>(fieldsToExtract: List<String>) : ExtractorLineAggrega
     )
   }
 
-  private val csvPrinter = CSVFormat.DEFAULT
-    .withRecordSeparator("") // the underlying aggregator adds line separators for us
+  private val csvPrinter = CSVFormat.DEFAULT.builder()
+    .setRecordSeparator("") // the underlying aggregator adds line separators for us
+    .build()
 
   override fun doAggregate(fields: Array<out Any>): String {
     val out = StringBuilder()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/BatchUtils.kt
@@ -25,6 +25,9 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.Date
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.name
+import kotlin.io.path.pathString
 
 @Component
 class BatchUtils {
@@ -113,6 +116,20 @@ class TimestampIncrementer : JobParametersIncrementer {
 
     return JobParametersBuilder(params)
       .addLong("timestamp", Instant.now().epochSecond)
+      .toJobParameters()
+  }
+}
+
+class OutputPathIncrementer : JobParametersIncrementer {
+  override fun getNext(inputParams: JobParameters?): JobParameters {
+    val params = inputParams ?: JobParameters()
+
+    if (params.parameters["outputPath"] != null) {
+      return params
+    }
+
+    return JobParametersBuilder(params)
+      .addString("outputPath", createTempDirectory().pathString)
       .toJobParameters()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -183,7 +183,7 @@ class NdmisPerformanceReportJobConfiguration(
     listOf(referralReportFilename, complexityReportFilename, appointmentReportFilename).forEach { file ->
       val path = Path.of(outputPath).resolve(file)
       s3Service.publishFileToS3(ndmisS3Bucket, path, pathPrefix, acl = ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL)
-      path.toFile().delete()
+      path.toFile().deleteOnExit()
     }
     RepeatStatus.FINISHED
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -27,10 +27,10 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStar
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.BatchUtils
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.NPESkipPolicy
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.OutputPathIncrementer
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.S3Service
-import java.io.File
-import kotlin.io.path.createTempDirectory
+import java.nio.file.Path
 
 @Configuration
 @EnableBatchProcessing
@@ -45,16 +45,12 @@ class NdmisPerformanceReportJobConfiguration(
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
   companion object : KLogging()
+
   private val pathPrefix = "dfinterventions/dfi/csv/reports/"
   private val referralReportFilename = "crs_performance_report-v2-referrals.csv"
   private val complexityReportFilename = "crs_performance_report-v2-complexity.csv"
   private val appointmentReportFilename = "crs_performance_report-v2-appointments.csv"
-
   private val skipPolicy = NPESkipPolicy()
-  private val tmpDir = createTempDirectory()
-  private val referralReportPath = tmpDir.resolve(referralReportFilename)
-  private val complexityReportPath = tmpDir.resolve(complexityReportFilename)
-  private val appointmentsReportPath = tmpDir.resolve(appointmentReportFilename)
 
   @Bean
   fun ndmisPerformanceReportJobLauncher(ndmisPerformanceReportJob: Job): ApplicationRunner {
@@ -76,10 +72,10 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   @StepScope
-  fun ndmisReferralsWriter(): FlatFileItemWriter<ReferralsData> {
+  fun ndmisReferralsWriter(@Value("#{jobParameters['outputPath']}") outputPath: String): FlatFileItemWriter<ReferralsData> {
     return batchUtils.csvFileWriter(
       "ndmisReferralsPerformanceReportWriter",
-      FileSystemResource(referralReportPath),
+      FileSystemResource(Path.of(outputPath).resolve(referralReportFilename)),
       ReferralsData.headers,
       ReferralsData.fields
     )
@@ -87,10 +83,10 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   @StepScope
-  fun ndmisComplexityWriter(): FlatFileItemWriter<Collection<ComplexityData>> {
+  fun ndmisComplexityWriter(@Value("#{jobParameters['outputPath']}") outputPath: String): FlatFileItemWriter<Collection<ComplexityData>> {
     return batchUtils.recursiveCollectionCsvFileWriter(
       "ndmisComplexityPerformanceReportWriter",
-      FileSystemResource(complexityReportPath),
+      FileSystemResource(Path.of(outputPath).resolve(complexityReportFilename)),
       ComplexityData.headers,
       ComplexityData.fields
     )
@@ -98,10 +94,10 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   @StepScope
-  fun ndmisAppointmentWriter(): FlatFileItemWriter<Collection<AppointmentData>> {
+  fun ndmisAppointmentWriter(@Value("#{jobParameters['outputPath']}") outputPath: String): FlatFileItemWriter<Collection<AppointmentData>> {
     return batchUtils.recursiveCollectionCsvFileWriter(
       "ndmisAppointmentPerformanceReportWriter",
-      FileSystemResource(appointmentsReportPath),
+      FileSystemResource(Path.of(outputPath).resolve(appointmentReportFilename)),
       AppointmentData.headers,
       AppointmentData.fields
     )
@@ -111,19 +107,17 @@ class NdmisPerformanceReportJobConfiguration(
   fun ndmisPerformanceReportJob(
     ndmisWriteReferralToCsvStep: Step,
     ndmisWriteComplexityToCsvStep: Step,
-    ndmisWriteAppointmentToCsvStep: Step
+    ndmisWriteAppointmentToCsvStep: Step,
+    pushToS3Step: Step,
   ): Job {
     val validator = DefaultJobParametersValidator()
-    validator.setRequiredKeys(
-      arrayOf(
-        "timestamp",
-      )
-    )
+    validator.setRequiredKeys(arrayOf("timestamp", "outputPath"))
 
     return jobBuilderFactory["ndmisPerformanceReportJob"]
       // this incrementer adds a timestamp parameter meaning we can
       // re-run the job with the same commandline params multiple times
       .incrementer(TimestampIncrementer())
+      .incrementer(OutputPathIncrementer())
       .validator(validator)
       .start(ndmisWriteReferralToCsvStep)
       .next(ndmisWriteComplexityToCsvStep)
@@ -180,13 +174,17 @@ class NdmisPerformanceReportJobConfiguration(
       .build()
   }
 
-  private val pushToS3Step = stepBuilderFactory["pushToS3Step"]
-    .tasklet { _: StepContribution, _: ChunkContext ->
-      listOf(referralReportPath, complexityReportPath, appointmentsReportPath).forEach { path ->
-        s3Service.publishFileToS3(ndmisS3Bucket, path, pathPrefix, acl = ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL)
-        File(path.toString()).delete()
-      }
-      RepeatStatus.FINISHED
+  @Bean
+  @JobScope
+  fun pushToS3Step(@Value("#{jobParameters['outputPath']}") outputPath: String): Step =
+    stepBuilderFactory["pushToS3Step"].tasklet(pushFilesToS3(outputPath)).build()
+
+  private fun pushFilesToS3(outputPath: String) = { _: StepContribution, _: ChunkContext ->
+    listOf(referralReportFilename, complexityReportFilename, appointmentReportFilename).forEach { file ->
+      val path = Path.of(outputPath).resolve(file)
+      s3Service.publishFileToS3(ndmisS3Bucket, path, pathPrefix, acl = ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL)
+      path.toFile().delete()
     }
-    .build()
+    RepeatStatus.FINISHED
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.pathString
 
 @Component
 class NdmisPerformanceJobLauncherTestUtils : JobLauncherTestUtils() {
@@ -23,8 +25,12 @@ class NdmisPerformanceReportJobConfigurationTest : IntegrationTestBase() {
   @Autowired
   lateinit var jobLauncher: NdmisPerformanceJobLauncherTestUtils
 
+  private val outputDir = createTempDirectory("test")
+
   fun executeJob(): JobExecution {
-    val parameters = JobParametersBuilder().toJobParameters()
+    val parameters = JobParametersBuilder()
+      .addString("outputPath", outputDir.pathString)
+      .toJobParameters()
     val parametersWithTimestamp = TimestampIncrementer().getNext(parameters)
     return jobLauncher.launchJob(parametersWithTimestamp)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
@@ -13,6 +13,9 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
 import kotlin.io.path.createTempDirectory
+import kotlin.io.path.fileSize
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 import kotlin.io.path.pathString
 
 @Component
@@ -36,8 +39,14 @@ class NdmisPerformanceReportJobConfigurationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `job completes successfully`() {
+  fun `job writes non-empty CSV export files`() {
     val execution = executeJob()
     assertThat(execution.exitStatus).isEqualTo(ExitStatus.COMPLETED)
+    assertThat(outputDir.listDirectoryEntries().filter { it.fileSize() > 0 }.map { it.name })
+      .containsExactlyInAnyOrder(
+        "crs_performance_report-v2-referrals.csv",
+        "crs_performance_report-v2-complexity.csv",
+        "crs_performance_report-v2-appointments.csv",
+      )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.batch.core.ExitStatus
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.JobExecution
+import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.test.JobLauncherTestUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
+
+@Component
+class NdmisPerformanceJobLauncherTestUtils : JobLauncherTestUtils() {
+  @Autowired
+  override fun setJob(@Qualifier("ndmisPerformanceReportJob") job: Job) = super.setJob(job)
+}
+
+class NdmisPerformanceReportJobConfigurationTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var jobLauncher: NdmisPerformanceJobLauncherTestUtils
+
+  fun executeJob(): JobExecution {
+    val parameters = JobParametersBuilder().toJobParameters()
+    val parametersWithTimestamp = TimestampIncrementer().getNext(parameters)
+    return jobLauncher.launchJob(parametersWithTimestamp)
+  }
+
+  @Test
+  fun `job completes successfully`() {
+    val execution = executeJob()
+    assertThat(execution.exitStatus).isEqualTo(ExitStatus.COMPLETED)
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

🔎 **Please review commit-by-commit**

Adds an end-to-end test to the daily NDMIS export job.

To make the job output testable, it now [requires an `outputPath` parameter](https://github.com/ministryofjustice/hmpps-interventions-service/pull/1446/commits/eaa3e89dcccd07d8f00da54d41e667773ad4b75e).

Additionally, [remove warnings from BatchUtils](https://github.com/ministryofjustice/hmpps-interventions-service/commit/aaf18bfd79d4d1480514fa25d93e0186da156179).
- `LoggingWriter` was unused
- `.withRecordSeparator` was deprecated

## What is the intent behind these changes?

To make sure it works before it gets executed by a cronjob.