### PR TITLE
introducing multi platform builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,10 +198,8 @@ workflows:
       - validate_helm:
           context:
             - hmpps-interventions-dev-deploy
-      - hmpps/build_docker:
+      - hmpps/build_multiplatform_docker:
           name: build_and_publish_docker
-          publish: true
-          persist_container_image: true
           filters:
             branches:
               only: [main]


### PR DESCRIPTION
## What does this pull request do?

configures the circle ci to build and push docker images for different platforms (linux/amd64,linux/arm64)

## What is the intent behind these changes?

Building docker images for different architectures((ex: New Macbook M1) will help us use the images seamlessly


