### PR TITLE
setting the kotlin compiler to Version 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.3"
   kotlin("plugin.spring") version "1.8.10"
@@ -20,6 +21,12 @@ jacoco {
 }
 
 tasks {
+
+  withType<KotlinCompile> {
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+  }
   test {
     useJUnitPlatform {
       exclude("**/*PactTest*")


### PR DESCRIPTION
## What does this pull request do?

- Setting the kotlin compiler to Version 17

## What is the intent behind these changes?

- The base dps gradle spring boot has compiler version 11
