### PR TITLE
Add columns to appointment table to support data cleanup

### DIFF
--- a/src/main/resources/db/migration/V1_132__add_superseded_control_appointments.sql
+++ b/src/main/resources/db/migration/V1_132__add_superseded_control_appointments.sql
@@ -1,0 +1,6 @@
+alter table appointment
+    add column superseded_by_appointment_id uuid NULL,
+    add column stale bool NOT NULL DEFAULT false;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('appointment','superseded_by_appointment_id', FALSE, FALSE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('appointment','stale', FALSE, FALSE);


### PR DESCRIPTION
New columns will allow a self referring FK to be added later (not in this commit)

Also allow a column to flag data created by duplicate submits to be "stale" and thus not shown from JPA joins (again to be added later).

## What does this pull request do?

Adds new columns to the appoinment table to support data cleanup activities

## What is the intent behind these changes?

To allow only relevant data to be selected from the appoinment table, and allow a constraint to be added later to keep data self referring and consistent.
