### PR TITLE
Fix NDMIS export job not running overnight

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -114,10 +114,7 @@ class NdmisPerformanceReportJobConfiguration(
     validator.setRequiredKeys(arrayOf("timestamp", "outputPath"))
 
     return jobBuilderFactory["ndmisPerformanceReportJob"]
-      // this incrementer adds a timestamp parameter meaning we can
-      // re-run the job with the same commandline params multiple times
-      .incrementer(TimestampIncrementer())
-      .incrementer(OutputPathIncrementer())
+      .incrementer { parameters -> OutputPathIncrementer().getNext(TimestampIncrementer().getNext(parameters)) }
       .validator(validator)
       .start(ndmisWriteReferralToCsvStep)
       .next(ndmisWriteComplexityToCsvStep)


### PR DESCRIPTION

## What does this pull request do?

IPB-332: Fix timestamp not incremented in NDMIS job

## What is the intent behind these changes?

Today I learned that `.incrementer` cannot be chained; it simply overwrites the previous value.

I also learned that I cannot test this behaviour end-to-end. Calling `jobLauncher.launchJob()` in
`NdmisPerformanceJobLauncherTestUtils` will complain about both arguments missing rather than calling this `incrementer`.

Local testing has resulted in a successful execution, though.
