### PR TITLE
Add service categories to GM Women's services

### DIFF
--- a/src/main/resources/db/migration/V1_133__add_gmws_service_categories.sql
+++ b/src/main/resources/db/migration/V1_133__add_gmws_service_categories.sql
@@ -1,0 +1,6 @@
+INSERT INTO contract_type_service_category (contract_type_id, service_category_id)
+VALUES
+-- Women's Support Services (GM)
+     ('a93c152c-ed56-48f9-92e8-401ff7aa2fa8', '428ee70f-3001-4399-95a6-ad25eaaede16') -- Accommodation
+     , ('a93c152c-ed56-48f9-92e8-401ff7aa2fa8', '96a63c39-4371-4f17-a6ec-265755f0cf7b') -- Finance, Benefits and Debt
+     , ('a93c152c-ed56-48f9-92e8-401ff7aa2fa8', '76bcdb97-1dea-41c1-a4f8-899d88e5d679') -- Dependency and Recovery


### PR DESCRIPTION
## What does this pull request do?

Adds a  migration file to link new service category ids to the Women's Support Services (GM) contract type id

## What is the intent behind these changes?

To add the following service categories:

- Accommodation
- Finance, Benefit and Debt
- Dependency and Recovery

To the following contracts: 

 - GM Womens Tameside
 - GM Womens Oldham
 - GM Womens Rochdale
 - GM Womens Salford
 - GM Womens Bolton
 - GM Womens Wigan and Leigh
 - GM Womens Manchester and Trafford
 - GM Womens Bury
 - GM Womens Stockport