### PR TITLE
Add referral ended domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisher.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.microsoft.applicationinsights.TelemetryClient
 import mu.KLogging
 import org.springframework.beans.factory.annotation.Value
@@ -23,6 +25,11 @@ class SNSPublisher(
 ) {
   companion object : KLogging()
 
+  init {
+    objectMapper.registerModule(JavaTimeModule())
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+  }
+
   fun publish(referralId: UUID, actor: AuthUserDTO, event: EventDTO) {
     if (enabled) {
       buildRequestAndPublish(event)
@@ -31,6 +38,7 @@ class SNSPublisher(
     }
     sendCustomEvent(referralId, actor, event.eventType)
   }
+
   fun publish(referralId: UUID, actor: AuthUser, event: EventDTO) {
     return publish(referralId, AuthUserDTO.from(actor), event)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EventDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/EventDTO.kt
@@ -2,12 +2,26 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import java.time.OffsetDateTime
 
+data class PersonIdentifier(
+  val type: String,
+  val value: String,
+)
+
+data class PersonReference(
+  val identifiers: List<PersonIdentifier> = listOf(),
+) {
+  companion object {
+    fun crn(crn: String): PersonReference = PersonReference(listOf(PersonIdentifier(type = "CRN", value = crn)))
+  }
+}
+
 data class EventDTO(
   val eventType: String,
   val description: String,
   val detailUrl: String,
   val occurredAt: OffsetDateTime,
-  val additionalInformation: Map<String, Any>
+  val additionalInformation: Map<String, Any>,
+  val personReference: PersonReference? = null,
 ) {
   val version: Int = 1
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -35,7 +35,7 @@ class ReferralEndingEvent(
   val detailUrl: String,
 ) : ApplicationEvent(source) {
   override fun toString(): String {
-    return "ReferralEndRequestedEvent(state=$state, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
+    return "ReferralEndingEvent(state=$state, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -96,6 +96,9 @@ class Referral(
   @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "referral_id")
   private val referralDetailsHistory: Set<ReferralDetails>? = null,
 ) {
+  val urn: String
+    get() = "urn:hmpps:interventions-referral:$id"
+
   val approvedActionPlan: ActionPlan?
     get() = actionPlans?.filter { it.approvedAt != null }?.maxByOrNull { it.approvedAt!! }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -67,10 +67,8 @@ class EndOfServiceReportService(
 
     endOfServiceReportEventPublisher.endOfServiceReportSubmittedEvent(draftEndOfServiceReport)
 
-    val savedReport = endOfServiceReportRepository.save(draftEndOfServiceReport)
-    referralConcluder.concludeIfEligible(savedReport.referral)
-
-    return savedReport
+    return endOfServiceReportRepository.save(draftEndOfServiceReport)
+      .also { referralConcluder.concludeIfEligible(it.referral) }
   }
 
   private fun updateDraftEndOfServiceReportAsSubmitted(endOfServiceReport: EndOfServiceReport, submittedByUser: AuthUser) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -207,10 +207,8 @@ class ReferralService(
     referral.endRequestedReason = reason
     comments?.let { referral.endRequestedComments = it }
 
-    val savedReferral = referralRepository.save(referral)
-    referralConcluder.concludeIfEligible(referral)
-
-    return savedReferral
+    return referralRepository.save(referral)
+      .also { referralConcluder.concludeIfEligible(it) }
   }
 
   fun updateReferralDetails(referral: Referral, update: UpdateReferralDetailsDTO, actor: AuthUser): ReferralDetails? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralConcludedListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralConcludedListener.kt
@@ -22,41 +22,17 @@ class ReferralConcludedListener(
 ) : ApplicationListener<ReferralConcludedEvent>, SNSService {
   @AsyncEventExceptionHandling
   override fun onApplicationEvent(event: ReferralConcludedEvent) {
-    when (event.type) {
-      ReferralConcludedState.CANCELLED -> {
-        val snsEvent = EventDTO(
-          "intervention.referral.cancelled",
-          "A referral has been cancelled",
-          event.detailUrl,
-          event.referral.concludedAt!!,
-          mapOf("referralId" to event.referral.id)
-        )
-        snsPublisher.publish(event.referral.id, event.referral.endRequestedBy!!, snsEvent)
-      }
-
-      ReferralConcludedState.PREMATURELY_ENDED -> {
-        val snsEvent = EventDTO(
-          "intervention.referral.prematurely-ended",
-          "A referral has been ended prematurely",
-          event.detailUrl,
-          event.referral.concludedAt!!,
-          mapOf("referralId" to event.referral.id)
-        )
-        snsPublisher.publish(event.referral.id, event.referral.endRequestedBy!!, snsEvent)
-      }
-
-      ReferralConcludedState.COMPLETED -> {
-        val snsEvent = EventDTO(
-          "intervention.referral.completed",
-          "A referral has been completed",
-          event.detailUrl,
-          event.referral.concludedAt!!,
-          mapOf("referralId" to event.referral.id)
-        )
-        // This is a system generated event at present and as such the actor will represent this
-        snsPublisher.publish(event.referral.id, AuthUser.interventionsServiceUser, snsEvent)
-      }
-    }
+    val snsEvent = EventDTO(
+      "intervention.referral.concluded",
+      "The referral has concluded, no more work is needed",
+      event.detailUrl,
+      event.referral.concludedAt!!,
+      mapOf(
+        "deliveryState" to event.type.name,
+        "referralId" to event.referral.id,
+      )
+    )
+    snsPublisher.publish(event.referral.id, AuthUser.interventionsServiceUser, snsEvent)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListener.kt
@@ -12,7 +12,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
-class ReferralEndingIntegrationListener(
+class ReferralEndingListener(
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.probation-practitioner.referral-details}") private val ppReferralDetailsLocation: String,
   @Value("\${community-api.locations.ended-referral}") private val communityAPIEndedReferralLocation: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListener.kt
@@ -5,7 +5,10 @@ import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEndingEvent
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralEndRequest
 import java.time.OffsetDateTime
@@ -17,9 +20,31 @@ class ReferralEndingListener(
   @Value("\${interventions-ui.locations.probation-practitioner.referral-details}") private val ppReferralDetailsLocation: String,
   @Value("\${community-api.locations.ended-referral}") private val communityAPIEndedReferralLocation: String,
   @Value("\${community-api.integration-context}") private val integrationContext: String,
+  private val snsPublisher: SNSPublisher,
   private val communityAPIClient: CommunityAPIClient,
 ) : ApplicationListener<ReferralEndingEvent>, CommunityAPIService {
   override fun onApplicationEvent(event: ReferralEndingEvent) {
+    sendDomainEvent(event)
+    terminateNSI(event)
+  }
+
+  private fun sendDomainEvent(event: ReferralEndingEvent) {
+    val snsEvent = EventDTO(
+      eventType = "intervention.referral.ended",
+      description = "The referral has ended. It might still require admin work from providers",
+      detailUrl = event.detailUrl,
+      occurredAt = endedTime(event),
+      additionalInformation = mapOf(
+        "deliveryState" to event.state.name,
+        "referralId" to event.referral.id.toString(),
+        "referralURN" to event.referral.urn,
+        "referralProbationUserURL" to referralDetailsUrl(event.referral.id),
+      ),
+    )
+    snsPublisher.publish(event.referral.id, AuthUser.interventionsServiceUser, snsEvent)
+  }
+
+  private fun terminateNSI(event: ReferralEndingEvent) {
     communityAPIClient.makeAsyncPostRequest(
       communityAPISentReferralUrl(event.referral.serviceUserCRN),
       ReferralEndRequest(
@@ -34,6 +59,8 @@ class ReferralEndingListener(
     )
   }
 
+  // TODO code smell: we are guessing at what happened by looking at data
+  // Better would be to emit "ReferralCancelledEvent" and "ReferralCompletedEvent" and listen to them to create this domain event
   private fun endedTime(event: ReferralEndingEvent): OffsetDateTime =
     event.referral.concludedAt ?: event.referral.endRequestedAt ?: OffsetDateTime.now()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListener.kt
@@ -7,6 +7,7 @@ import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.PersonReference
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEndingEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.CommunityAPIService
@@ -40,6 +41,7 @@ class ReferralEndingListener(
         "referralURN" to event.referral.urn,
         "referralProbationUserURL" to referralDetailsUrl(event.referral.id),
       ),
+      personReference = PersonReference.crn(event.referral.serviceUserCRN),
     )
     snsPublisher.publish(event.referral.id, AuthUser.interventionsServiceUser, snsEvent)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/SNSPublisherTest.kt
@@ -14,24 +14,26 @@ import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.PersonReference
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import java.time.OffsetDateTime
 import java.util.UUID
 
 class SNSPublisherTest {
   private val snsClient = mock<SnsClient>()
-  private val objectMapper = mock<ObjectMapper>()
+  private val objectMapper = ObjectMapper()
   private val telemetryClient = mock<TelemetryClient>()
 
   private val aReferralId = UUID.fromString("82138d14-3835-442b-b39b-9f8a07650bbe")
   private val aUser = AuthUser("d7c4c3a7a7", "irrelevant", "d7c4c3a7a7@example.org")
 
   val event = EventDTO(
-    "intervention.test.event",
-    "A referral has been sent to a Service Provider",
-    "http:test/abc",
-    OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
-    mapOf()
+    eventType = "intervention.test.event",
+    description = "A referral has been sent to a Service Provider",
+    detailUrl = "http:test/abc",
+    occurredAt = OffsetDateTime.parse("2020-12-04T10:42:43.123+00:00"),
+    additionalInformation = mapOf("somethingSpecific" to 42),
+    personReference = PersonReference.crn("X123456"),
   )
 
   private fun snsPublisher(enabled: Boolean): SNSPublisher {
@@ -39,15 +41,34 @@ class SNSPublisherTest {
   }
 
   @Test
-  fun `successful event published`() {
-    whenever(objectMapper.writeValueAsString(event)).thenReturn("{}")
+  fun `puts eventType into the message attributes so listener can use it for filtering`() {
     snsPublisher(true).publish(aReferralId, aUser, event)
 
     val requestCaptor = argumentCaptor<PublishRequest>()
     verify(snsClient).publish(requestCaptor.capture())
     assertThat(requestCaptor.firstValue.messageAttributes()["eventType"]!!.dataType()).isEqualTo("String")
     assertThat(requestCaptor.firstValue.messageAttributes()["eventType"]!!.stringValue()).isEqualTo(event.eventType)
-    assertThat(requestCaptor.firstValue.message()).isEqualTo("{}")
+  }
+
+  @Test
+  fun `serialises the event payload as JSON`() {
+    snsPublisher(true).publish(aReferralId, aUser, event)
+
+    val requestCaptor = argumentCaptor<PublishRequest>()
+    verify(snsClient).publish(requestCaptor.capture())
+    assertThat(requestCaptor.firstValue.message()).isEqualTo(
+      """
+      {
+      "eventType":"intervention.test.event",
+      "description":"A referral has been sent to a Service Provider",
+      "detailUrl":"http:test/abc",
+      "occurredAt":"2020-12-04T10:42:43.123Z",
+      "additionalInformation":{"somethingSpecific":42},
+      "personReference":{"identifiers":[{"type":"CRN","value":"X123456"}]},
+      "version":1
+      }
+      """.trimIndent().replace("\n", "")
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralTest.kt
@@ -16,6 +16,13 @@ internal class ReferralTest {
   private val authUserFactory = AuthUserFactory()
   private val actionPlanFactory = ActionPlanFactory()
 
+  @Test
+  fun `referral URN contains the ID`() {
+    val uuid = UUID.fromString("70ce237c-9b9c-4028-aae5-52c4622b22ca")
+    val referral = referralFactory.createSent(id = uuid)
+    assertThat(referral.urn).isEqualTo("urn:hmpps:interventions-referral:70ce237c-9b9c-4028-aae5-52c4622b22ca")
+  }
+
   @Nested
   inner class Assignments {
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.mockito.AdditionalAnswers
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.firstValue
@@ -175,11 +176,10 @@ class EndOfServiceReportServiceTest {
     val authUser = AuthUser("CRN123", "auth", "user")
 
     val endOfServiceReport = endOfServiceReportFactory.create(id = endOfServiceReportId)
-    val referral = referralFactory.createSent()
 
     whenever(endOfServiceReportRepository.findById(any())).thenReturn(of(endOfServiceReport))
-    whenever(endOfServiceReportRepository.save(any())).thenReturn(endOfServiceReport)
-    whenever(authUserRepository.save(any())).thenReturn(authUser)
+    whenever(endOfServiceReportRepository.save(any())).thenAnswer(AdditionalAnswers.returnsFirstArg<EndOfServiceReport>())
+    whenever(authUserRepository.save(any())).thenAnswer(AdditionalAnswers.returnsFirstArg<AuthUser>())
 
     val argumentCaptor: ArgumentCaptor<EndOfServiceReport> = ArgumentCaptor.forClass(EndOfServiceReport::class.java)
     endOfServiceReportService.submitEndOfServiceReport(endOfServiceReportId, authUser)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -4,6 +4,7 @@ import io.netty.handler.timeout.ReadTimeoutException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.AdditionalAnswers
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.firstValue
@@ -19,7 +20,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.User
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAmendmentDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateReferralDetailsDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.CancellationReason
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
@@ -114,8 +117,8 @@ class ReferralServiceUnitTest {
     val cancellationReason = cancellationReasonFactory.create()
     val cancellationComments = "comment"
 
-    whenever(authUserRepository.save(authUser)).thenReturn(authUser)
-    whenever(referralRepository.save(any())).thenReturn(referralFactory.createEnded(endRequestedComments = cancellationComments))
+    whenever(authUserRepository.save(any())).thenAnswer(AdditionalAnswers.returnsFirstArg<AuthUser>())
+    whenever(referralRepository.save(any())).thenAnswer(AdditionalAnswers.returnsFirstArg<Referral>())
 
     referralService.requestReferralEnd(referral, authUser, cancellationReason, cancellationComments)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListenerTest.kt
@@ -7,6 +7,8 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.PersonIdentifier
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.PersonReference
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEndingEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
@@ -31,6 +33,7 @@ private fun referralEndingEvent(state: ReferralConcludedState): ReferralEndingEv
       id = UUID.fromString("68df9f6c-3fcb-4ec6-8fcf-96551cd9b080"),
       referenceNumber = "HAS71263",
       relevantSentenceId = 123456789,
+      serviceUserCRN = "T123000",
       sentAt = sentAtDefault,
       endRequestedAt = cancelledAtDefault,
       endRequestedBy = AuthUser("ecd7b8d690", "irrelevant", "irrelevant"),
@@ -74,7 +77,12 @@ internal class ReferralEndingListenerTest {
         "referralId" to "68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
         "referralURN" to "urn:hmpps:interventions-referral:68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
         "referralProbationUserURL" to "http://testUrl/pp/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
-      )
+      ),
+      personReference = PersonReference(
+        identifiers = listOf(
+          PersonIdentifier(type = "CRN", value = "T123000")
+        )
+      ),
     )
     verify(snsPublisher).publish(event.referral.id, AuthUser.interventionsServiceUser, eventPayload)
   }
@@ -86,7 +94,7 @@ internal class ReferralEndingListenerTest {
     listener.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
+      "secure/offenders/crn/T123000/referral/end/context/commissioned-rehabilitation-services",
       ReferralEndRequest(
         contractType = "ACC",
         startedAt = sentAtDefault,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListenerTest.kt
@@ -43,9 +43,9 @@ private fun referralEndingEvent(state: ReferralConcludedState): ReferralEndingEv
   )
 }
 
-internal class ReferralEndingIntegrationListenerTest {
+internal class ReferralEndingListenerTest {
   private val communityAPIClient = mock<CommunityAPIClient>()
-  private val listener = ReferralEndingIntegrationListener(
+  private val listener = ReferralEndingListener(
     "http://testUrl",
     "/pp/referral/{id}",
     "secure/offenders/crn/{crn}/referral/end/context/{contextName}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralEndingListenerTest.kt
@@ -1,9 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.listeners
 
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.CommunityAPIClient
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.SNSPublisher
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.EventDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEndingEvent
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
@@ -16,7 +19,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 
 private val sentAtDefault = OffsetDateTime.of(2020, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
-private val concludedAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
+private val cancelledAtDefault = OffsetDateTime.of(2020, 2, 2, 2, 2, 2, 2, ZoneOffset.UTC)
 
 private fun referralEndingEvent(state: ReferralConcludedState): ReferralEndingEvent {
   val referralFactory = ReferralFactory()
@@ -29,7 +32,7 @@ private fun referralEndingEvent(state: ReferralConcludedState): ReferralEndingEv
       referenceNumber = "HAS71263",
       relevantSentenceId = 123456789,
       sentAt = sentAtDefault,
-      concludedAt = concludedAtDefault,
+      endRequestedAt = cancelledAtDefault,
       endRequestedBy = AuthUser("ecd7b8d690", "irrelevant", "irrelevant"),
       assignments = listOf(
         ReferralAssignment(
@@ -44,70 +47,54 @@ private fun referralEndingEvent(state: ReferralConcludedState): ReferralEndingEv
 }
 
 internal class ReferralEndingListenerTest {
+  private val snsPublisher = mock<SNSPublisher>()
   private val communityAPIClient = mock<CommunityAPIClient>()
   private val listener = ReferralEndingListener(
     "http://testUrl",
     "/pp/referral/{id}",
     "secure/offenders/crn/{crn}/referral/end/context/{contextName}",
     "commissioned-rehabilitation-services",
-    communityAPIClient
+    snsPublisher,
+    communityAPIClient,
   )
 
-  @Test
-  fun `terminates the NSI for the cancelled referral`() {
-    val event = referralEndingEvent(ReferralConcludedState.CANCELLED)
+  @ParameterizedTest
+  @EnumSource(ReferralConcludedState::class)
+  fun `publishes domain event`(state: ReferralConcludedState) {
+    val event = referralEndingEvent(state)
     listener.onApplicationEvent(event)
 
-    verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
-      ReferralEndRequest(
-        "ACC",
-        sentAtDefault,
-        concludedAtDefault,
-        123456789,
-        event.referral.id,
-        "CANCELLED",
-        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
-          "http://testUrl/pp/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
+    val eventPayload = EventDTO(
+      eventType = "intervention.referral.ended",
+      description = "The referral has ended. It might still require admin work from providers",
+      detailUrl = "http://localhost:8080/sent-referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
+      occurredAt = cancelledAtDefault,
+      additionalInformation = mapOf(
+        "deliveryState" to state.name,
+        "referralId" to "68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
+        "referralURN" to "urn:hmpps:interventions-referral:68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
+        "referralProbationUserURL" to "http://testUrl/pp/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
       )
     )
+    verify(snsPublisher).publish(event.referral.id, AuthUser.interventionsServiceUser, eventPayload)
   }
 
-  @Test
-  fun `terminates the NSI for the prematurely ended referral`() {
-    val event = referralEndingEvent(ReferralConcludedState.PREMATURELY_ENDED)
+  @ParameterizedTest
+  @EnumSource(ReferralConcludedState::class)
+  fun `terminates the NSI`(state: ReferralConcludedState) {
+    val event = referralEndingEvent(state)
     listener.onApplicationEvent(event)
 
     verify(communityAPIClient).makeAsyncPostRequest(
       "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
       ReferralEndRequest(
-        "ACC",
-        sentAtDefault,
-        concludedAtDefault,
-        123456789,
-        event.referral.id,
-        "PREMATURELY_ENDED",
-        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
-          "http://testUrl/pp/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
-      )
-    )
-  }
-
-  @Test
-  fun `terminates the NSI for the completed referral`() {
-    val event = referralEndingEvent(ReferralConcludedState.COMPLETED)
-    listener.onApplicationEvent(event)
-
-    verify(communityAPIClient).makeAsyncPostRequest(
-      "secure/offenders/crn/X123456/referral/end/context/commissioned-rehabilitation-services",
-      ReferralEndRequest(
-        "ACC",
-        sentAtDefault,
-        concludedAtDefault,
-        123456789,
-        event.referral.id,
-        "COMPLETED",
-        "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
+        contractType = "ACC",
+        startedAt = sentAtDefault,
+        endedAt = cancelledAtDefault,
+        sentenceId = 123456789,
+        referralId = event.referral.id,
+        endType = state.name,
+        notes = "Referral Ended for Accommodation Referral HAS71263 with Prime Provider Harmony Living\n" +
           "http://testUrl/pp/referral/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080",
       )
     )


### PR DESCRIPTION
## What does this pull request do?

- Adds an `intervention.referral.ended` domain event. 
- Collapses the "concluded" events into `intervention.referral.concluded`.
- Removes test duplication for the three states (cancelled, prematurely ended, completed) using `@ParameterizedTest` and `@EnumSource`.
- Does **not** include a feature flag for turning off the POST calls. That can be done in a separate PR.

## Where should the reviewer start?

Please read #1471, then please review commit-by-commit.

## What is the intent behind these changes?

[PI-795](https://dsdmoj.atlassian.net/browse/PI-795): We want to remove calling the `community-api` endpoint in `ReferralEndingListener` and replace it with an SNS listener.

The payload on the event will enable us to switch over time.

[PI-795]: https://dsdmoj.atlassian.net/browse/PI-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ