### PR TITLE
Show worst performing API calls in a timeline

### DIFF
--- a/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
+++ b/helm_deploy/hmpps-interventions-service/grafana/hmpps-interventions-dashboard.json
@@ -1095,7 +1095,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.9",
+      "pluginVersion": "9.2.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1195,7 +1195,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.9",
+      "pluginVersion": "9.2.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1254,104 +1254,80 @@
       }
     },
     {
-      "aliasColors": {
-        "Limit": "#bf1b00",
-        "Requested (soft limit)": "#f2c96d"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "description": "",
-      "fill": 1,
-      "fillGradient": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
         "y": 41
       },
-      "hiddenSeries": false,
       "id": 27,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "sideWidth": 450,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.5.9",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "9.2.4",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "topk(3,\n  quantile(0.99, \n    increase(http_server_requests_seconds_sum{namespace='$namespace'}[5m])\n    /increase(http_server_requests_seconds_count{namespace='$namespace'}[5m])\n  ) by (uri)\n)",
+          "expr": "quantile(0.99, \n  increase(http_server_requests_seconds_sum{namespace='$namespace'}[5m])\n  /increase(http_server_requests_seconds_count{namespace='$namespace'}[5m])\n) by (method,uri) > 3.0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{ uri }}",
+          "legendFormat": "{{method}} {{ uri }}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Slowest API requests (99th percentile)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
+      "title": "API requests (99th percentile, slower than 3 seconds)",
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:691",
-          "format": "s",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:692",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "state-timeline"
     },
     {
       "aliasColors": {
@@ -1396,7 +1372,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.5.9",
+      "pluginVersion": "9.2.4",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -1501,7 +1477,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.9",
+      "pluginVersion": "9.2.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1612,7 +1588,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.9",
+      "pluginVersion": "9.2.4",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",


### PR DESCRIPTION

## What does this pull request do?

Show worst-performing API calls in a timeline.

| Before | After |
| --- | --- |
| <img width="851" alt="image" src="https://user-images.githubusercontent.com/1526295/218838057-5c5e58f2-521f-4a92-a669-64c16664c1b3.png"> |  <img width="830" alt="image" src="https://user-images.githubusercontent.com/1526295/218837986-fb1e9845-2df2-49d7-a561-a8082af36da5.png">

## What is the intent behind these changes?

So that we can track which are the consistently worst-performing calls in a better visualisation