### PR TITLE
add new custody location field to pact test data

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -272,10 +272,10 @@ class SetupAssistant(
     )
   }
 
-  fun createEndedReferral(id: UUID = UUID.randomUUID(), intervention: Intervention = createIntervention(), endRequestedReason: CancellationReason? = randomCancellationReason(), endRequestedComments: String? = null): Referral {
+  fun createEndedReferral(id: UUID = UUID.randomUUID(), intervention: Intervention = createIntervention(), endRequestedReason: CancellationReason? = randomCancellationReason(), endRequestedComments: String? = null, personCurrentLocationType: PersonCurrentLocationType? = null, personCustodyPrisonId: String? = null): Referral {
     val ppUser = createPPUser()
     val spUser = createSPUser()
-    draftReferralRepository.save(referralFactory.createDraft(id = id, intervention = intervention, createdBy = ppUser))
+    draftReferralRepository.save(referralFactory.createDraft(id = id, intervention = intervention, createdBy = ppUser, personCustodyPrisonId = personCustodyPrisonId, personCurrentLocationType = personCurrentLocationType))
     return referralRepository.save(referralFactory.createEnded(id = id, intervention = intervention, createdBy = ppUser, sentBy = ppUser, endRequestedBy = ppUser, assignments = listOf(ReferralAssignment(OffsetDateTime.now(), spUser, spUser)), endRequestedReason = endRequestedReason, endRequestedComments = endRequestedComments))
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ReferralContracts.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.pact
 
 import au.com.dius.pact.provider.junitsupport.State
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.integration.SetupAssistant
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -16,6 +17,8 @@ class ReferralContracts(private val setupAssistant: SetupAssistant) {
     val referral = setupAssistant.createEndedReferral(
       id = UUID.fromString("c5554f8f-aac6-4eaf-ba70-63281de35685"),
       endRequestedComments = "Alex was arrested for driving without insurance and immediately recalled",
+      personCurrentLocationType = PersonCurrentLocationType.CUSTODY,
+      personCustodyPrisonId = "aaa",
     )
     setupAssistant.fillReferralFields(referral)
   }


### PR DESCRIPTION
## What does this pull request do?

Adds custody location default data to pact test state

## What is the intent behind these changes?

To match the UI's expectation of the default data setup