### PR TITLE
Remove redundant flush calls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -250,11 +250,11 @@ class ReferralService(
       newDetails.maximumEnforceableDays = it
     }
 
-    referralDetailsRepository.saveAndFlush(newDetails)
+    referralDetailsRepository.save(newDetails)
 
     if (existingDetails !== newDetails) {
       existingDetails.supersededById = newDetails.id
-      referralDetailsRepository.saveAndFlush(existingDetails)
+      referralDetailsRepository.save(existingDetails)
 
       eventPublisher.referralDetailsChangedEvent(referral, newDetails, existingDetails)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -189,7 +189,7 @@ class ReferralServiceUnitTest {
       val update = UpdateReferralDetailsDTO(null, null, null, null, null, reasonForChange = "blah blah")
       val returnedValue = referralService.updateReferralDetails(referral, update, referral.createdBy)
 
-      verify(referralDetailsRepository, times(0)).saveAndFlush(any())
+      verify(referralDetailsRepository, times(0)).save(any())
       assertThat(returnedValue).isNull()
     }
 
@@ -218,7 +218,7 @@ class ReferralServiceUnitTest {
       )
 
       val captor = ArgumentCaptor.forClass(ReferralDetails::class.java)
-      verify(referralDetailsRepository, times(2)).saveAndFlush(captor.capture())
+      verify(referralDetailsRepository, times(2)).save(captor.capture())
 
       val oldReferralValue = ReferralAmendmentDetails(listOf(existingDetails.completionDeadline.toString()))
       val newValue = ReferralAmendmentDetails(listOf(returnedValue?.completionDeadline.toString()))


### PR DESCRIPTION

## What does this pull request do?

saveAndFlush is called twice in the update referral details code, but result isn't read in either record.

Choosing to rely on @Transactional behaviour instead to commit or rollback.

Fixed tests with verify calls expecting saveAndFlush > now expecting save.


## What is the intent behind these changes?

Make updates to referral transactional and atomic so we don't get insert of new referral without making the old referral details superseded.   Avoid redundant intermediate flushes and improve performance.


