### PR TITLE
Make dashboard queries less costly

### DIFF
--- a/src/main/resources/db/migration/V1_127__index_interventions_on_referral.sql
+++ b/src/main/resources/db/migration/V1_127__index_interventions_on_referral.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_referral_intervention
+    ON referral (intervention_id);


### PR DESCRIPTION
## What does this pull request do?

Make "contract referral" queries quicker by indexing `intervention_id` on the referral table.

## What is the intent behind these changes?

### Full scan of the `referral` table

As part of dashboard requests, we execute this query:

```
select
  sentreferr0_.id as id1_24_,
  sentreferr0_.concluded_at as conclude2_24_,
  sentreferr0_.created_by_id as created20_24_,
  sentreferr0_.end_requested_at as end_requ3_24_,
  sentreferr0_.intervention_id as interve21_24_,
  sentreferr0_.reference_number as referenc4_24_,
  sentreferr0_.sent_at as sent_at5_24_,
  sentreferr0_.sent_by_id as sent_by22_24_,
  sentreferr0_.service_usercrn as service_6_24_
from
  referral sentreferr0_
  inner join intervention interventi1_ on sentreferr0_.intervention_id = interventi1_.id
  left outer join dynamic_framework_contract dynamicfra2_ on interventi1_.dynamic_framework_contract_id = dynamicfra2_.id
where
   (
    exists (
      select
        assignment3_.assigned_at,
        assignment3_.assigned_by_id,
        assignment3_.assigned_to_id,
        assignment3_.superseded
      from
        referral_assignments assignment3_
      where
        sentreferr0_.id = assignment3_.referral_id
        and (assignment3_.superseded = false)
    )
  )
  and (dynamicfra2_.id in ('?'))
order by
  sentreferr0_.sent_at desc
limit
  ?;
```

The EXPLAIN ANALYSE result shows that it executes a `Parallel Seq Scan on referral sentreferr0_ (cost=0.00..15,018.82 rows=62,842 width=32) (actual time=0.004..49.541 rows=50,071 loops=3)`

**Doing a full scan for every referral on every dashboard request is wasteful**.

The lookup key is `sentreferr0_.intervention_id`. The index improves this to: `Bitmap Index Scan on ix_referral_intervention_manual_dl (cost=0.00..18.38 rows=1,328 width=0) (actual time=0.071..0.071 rows=909 loops=1)`

### Validating that the index improves performance

I have rolled this index out **on production** for test purposes.
```
dbd6224bbb698ff221.public> CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_referral_intervention_manual_test_by_dl
                               ON referral (intervention_id)
[2023-02-09 16:49:18] completed in 324 ms
```

```
dependencies
| where cloud_RoleName == 'interventions-service' and operation_Name == 'GET /sent-referrals/summaries' and type =='postgresql' and hourofday(timestamp) >= 8 and hourofday(timestamp) <= 18
| summarize t_ms=sum(duration) by operation_Id, timestamp
| summarize percentile(t_ms, 99.9) by bin(timestamp, 1h)
| render columnchart
```
[AppInsight query](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA3VQO0%252FDMBDe%252BRW3JZHSVt0aCbNVFUuHqnvk2ldiyS%252FubFAqfjw2QQUGtnt8rzuNEb1Grwzywwe8T0gIyoasx1OweJQOQQhojE9Ib%252BiTCZ5XXGqjsAHpNYSIJOt8vKMP%252BzNsuKBXhFckkpY3nJ2TVGwWVppjxTYxcHoh5Fe7zKeQKVy1nNtkHHKSLnbwJGD3%252F%252FZRwHZXwn873BDS6FiUttV5idbBZf4V9Fn3cBf4wywQVa%252B02FaRHoZhPXyxL8b%252FmPawnbpCpPo8AhVsdl5NktInxIjQKlEBAAA%253D/timespan/P3D) shows me that the 99.9th percentile time spent on PostgreSQL calls in dashboard queries:

- Was between 62-98 ms
- Now is 25-32 ms

We have about ~5000 requests per hour, so avoiding a full `referral` scan greatly helps.

<img width="1783" alt="image" src="https://user-images.githubusercontent.com/1526295/218105115-069217bf-e3e7-460f-a28c-f2595d0a47cc.png">

And the database CPU load seems to be around 10% less than usual. More conclusive results would arrive after one week:

<img width="2094" alt="image" src="https://user-images.githubusercontent.com/1526295/218105201-08dac280-cf14-4c30-9b3c-51ebac4bdc19.png">
