### PR TITLE
configuring to use the latest trivy scan and scan only in main build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,10 +210,10 @@ workflows:
           filters:
             branches:
               ignore: [main]
-      - hmpps/trivy_pipeline_scan:
+      - hmpps/trivy_latest_scan:
           name: vulnerability_scan
           additional_args: --debug --offline-scan
-          requires: [build_docker, build_and_publish_docker]
+          requires: [build_and_publish_docker]
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"


### PR DESCRIPTION
## What does this pull request do?

- configure circle ci to use the latest trivy scan in the pipeline
- configure circle ci to run trivy scan only in main

## What is the intent behind these changes?

-The new multi arch docker build is not working well with existing trivy scan config. So, we need to switch to the latest trivy scan config which will work only in main. So we need to disable it in non main branches
