### PR TITLE
Ipb 10/add expected release date

### DIFF
--- a/doc/adr/0004-make-draft-referral-self-contained.md
+++ b/doc/adr/0004-make-draft-referral-self-contained.md
@@ -1,0 +1,25 @@
+# 1. Make draft referrals self contained
+
+Date: 2023-01-26
+
+## Status
+
+Accepted
+
+## Context
+
+We store data in the service database about draft referrals in a table which contains some sensitive personal data and are 
+looking to add new fields relating to drafts.
+It would be difficult at the moment to delete this when no longer used due to referential constraints, which means we store
+unnecessary data and causes concerns relating to GDPR.
+
+## Decision
+
+We decided to add no further referential constraints on the DRAFT_REFERRALS table, and 
+move to a point where existing constraints are dropped and a job/task added to remove records more than a month old. 
+
+## Consequences
+
+1. DRAFT_REFERRALS table should ideally store all fields needed to store a draft.
+2. The draft data should be considered temporary
+3. Previous referential constraints which link to production data tables are targets for removal

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -50,6 +50,7 @@ data class DraftReferralDTO(
   val contractTypeName: String? = null,
   val personCurrentLocationType: PersonCurrentLocationType? = null,
   val personCustodyPrisonId: String? = null,
+  val hasExpectedReleaseDate: Boolean? = false,
   val expectedReleaseDate: LocalDate? = null,
   val expectedReleaseDateMissingReason: String? = null
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -50,7 +50,7 @@ data class DraftReferralDTO(
   val contractTypeName: String? = null,
   val personCurrentLocationType: PersonCurrentLocationType? = null,
   val personCustodyPrisonId: String? = null,
-  val hasExpectedReleaseDate: Boolean? = false,
+  val hasExpectedReleaseDate: Boolean? = null,
   val expectedReleaseDate: LocalDate? = null,
   val expectedReleaseDateMissingReason: String? = null
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -49,7 +49,9 @@ data class DraftReferralDTO(
   val interventionId: UUID? = null,
   val contractTypeName: String? = null,
   val personCurrentLocationType: PersonCurrentLocationType? = null,
-  val personCustodyPrisonId: String? = null
+  val personCustodyPrisonId: String? = null,
+  val expectedReleaseDate: LocalDate? = null,
+  val expectedReleaseDateMissingReason: String? = null
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {
@@ -88,7 +90,9 @@ data class DraftReferralDTO(
         interventionId = referral.intervention.id,
         contractTypeName = referral.intervention.dynamicFrameworkContract.contractType.name,
         personCurrentLocationType = referral.personCurrentLocationType,
-        personCustodyPrisonId = referral.personCustodyPrisonId
+        personCustodyPrisonId = referral.personCustodyPrisonId,
+        expectedReleaseDate = referral.expectedReleaseDate,
+        expectedReleaseDateMissingReason = referral.expectedReleaseDateMissingReason
       )
     }
     @Deprecated("deprecated as we will be using from(referral: DraftReferral) in the future")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralDetailsDTO.kt
@@ -9,6 +9,8 @@ data class UpdateReferralDetailsDTO(
   val maximumEnforceableDays: Int?,
   val completionDeadline: LocalDate?,
   val furtherInformation: String?,
+  val expectedReleaseDate: LocalDate?,
+  val expectedReleaseDateMissingReason: String?,
   val reasonForChange: String,
 ) {
   val isValidUpdate: Boolean get() = maximumEnforceableDays != null || completionDeadline !== null || furtherInformation !== null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftReferral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -28,7 +29,9 @@ class SentReferralDTO(
   val endOfServiceReportCreationRequired: Boolean,
   val createdBy: AuthUserDTO,
   val personCurrentLocationType: PersonCurrentLocationType?,
-  val personCustodyPrisonId: String?
+  val personCustodyPrisonId: String?,
+  val expectedReleaseDate: LocalDate?,
+  val expectedReleaseDateMissingReason: String?
 ) {
   companion object {
     fun from(referral: Referral, endOfServiceReportRequired: Boolean, draftReferral: DraftReferral? = null): SentReferralDTO {
@@ -54,6 +57,8 @@ class SentReferralDTO(
         endOfServiceReportCreationRequired = endOfServiceReportRequired,
         personCurrentLocationType = referral.referralLocation?.let { it.type },
         personCustodyPrisonId = referral.referralLocation?.let { it.prisonId },
+        expectedReleaseDate = referral.referralLocation?.let { it.expectedReleaseDate },
+        expectedReleaseDateMissingReason = referral.referralLocation?.let { it.expectedReleaseDateMissingReason },
         createdBy = AuthUserDTO.from(referral.createdBy)
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
@@ -5,6 +5,7 @@ import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode.JOIN
 import org.hibernate.annotations.Type
 import org.hibernate.annotations.TypeDef
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.persistence.CascadeType
@@ -67,6 +68,9 @@ class DraftReferral(
   @ElementCollection
   @CollectionTable(name = "referral_complexity_level_ids", joinColumns = [JoinColumn(name = "referral_id")])
   var complexityLevelIds: MutableMap<UUID, UUID>? = null,
+
+  @Column(name = "person_expected_release_date") var expectedReleaseDate: LocalDate? = null,
+  @Column(name = "person_expected_release_date_missing_reason") var expectedReleaseDateMissingReason: String? = null,
 
   // required fields
   @NotNull @ManyToOne(fetch = FetchType.LAZY) val intervention: Intervention,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralLocation.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
 
 import org.hibernate.annotations.Type
 import org.jetbrains.annotations.NotNull
+import java.time.LocalDate
 import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -16,5 +17,7 @@ data class ReferralLocation(
   @Id val id: UUID,
   @OneToOne(fetch = FetchType.LAZY) val referral: Referral,
   @Type(type = "person_current_location_type") @Enumerated(EnumType.STRING) @NotNull @Column(name = "type") val type: PersonCurrentLocationType,
-  @Column(name = "prison_id") val prisonId: String?
+  @Column(name = "prison_id") val prisonId: String?,
+  @Column(name = "expected_release_date") val expectedReleaseDate: LocalDate?,
+  @Column(name = "expected_release_date_missing_reason") val expectedReleaseDateMissingReason: String?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -462,7 +462,9 @@ class DraftReferralService(
           referral = referral,
           type = draftReferral.personCurrentLocationType
             ?: throw ServerWebInputException("can't submit a referral without current location"),
-          prisonId = draftReferral.personCustodyPrisonId
+          prisonId = draftReferral.personCustodyPrisonId,
+          expectedReleaseDate = draftReferral.expectedReleaseDate,
+          expectedReleaseDateMissingReason = draftReferral.expectedReleaseDateMissingReason
         )
       )
       referralRepository.save(referral)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -106,6 +106,8 @@ class DraftReferralService(
         update.maximumEnforceableDays,
         update.completionDeadline,
         update.furtherInformation,
+        update.expectedReleaseDate,
+        update.expectedReleaseDateMissingReason,
         "initial referral details",
       ),
       referral.createdBy,
@@ -116,6 +118,7 @@ class DraftReferralService(
     updateServiceCategoryDetails(referral, update)
     if (currentLocationEnabled) {
       updatePersonCurrentLocation(referral, update)
+      updatePersonExpectedReleaseDate(referral, update)
     }
 
     // this field doesn't fit into any other categories - is this a smell?
@@ -199,6 +202,11 @@ class DraftReferralService(
       draftReferral.personCurrentLocationType = it
       draftReferral.personCustodyPrisonId = if (it == PersonCurrentLocationType.CUSTODY) update.personCustodyPrisonId else null
     }
+  }
+
+  fun updatePersonExpectedReleaseDate(draftReferral: DraftReferral, update: DraftReferralDTO) {
+    draftReferral.expectedReleaseDate = update.expectedReleaseDate
+    draftReferral.expectedReleaseDateMissingReason = update.expectedReleaseDateMissingReason
   }
 
   private fun updateServiceUserNeeds(draftReferral: DraftReferral, update: DraftReferralDTO) {

--- a/src/main/resources/db/migration/V1_125__add_expected_release_date.sql
+++ b/src/main/resources/db/migration/V1_125__add_expected_release_date.sql
@@ -6,8 +6,8 @@ alter table referral_location
     add column expected_release_date date,
     add column expected_release_date_missing_reason text;
 
-INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','person_current_expected_release_date',TRUE, TRUE);
-INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','person_custody_expected_release_date_missing_reason',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','person_expected_release_date',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','person_expected_release_date_missing_reason',TRUE, TRUE);
 
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral_location','expected_release_date',TRUE, TRUE);
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral_location','expected_release_date_missing_reason',TRUE, TRUE);

--- a/src/main/resources/db/migration/V1_125__add_expected_release_date.sql
+++ b/src/main/resources/db/migration/V1_125__add_expected_release_date.sql
@@ -1,0 +1,13 @@
+alter table draft_referral
+    add column person_expected_release_date date,
+    add column person_expected_release_date_missing_reason text;
+
+alter table referral_location
+    add column expected_release_date date,
+    add column expected_release_date_missing_reason text;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','person_current_expected_release_date',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','person_custody_expected_release_date_missing_reason',TRUE, TRUE);
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral_location','expected_release_date',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral_location','expected_release_date_missing_reason',TRUE, TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -252,7 +253,9 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
       id = UUID.randomUUID(),
       referral = referral,
       type = PersonCurrentLocationType.CUSTODY,
-      prisonId = "ABC"
+      prisonId = "ABC" ,
+      expectedReleaseDate = LocalDate.of(2050, 1, 1),
+      expectedReleaseDateMissingReason = null
     )
 
     val out = json.write(SentReferralDTO.from(referral, false))
@@ -263,6 +266,30 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
         "personCustodyPrisonId": "ABC"
       }
     }
+    """
+    )
+  }
+
+  @Test
+  fun `sent referral DTO includes expected release date and missing reason`() {
+    val referral = referralFactory.createSent()
+    referral.referralLocation = ReferralLocation(
+      id = UUID.randomUUID(),
+      referral = referral,
+      type = PersonCurrentLocationType.CUSTODY,
+      prisonId = "ABC",
+      expectedReleaseDate = LocalDate.of(2050, 1, 1),
+      expectedReleaseDateMissingReason = "Looking for a reason"
+    )
+
+    val out = json.write(SentReferralDTO.from(referral, false))
+    Assertions.assertThat(out).isEqualToJson(
+      """
+      {
+        "expectedReleaseDate": "2050-01-01",
+        "expectedReleaseDateMissingReason": "Looking for a reason"
+      }
+    )
     """
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTOTest.kt
@@ -253,7 +253,7 @@ class SentReferralDTOTest(@Autowired private val json: JacksonTester<SentReferra
       id = UUID.randomUUID(),
       referral = referral,
       type = PersonCurrentLocationType.CUSTODY,
-      prisonId = "ABC" ,
+      prisonId = "ABC",
       expectedReleaseDate = LocalDate.of(2050, 1, 1),
       expectedReleaseDateMissingReason = null
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -591,12 +591,14 @@ class SetupAssistant(
     maximumEnforceableDays: Int = 10,
     needsInterpreter: Boolean = true,
     relevantSentenceId: Long = 2600295124,
-    whenUnavailable: String = "She works Mondays 9am - midday"
+    whenUnavailable: String = "She works Mondays 9am - midday",
+    expectedReleaseDate: LocalDate = LocalDate.of(2050,11,1)
   ): Referral {
     referral.selectedServiceCategories = selectedServiceCategories.toMutableSet()
     // required to satisfy foreign key constrains on desired outcomes and complexity levels
     val draftReferral = serviceUserData.draftReferral!!
     draftReferral.serviceUserData = serviceUserData
+    draftReferral.expectedReleaseDate = expectedReleaseDate
     draftReferralRepository.save(draftReferral)
     referralRepository.saveAndFlush(referral)
 
@@ -663,7 +665,8 @@ class SetupAssistant(
     relevantSentenceId: Long = 2600295124,
     whenUnavailable: String = "She works Mondays 9am - midday",
     personCurrentLocationType: PersonCurrentLocationType? = PersonCurrentLocationType.CUSTODY,
-    personCustodyPrisonId: String? = "ABC"
+    personCustodyPrisonId: String? = "ABC",
+    expectedReleaseDate: LocalDate? = LocalDate.of(2050,11,1)
   ): DraftReferral {
     referral.selectedServiceCategories = selectedServiceCategories.toMutableSet()
     // required to satisfy foreign key constrains on desired outcomes and complexity levels
@@ -683,6 +686,7 @@ class SetupAssistant(
     referral.whenUnavailable = whenUnavailable
     referral.personCurrentLocationType = personCurrentLocationType
     referral.personCustodyPrisonId = personCustodyPrisonId
+    referral.expectedReleaseDate = expectedReleaseDate
 
     return draftReferralRepository.save(referral).also {
       val details = referralDetailsRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -592,7 +592,7 @@ class SetupAssistant(
     needsInterpreter: Boolean = true,
     relevantSentenceId: Long = 2600295124,
     whenUnavailable: String = "She works Mondays 9am - midday",
-    expectedReleaseDate: LocalDate = LocalDate.of(2050,11,1)
+    expectedReleaseDate: LocalDate = LocalDate.of(2050, 11, 1)
   ): Referral {
     referral.selectedServiceCategories = selectedServiceCategories.toMutableSet()
     // required to satisfy foreign key constrains on desired outcomes and complexity levels
@@ -666,7 +666,7 @@ class SetupAssistant(
     whenUnavailable: String = "She works Mondays 9am - midday",
     personCurrentLocationType: PersonCurrentLocationType? = PersonCurrentLocationType.CUSTODY,
     personCustodyPrisonId: String? = "ABC",
-    expectedReleaseDate: LocalDate? = LocalDate.of(2050,11,1)
+    expectedReleaseDate: LocalDate? = LocalDate.of(2050, 11, 1)
   ): DraftReferral {
     referral.selectedServiceCategories = selectedServiceCategories.toMutableSet()
     // required to satisfy foreign key constrains on desired outcomes and complexity levels

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
@@ -491,7 +491,7 @@ class AmendReferralServiceTest @Autowired constructor(
       saved = true
     )
 
-    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", "we decided 10 days wasn't enough")
+    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough")
 
     whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(user)
     whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -374,6 +374,8 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draftReferral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draftReferral.personCustodyPrisonId = "ABC"
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+
 
       assertThat(draftReferralService.getDraftReferralForUser(draftReferral.id, user)).isNotNull
 
@@ -390,6 +392,8 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draftReferral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draftReferral.personCustodyPrisonId = "ABC"
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
       assertThat(sentReferral.referenceNumber).isNotNull
@@ -406,6 +410,8 @@ class DraftReferralServiceTest @Autowired constructor(
       val personCustodyPrisonId = "ABC"
       draftReferral.personCurrentLocationType = personCurrentLocationType
       draftReferral.personCustodyPrisonId = personCustodyPrisonId
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
       assertThat(referralLocationRepository.findByReferralId(sentReferral.id)?.referral).isEqualTo(sentReferral)
@@ -424,6 +430,7 @@ class DraftReferralServiceTest @Autowired constructor(
       val personCustodyPrisonId = "ABC"
       draftReferral.personCurrentLocationType = personCurrentLocationType
       draftReferral.personCustodyPrisonId = personCustodyPrisonId
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
       assertThat(referralRepository.findById(sentReferral.id).get().referralLocation?.prisonId).isEqualTo(personCustodyPrisonId)
@@ -439,10 +446,13 @@ class DraftReferralServiceTest @Autowired constructor(
       draft1.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draft1.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draft1.personCustodyPrisonId = "ABC"
+      draft1.expectedReleaseDate = LocalDate.of(2050,11,1)
       draft2.additionalRiskInformation = "risk"
       draft2.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draft2.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draft2.personCustodyPrisonId = "ABC"
+      draft2.expectedReleaseDate = LocalDate.of(2050,11,1)
+
 
       whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.name))
         .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
@@ -462,6 +472,8 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draftReferral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draftReferral.personCustodyPrisonId = "ABC"
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+
 
       val referral = draftReferralService.sendDraftReferral(draftReferral, user)
       val eventCaptor = argumentCaptor<Referral>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -374,8 +374,7 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draftReferral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draftReferral.personCustodyPrisonId = "ABC"
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
-
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       assertThat(draftReferralService.getDraftReferralForUser(draftReferral.id, user)).isNotNull
 
@@ -392,8 +391,7 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draftReferral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draftReferral.personCustodyPrisonId = "ABC"
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
-
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
       assertThat(sentReferral.referenceNumber).isNotNull
@@ -410,8 +408,7 @@ class DraftReferralServiceTest @Autowired constructor(
       val personCustodyPrisonId = "ABC"
       draftReferral.personCurrentLocationType = personCurrentLocationType
       draftReferral.personCustodyPrisonId = personCustodyPrisonId
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
-
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
       assertThat(referralLocationRepository.findByReferralId(sentReferral.id)?.referral).isEqualTo(sentReferral)
@@ -430,7 +427,7 @@ class DraftReferralServiceTest @Autowired constructor(
       val personCustodyPrisonId = "ABC"
       draftReferral.personCurrentLocationType = personCurrentLocationType
       draftReferral.personCustodyPrisonId = personCustodyPrisonId
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       val sentReferral = draftReferralService.sendDraftReferral(draftReferral, user)
       assertThat(referralRepository.findById(sentReferral.id).get().referralLocation?.prisonId).isEqualTo(personCustodyPrisonId)
@@ -446,13 +443,12 @@ class DraftReferralServiceTest @Autowired constructor(
       draft1.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draft1.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draft1.personCustodyPrisonId = "ABC"
-      draft1.expectedReleaseDate = LocalDate.of(2050,11,1)
+      draft1.expectedReleaseDate = LocalDate.of(2050, 11, 1)
       draft2.additionalRiskInformation = "risk"
       draft2.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draft2.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draft2.personCustodyPrisonId = "ABC"
-      draft2.expectedReleaseDate = LocalDate.of(2050,11,1)
-
+      draft2.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       whenever(referenceGenerator.generate(sampleIntervention.dynamicFrameworkContract.contractType.name))
         .thenReturn("AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "AA0000ZZ", "BB0000ZZ")
@@ -472,8 +468,7 @@ class DraftReferralServiceTest @Autowired constructor(
       draftReferral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
       draftReferral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
       draftReferral.personCustodyPrisonId = "ABC"
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
-
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       val referral = draftReferralService.sendDraftReferral(draftReferral, user)
       val eventCaptor = argumentCaptor<Referral>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
@@ -629,7 +629,7 @@ class DraftReferralServiceUnitTest {
       personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
       personCustodyPrisonId = "ABC"
     )
-    draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+    draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
     val authUser = authUserFactory.create()
 
     val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
@@ -644,7 +644,7 @@ class DraftReferralServiceUnitTest {
       personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
       personCustodyPrisonId = "ABC"
     )
-    draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+    draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
     val authUser = authUserFactory.create()
 
     whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(draftReferral.id), any(), any(), anyOrNull(), any(), anyOrNull()))
@@ -675,7 +675,7 @@ class DraftReferralServiceUnitTest {
         personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
         personCustodyPrisonId = "ABC"
       )
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
       val authUser = authUserFactory.create()
 
       whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(draftReferral.id)).thenReturn(draftRisk)
@@ -695,7 +695,7 @@ class DraftReferralServiceUnitTest {
         personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
         personCustodyPrisonId = "ABC"
       )
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(draftReferral.id)).thenReturn(draftRisk)
       whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(draftReferral.id), any(), any(), anyOrNull(), any(), any()))
@@ -714,7 +714,7 @@ class DraftReferralServiceUnitTest {
         personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
         personCustodyPrisonId = "ABC"
       )
-      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+      draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
 
       val authUser = authUserFactory.create()
 
@@ -745,7 +745,7 @@ class DraftReferralServiceUnitTest {
       personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
       personCustodyPrisonId = "ABC"
     )
-    draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
+    draftReferral.expectedReleaseDate = LocalDate.of(2050, 11, 1)
     val authUser = authUserFactory.create()
 
     val sendReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.AdditionalAnswers.returnsFirstArg
 import org.mockito.ArgumentCaptor
@@ -590,6 +591,35 @@ class DraftReferralServiceUnitTest {
 
     assertThat(e.message).contains("can't submit a referral without risk information")
   }
+  @Test
+  fun `cannot send draft referral for person in custody without expected release date or reason`() {
+    val referral = referralFactory.createDraft()
+    referral.additionalRiskInformation = "TEST RISK DATA"
+    referral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
+    referral.personCurrentLocationType = PersonCurrentLocationType.CUSTODY
+    referral.personCustodyPrisonId = "Prison ID 123"
+    val authUser = authUserFactory.create()
+
+    val e = assertThrows<ServerWebInputException> {
+      draftReferralService.sendDraftReferral(referral, authUser)
+    }
+
+    assertThat(e.message).contains("cannot submit a referral for a person in custody without either expected release date or reason")
+  }
+
+  @Test
+  fun `can send draft referral for person in community without expected release date or reason`() {
+    val referral = referralFactory.createDraft()
+    referral.additionalRiskInformation = "TEST RISK DATA"
+    referral.additionalRiskInformationUpdatedAt = OffsetDateTime.now()
+    referral.personCurrentLocationType = PersonCurrentLocationType.COMMUNITY
+    referral.personCustodyPrisonId = null
+    val authUser = authUserFactory.create()
+
+    val e = assertDoesNotThrow {
+      draftReferralService.sendDraftReferral(referral, authUser)
+    }
+  }
 
   @Test
   fun`draft referral risk information is deleted when referral is sent`() {
@@ -599,6 +629,7 @@ class DraftReferralServiceUnitTest {
       personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
       personCustodyPrisonId = "ABC"
     )
+    draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
     val authUser = authUserFactory.create()
 
     val sentReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
@@ -613,6 +644,7 @@ class DraftReferralServiceUnitTest {
       personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
       personCustodyPrisonId = "ABC"
     )
+    draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
     val authUser = authUserFactory.create()
 
     whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(draftReferral.id), any(), any(), anyOrNull(), any(), anyOrNull()))
@@ -643,6 +675,7 @@ class DraftReferralServiceUnitTest {
         personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
         personCustodyPrisonId = "ABC"
       )
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
       val authUser = authUserFactory.create()
 
       whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(draftReferral.id)).thenReturn(draftRisk)
@@ -662,6 +695,7 @@ class DraftReferralServiceUnitTest {
         personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
         personCustodyPrisonId = "ABC"
       )
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
 
       whenever(draftOasysRiskInformationService.getDraftOasysRiskInformation(draftReferral.id)).thenReturn(draftRisk)
       whenever(assessRisksAndNeedsService.createSupplementaryRisk(eq(draftReferral.id), any(), any(), anyOrNull(), any(), any()))
@@ -680,6 +714,7 @@ class DraftReferralServiceUnitTest {
         personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
         personCustodyPrisonId = "ABC"
       )
+      draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
 
       val authUser = authUserFactory.create()
 
@@ -710,6 +745,7 @@ class DraftReferralServiceUnitTest {
       personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
       personCustodyPrisonId = "ABC"
     )
+    draftReferral.expectedReleaseDate = LocalDate.of(2050,11,1)
     val authUser = authUserFactory.create()
 
     val sendReferral = draftReferralService.sendDraftReferral(draftReferral, authUser)
@@ -741,7 +777,7 @@ class DraftReferralServiceUnitTest {
     @Test
     fun `can set person current location when person custody prison id has been selected`() {
       val referral = referralFactory.createDraft()
-      val update = DraftReferralDTO(personCurrentLocationType = PersonCurrentLocationType.CUSTODY, personCustodyPrisonId = "ABC")
+      val update = DraftReferralDTO(personCurrentLocationType = PersonCurrentLocationType.CUSTODY, personCustodyPrisonId = "ABC", expectedReleaseDate = LocalDate.now())
 
       whenever(draftReferralRepository.save(any())).thenReturn(referral)
       draftReferralService.updateDraftReferral(referral, update)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -979,6 +979,7 @@ class ReferralServiceTest @Autowired constructor(
     val id = UUID.randomUUID()
     val existingCompletionDate = LocalDate.of(2022, 10, 21)
     val completionDateToChange = LocalDate.of(2022, 10, 30)
+    val expectedreleaseDate = LocalDate.of(2023, 12, 31)
     val intervention = interventionFactory.create(description = description)
     val referral = referralFactory.createSent(
       createdAt = OffsetDateTime.now(),
@@ -998,7 +999,7 @@ class ReferralServiceTest @Autowired constructor(
     )
     whenever(userMapper.fromToken(jwtAuthentionToken)).thenReturn(authUser)
 
-    val referralToUpdate = UpdateReferralDetailsDTO(20, completionDateToChange, "new information", "we decided 10 days wasn't enough")
+    val referralToUpdate = UpdateReferralDetailsDTO(20, completionDateToChange, "new information", expectedreleaseDate, null, "we decided 10 days wasn't enough")
     val referralDetailsReturned = referralService.updateReferralDetails(referral, referralToUpdate, user)
     val referralDetailsValue = referralService.getReferralDetailsById(referralDetailsReturned?.id)
 
@@ -1033,7 +1034,7 @@ class ReferralServiceTest @Autowired constructor(
 
     whenever(userMapper.fromToken(jwtAuthentionToken)).thenReturn(authUser)
 
-    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", "we decided 10 days wasn't enough")
+    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough")
     val referralDetailsReturned = referralService.updateReferralDetails(referral, referralToUpdate, user)
     val referralDetailsValue = referralService.getReferralDetailsById(referralDetailsReturned?.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -186,7 +186,7 @@ class ReferralServiceUnitTest {
     @Test
     fun `a new version is not created if the update contains no data`() {
       val referral = referralFactory.createSent()
-      val update = UpdateReferralDetailsDTO(null, null, null, reasonForChange = "blah blah")
+      val update = UpdateReferralDetailsDTO(null, null, null, null, null, reasonForChange = "blah blah")
       val returnedValue = referralService.updateReferralDetails(referral, update, referral.createdBy)
 
       verify(referralDetailsRepository, times(0)).saveAndFlush(any())
@@ -213,7 +213,7 @@ class ReferralServiceUnitTest {
 
       val returnedValue = referralService.updateReferralDetails(
         referral,
-        UpdateReferralDetailsDTO(20, null, "new information", "we decided 10 days wasn't enough"),
+        UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough"),
         referral.createdBy,
       )
 


### PR DESCRIPTION
## What does this pull request do?

Adds expected release dates and missing reason fields to draft referral and referral_location.   Also adds validation logic to ensure referral cannot be sent without one of these fields being populated (this is feature flagged).  The fields themselves are nullable, but one of the two should be set in order to send a referral.

## What is the intent behind these changes?

Allow PP's and SP's to share expected release date for a person in custody and associated data within the service, instead of having to do this manually.
