### PR TITLE
upgrading the docker file to use eclipse-temurin 19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.6_10-jre-alpine AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} eclipse-temurin:17.0.6_10-jre-focal AS builder
 
 WORKDIR /app
 
@@ -23,17 +23,19 @@ RUN ./gradlew assemble
 
 
 # ---
-FROM eclipse-temurin:17.0.6_10-jre-alpine AS final
+FROM eclipse-temurin:17.0.6_10-jre-focal AS final
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 # force a rebuild of `apk upgrade` below by invalidating the BUILD_NUMBER env variable on every commit
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
-RUN apk upgrade --no-cache && \
-     apk add --no-cache \
-       curl \
-       tzdata
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install -y \
+      curl \
+      tzdata \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Europe/London
 RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} eclipse-temurin:17.0.6_10-jre-focal AS builder
+FROM eclipse-temurin:17.0.6_10-jre-focal AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What does this pull request do?

- upgrades the docker file to use eclipse-temurin:19-jre base image for the application
- The new multi architecture docker build is not working with the existing eclipse-temurin:17.0.6_10-jre-alpine base image and hence we have to upgrade it

## What is the intent behind these changes?

The latest changes to make the application built multi architecture images  (https://github.com/ministryofjustice/hmpps-interventions-service/pull/1448) requires the base to be eclipse-temurin:19-jre. 
