### PR TITLE
Allow Prisoner release date fields to be null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/PrisonerOffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/PrisonerOffenderSearchService.kt
@@ -9,14 +9,14 @@ import java.time.LocalDate
 
 data class Prisoner(
   val prisonId: String,
-  val releaseDate: LocalDate,
-  val confirmedReleaseDate: LocalDate,
-  val nonDtoReleaseDate: LocalDate,
-  val automaticReleaseDate: LocalDate,
-  val postRecallReleaseDate: LocalDate,
-  val conditionalReleaseDate: LocalDate,
-  val actualParoleDate: LocalDate,
-  val dischargeDate: LocalDate
+  val releaseDate: LocalDate?,
+  val confirmedReleaseDate: LocalDate?,
+  val nonDtoReleaseDate: LocalDate?,
+  val automaticReleaseDate: LocalDate?,
+  val postRecallReleaseDate: LocalDate?,
+  val conditionalReleaseDate: LocalDate?,
+  val actualParoleDate: LocalDate?,
+  val dischargeDate: LocalDate?
 )
 
 @Service


### PR DESCRIPTION
## What does this pull request do?

Updates Prisoner release dates fields to be nullable

## What is the intent behind these changes?

To prevent errors occurring when parsing the Prisoner response with some null release date fields from prisoner-offender-search preventing the non-null fields being recorded.
