### PR TITLE
Ipb 262/onboard contracts and providers with task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ dependencyManagement {
 dependencies {
   // batch processing
   implementation("org.springframework.boot:spring-boot-starter-batch")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2") // also needed runtime for AppInsights
 
   // monitoring and logging
   implementation("io.micrometer:micrometer-registry-prometheus")

--- a/helm_deploy/hmpps-interventions-service/templates/job-contract-onboarding.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-contract-onboarding.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: contract-onboarding
+spec:
+  schedule: "0 2 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: "Never"
+          containers:
+            - name: contract-onboarding
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: Always
+              args: ["--jobName=upsertContractsJob"]
+{{- include "deployment.envs" . | nindent 14 }}

--- a/helm_deploy/hmpps-interventions-service/templates/job-contract-onboarding.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-contract-onboarding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: contract-onboarding
 spec:
   schedule: "0 2 * * *"
+  suspend: true
   jobTemplate:
     spec:
       template:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -17,7 +17,7 @@ class BatchConfiguration(
   fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
     taskExecutor.corePoolSize = poolSize
-    taskExecutor.setQueueCapacity(queueSize)
+    taskExecutor.queueCapacity = queueSize
     taskExecutor.afterPropertiesSet()
 
     val launcher = SimpleJobLauncher()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDefinition.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class RegionDefinition(
+  @JsonProperty("nps_region_code") val npsCode: Char?,
+  @JsonProperty("pcc_region_code") val pccCode: String?,
+)
+
+data class EligibilityDefinition(
+  @JsonProperty("allows_female") val allowsFemale: Boolean,
+  @JsonProperty("allows_male") val allowsMale: Boolean,
+  @JsonProperty("minimum_age") val minimumAge: Int,
+  @JsonProperty("maximum_age") val maximumAge: Int?,
+)
+
+data class SchedulingDefinition(
+  @JsonProperty("hide_before") val hideBefore: LocalDate,
+  @JsonProperty("hide_after") val hideAfter: OffsetDateTime?,
+)
+
+data class ActivityDefinition(
+  @JsonProperty("need_area") val needArea: String,
+  @JsonProperty("activity") val activity: String,
+  @JsonProperty("delivery_method") val deliveryMethod: String,
+  @JsonProperty("delivery_location") val deliveryLocation: String,
+)
+
+data class ProviderDefinition(
+  @JsonProperty("prime_provider_code") val primeProviderId: String,
+  @JsonProperty("subcontractor_codes") val subcontractorIds: List<String>,
+)
+
+data class ContractDefinition(
+  @JsonProperty("internal_contract_id") val internalContractId: UUID,
+  @JsonProperty("contract_reference") val contractReference: String,
+  @JsonProperty("contract_type_id") val contractTypeCode: String,
+  @JsonProperty("region") val region: RegionDefinition,
+  @JsonProperty("eligibility") val eligibility: EligibilityDefinition,
+  @JsonProperty("scheduling") val scheduling: SchedulingDefinition,
+  @JsonProperty("providers") val providers: ProviderDefinition,
+
+  @JsonProperty("internal_intervention_id") val internalInterventionId: UUID,
+  @JsonProperty("intervention_title") val interventionTitle: String,
+  @JsonProperty("short_description") val shortDescription: String?,
+  @JsonProperty("activities") val activities: List<ActivityDefinition>?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDefinitionReader.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDefinitionReader.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import mu.KLogging
+import org.springframework.batch.item.ItemReader
+import org.springframework.stereotype.Component
+import org.springframework.util.ResourceUtils
+import java.io.File
+
+@Component
+class ContractDefinitionReader : ItemReader<ContractDefinition> {
+  companion object : KLogging()
+
+  private var files: Array<File> = ResourceUtils.getFile("classpath:contracts/").listFiles()
+  private var index = 0
+  private val objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+
+  override fun read(): ContractDefinition? {
+    if (files.size <= index) return null
+
+    val currentIndex = index
+    index++
+
+    val file = files[currentIndex]
+    logger.info("Reading file $index/${this.files.size}: $file")
+    return objectMapper.readValue(file, ContractDefinition::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDetailsDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDetailsDefinition.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class Complexity(
+  @JsonProperty("severity") val severity: String,
+  @JsonProperty("description") val description: String,
+)
+
+data class ContractDetailsDefinition(
+  @JsonProperty("contract_type") val contractType: String,
+  @JsonProperty("contract_code") val contractCode: String,
+  @JsonProperty("service_category") val serviceCategory: String,
+  @JsonProperty("desired_outcomes") val desiredOutcomes: List<String>,
+  @JsonProperty("complexity_levels") val complexity: List<Complexity>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDetailsSetupTasklet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ContractDetailsSetupTasklet.kt
@@ -1,0 +1,143 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import mu.KLogging
+import org.springframework.batch.core.StepContribution
+import org.springframework.batch.core.scope.context.ChunkContext
+import org.springframework.batch.core.step.tasklet.Tasklet
+import org.springframework.batch.repeat.RepeatStatus
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.util.ResourceUtils
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ComplexityLevel
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ContractType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceCategory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ComplexityLevelRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ContractTypeRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DesiredOutcomeRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceCategoryRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Component
+class ContractDetailsSetupTasklet @Autowired constructor(
+  val contractTypeRepository: ContractTypeRepository,
+  val serviceCategoryRepository: ServiceCategoryRepository,
+  val desiredOutcomeRepository: DesiredOutcomeRepository,
+  val complexityLevelRepository: ComplexityLevelRepository,
+) : Tasklet {
+  companion object : KLogging()
+
+  override fun execute(contribution: StepContribution, chunkContext: ChunkContext): RepeatStatus {
+    logger.info("Setting up contract types, desired outcomes and complexity levels")
+
+    val contractDetails = ResourceUtils.getFile("classpath:desiredoutcomes/contractDetails.json")
+    val contractDetailsDefinitions =
+      ObjectMapper().readValue(contractDetails, object : TypeReference<List<ContractDetailsDefinition>>() {})
+    contractDetailsDefinitions.forEach {
+      val contractType = upsertContractType(it)
+      val upsertServiceCategory = upsertServiceCategory(it)
+      val upsertDesiredOutcomes = upsertDesiredOutcomes(it.desiredOutcomes, upsertServiceCategory.id)
+      val upsertComplexityLevels = upsertComplexityLevels(it.complexity, upsertServiceCategory.id)
+      val serviceCategory = serviceCategoryRepository.save(
+        ServiceCategory(
+          id = upsertServiceCategory.id,
+          created = upsertServiceCategory.created,
+          name = upsertServiceCategory.name,
+          complexityLevels = upsertComplexityLevels,
+          desiredOutcomes = upsertDesiredOutcomes,
+        ),
+      )
+      contractTypeRepository.save(
+        ContractType(id = contractType.id, name = contractType.name, code = contractType.code, serviceCategories = setOf(serviceCategory)),
+      )
+    }
+
+    return RepeatStatus.FINISHED
+  }
+
+  private fun upsertContractType(contractDefinition: ContractDetailsDefinition): ContractType {
+    val contractType = contractTypeRepository.findByCode(contractDefinition.contractCode)
+    if (contractType == null) {
+      logger.info("Creating missing contract type ${contractDefinition.contractCode}")
+      return contractTypeRepository.save(
+        ContractType(
+          id = UUID.randomUUID(),
+          name = contractDefinition.contractType,
+          code = contractDefinition.contractCode,
+        ),
+      )
+    }
+    return contractType
+  }
+
+  private fun upsertServiceCategory(contractDefinition: ContractDetailsDefinition): ServiceCategory {
+    val serviceCategory = serviceCategoryRepository.findByName(contractDefinition.serviceCategory)
+    if (serviceCategory == null) {
+      logger.info("Creating missing service category ${contractDefinition.serviceCategory}")
+      return serviceCategoryRepository.save(
+        ServiceCategory(
+          id = UUID.randomUUID(),
+          created = OffsetDateTime.now(),
+          name = contractDefinition.serviceCategory,
+          emptyList(),
+          emptyList(),
+        ),
+      )
+    }
+    return serviceCategory
+  }
+
+  private fun upsertDesiredOutcomes(desiredOutComes: List<String>, serviceCategoryId: UUID): List<DesiredOutcome> {
+    val newDesiredOutcomes = mutableListOf<DesiredOutcome>()
+    val existingDesiredOutcomes = desiredOutcomeRepository.findByServiceCategoryId(serviceCategoryId)
+    if (existingDesiredOutcomes.isEmpty()) {
+      logger.info("Creating missing desired outcome for the service category $serviceCategoryId")
+      desiredOutComes.forEach {
+        newDesiredOutcomes.add(
+          desiredOutcomeRepository.save(
+            DesiredOutcome(id = UUID.randomUUID(), description = it, serviceCategoryId = serviceCategoryId),
+          ),
+        )
+      }
+    } else {
+      return existingDesiredOutcomes
+    }
+    return newDesiredOutcomes
+  }
+
+  private fun upsertComplexityLevels(complexities: List<Complexity>, serviceCategoryId: UUID): List<ComplexityLevel> {
+    val newComplexityLevels = mutableListOf<ComplexityLevel>()
+    val existingComplexityLevels = complexityLevelRepository.findByServiceCategoryId(serviceCategoryId)
+    if (existingComplexityLevels.isEmpty()) {
+      logger.info("Creating missing desired outcome for the service category $serviceCategoryId")
+      complexities.forEach {
+        newComplexityLevels.add(
+          complexityLevelRepository.save(
+            ComplexityLevel(
+              id = UUID.randomUUID(),
+              description = it.description,
+              title = deriveTitle(it.severity),
+              complexity = uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Complexity.valueOf(it.severity),
+              serviceCategoryId = serviceCategoryId,
+            ),
+          ),
+        )
+      }
+    } else {
+      return existingComplexityLevels
+    }
+    return newComplexityLevels
+  }
+
+  private fun deriveTitle(severity: String): String {
+    return when (severity) {
+      "LOW" -> "Low complexity"
+      "MEDIUM" -> "Medium complexity"
+      "HIGH" -> "High complexity"
+      else -> ""
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ProviderSetupTasklet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/ProviderSetupTasklet.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import mu.KLogging
+import org.springframework.batch.core.StepContribution
+import org.springframework.batch.core.scope.context.ChunkContext
+import org.springframework.batch.core.step.tasklet.Tasklet
+import org.springframework.batch.repeat.RepeatStatus
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.util.ResourceUtils
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProvider
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceProviderRepository
+import kotlin.jvm.optionals.getOrElse
+
+@Component
+class ProviderSetupTasklet @Autowired constructor(
+  val providerRepository: ServiceProviderRepository,
+) : Tasklet {
+  companion object : KLogging()
+
+  override fun execute(contribution: StepContribution, chunkContext: ChunkContext): RepeatStatus {
+    logger.info("Setting up providers")
+
+    val providers = ResourceUtils.getFile("classpath:providers/providers.json")
+    ObjectMapper().readTree(providers)
+      .map { upsertProvider(it.get("code").asText(), it.get("name").asText()) }
+      .also { providerRepository.saveAll(it) }
+
+    return RepeatStatus.FINISHED
+  }
+
+  private fun upsertProvider(code: String, name: String): ServiceProvider {
+    return providerRepository.findById(code).getOrElse {
+      logger.info("Creating missing provider $code")
+      ServiceProvider(code, name)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/UpsertContractProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/UpsertContractProcessor.kt
@@ -1,0 +1,190 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import mu.KLogging
+import org.springframework.batch.core.configuration.annotation.JobScope
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ContractTypeRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DynamicFrameworkContractRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.NPSRegionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.PCCRegionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ServiceProviderRepository
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import kotlin.jvm.optionals.getOrElse
+
+private const val DEFAULT_REFERRAL_EMAIL = "interventions-referrals-fallback@digital.justice.gov.uk"
+private const val DEFAULT_DESCRIPTION = ""
+private val defaultEndDate = LocalDate.of(2100, 12, 31)
+
+@Component
+@JobScope
+class UpsertContractProcessor(
+  val dynamicFrameworkContractRepository: DynamicFrameworkContractRepository,
+  val interventionRepository: InterventionRepository,
+  val providerRepository: ServiceProviderRepository,
+  val contractTypeRepository: ContractTypeRepository,
+  val npsRegionRepository: NPSRegionRepository,
+  val pccRegionRepository: PCCRegionRepository,
+) : ItemProcessor<ContractDefinition, Intervention> {
+  companion object : KLogging()
+
+  override fun process(item: ContractDefinition): Intervention? {
+    logger.info("Processing ${item.contractReference}")
+
+    val errors = verifyReferenceDataExists(item.contractTypeCode, item.region, item.providers)
+    if (errors.isNotEmpty()) {
+      logger.error(
+        "${item.contractReference} is missing reference data; " +
+          "please add these in a migration before this task: {}",
+        errors,
+      )
+      return null
+    }
+    return upsertIntervention(upsertContract(item), item).also {
+      logger.info("${item.contractReference} completed")
+    }
+  }
+
+  private fun verifyReferenceDataExists(
+    contractTypeCode: String,
+    region: RegionDefinition,
+    providers: ProviderDefinition,
+  ): List<String> {
+    return mutableListOf<String>().also {
+      it.addAll(validateContractType(contractTypeCode))
+      it.addAll(validateRegions(region))
+      it.addAll(validateProviders(providers))
+    }
+  }
+
+  private fun validateContractType(contractTypeCode: String): List<String> {
+    return if (contractTypeRepository.findByCode(contractTypeCode) == null) {
+      listOf("Cannot find $contractTypeCode contract type")
+    } else {
+      listOf()
+    }
+  }
+
+  private fun validateProviders(providers: ProviderDefinition): List<String> {
+    val errors = mutableListOf<String>()
+
+    providerRepository.findById(providers.primeProviderId)
+      .getOrElse { errors.add("Cannot find ${providers.primeProviderId} provider") }
+
+    val subcontractors = providerRepository.findAllById(providers.subcontractorIds).toSet()
+    if (subcontractors.size != providers.subcontractorIds.size) {
+      val missing = providers.subcontractorIds.toSet() - subcontractors.map { it.id }.toSet()
+      errors.add("Cannot resolve $missing subcontractor providers")
+    }
+
+    return errors
+  }
+
+  private fun validateRegions(region: RegionDefinition): List<String> {
+    val errors = mutableListOf<String>()
+
+    if (region.npsCode != null) {
+      npsRegionRepository.findById(region.npsCode)
+        .getOrElse { errors.add("Cannot find ${region.npsCode} NPS region") }
+    }
+    if (region.pccCode != null) {
+      pccRegionRepository.findById(region.pccCode)
+        .getOrElse { errors.add("Cannot find ${region.pccCode} PCC region") }
+    }
+    if (region.npsCode == null && region.pccCode == null) {
+      errors.add("Either NPS or PCC code must exist")
+    }
+    if (region.npsCode != null && region.pccCode != null) {
+      errors.add("NPS and PCC region codes are mutually exclusive, only one should exist")
+    }
+
+    return errors
+  }
+
+  private fun upsertContract(item: ContractDefinition): DynamicFrameworkContract {
+    val contractType = contractTypeRepository.findByCode(item.contractTypeCode)!!
+    val prime = providerRepository.findById(item.providers.primeProviderId).get()
+    val subcontractors = providerRepository.findAllById(item.providers.subcontractorIds).toMutableSet()
+
+    val definedContract = DynamicFrameworkContract(
+      id = item.internalContractId,
+      contractReference = item.contractReference,
+      contractType = contractType,
+      minimumAge = item.eligibility.minimumAge,
+      maximumAge = item.eligibility.maximumAge,
+      allowsFemale = item.eligibility.allowsFemale,
+      allowsMale = item.eligibility.allowsMale,
+      startDate = item.scheduling.hideBefore,
+      endDate = item.scheduling.hideAfter?.toLocalDate() ?: defaultEndDate,
+      referralEndAt = item.scheduling.hideAfter,
+      referralStartDate = item.scheduling.hideBefore,
+      primeProvider = prime,
+      subcontractorProviders = subcontractors,
+    )
+
+    val foundContract = dynamicFrameworkContractRepository.findById(item.internalContractId)
+      .getOrElse {
+        logger.info("Creating missing contract ${item.contractReference} with ID ${item.internalContractId}")
+        definedContract
+      }.also {
+        // allowable overrides
+        it.referralEndAt = item.scheduling.hideAfter
+        it.referralStartDate = item.scheduling.hideBefore
+        it.subcontractorProviders.addAll(subcontractors)
+        it.subcontractorProviders.retainAll(subcontractors)
+      }
+
+    return dynamicFrameworkContractRepository.save(foundContract)
+  }
+
+  private fun upsertIntervention(contract: DynamicFrameworkContract, item: ContractDefinition): Intervention {
+    val description = descriptionWithActivities(
+      item.shortDescription ?: DEFAULT_DESCRIPTION,
+      item.activities ?: listOf(),
+    )
+
+    val definedIntervention = Intervention(
+      id = item.internalInterventionId,
+      title = item.interventionTitle,
+      description = description,
+      incomingReferralDistributionEmail = DEFAULT_REFERRAL_EMAIL,
+      dynamicFrameworkContract = contract,
+      createdAt = OffsetDateTime.now(),
+    )
+
+    val foundIntervention = interventionRepository.findById(item.internalInterventionId)
+      .getOrElse {
+        logger.info("Creating missing intervention for contract ${item.contractReference} with ID ${item.internalInterventionId}")
+        definedIntervention
+      }.also {
+        it.title = item.interventionTitle
+        it.description = description
+      }
+
+    return interventionRepository.save(foundIntervention)
+  }
+
+  private fun descriptionWithActivities(description: String, activities: List<ActivityDefinition>): String {
+    val buf = StringBuilder(description)
+    buf.append("\n\nActivities:")
+
+    activities.groupBy {
+      mapOf(
+        "area" to it.needArea,
+        "location" to it.deliveryLocation,
+        "method" to it.deliveryMethod,
+      )
+    }.forEach { (key, matchingActivities) ->
+      buf.append("\n\n${key["area"]}")
+      buf.append("\n${key["method"]}; ${key["location"]}")
+      matchingActivities.map { it.activity }.sorted().distinct().forEach {
+        buf.append("\n• $it")
+      }
+    }
+    return buf.toString().trim()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/UpsertContractsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/scheduled/onboarding/UpsertContractsJobConfiguration.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.scheduled.onboarding
+
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.boot.ApplicationRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer
+
+@Configuration
+@EnableBatchProcessing
+class UpsertContractsJobConfiguration(
+  private val jobBuilderFactory: JobBuilderFactory,
+  private val stepBuilderFactory: StepBuilderFactory,
+  private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
+) {
+
+  @Bean
+  fun upsertContractsJobLauncher(upsertContractsJob: Job): ApplicationRunner {
+    return onStartupJobLauncherFactory.makeBatchLauncher(upsertContractsJob)
+  }
+
+  @Bean
+  fun upsertContractsJob(upsertProvidersStep: Step, upsertContractStep: Step, upsertContractDetailsStep: Step): Job {
+    return jobBuilderFactory["upsertContractsJob"]
+      .incrementer(TimestampIncrementer())
+      .start(upsertProvidersStep)
+      .next(upsertContractStep)
+      .next(upsertContractDetailsStep)
+      .build()
+  }
+
+  @Bean
+  fun upsertProvidersStep(
+    providerSetup: ProviderSetupTasklet,
+  ): Step {
+    return stepBuilderFactory.get("upsertProvidersStep")
+      .tasklet(providerSetup)
+      .build()
+  }
+
+  @Bean
+  fun upsertContractDetailsStep(
+    contractDetailsSetupTasklet: ContractDetailsSetupTasklet,
+  ): Step {
+    return stepBuilderFactory.get("upsertContractDetailsStep")
+      .tasklet(contractDetailsSetupTasklet)
+      .build()
+  }
+
+  @Bean
+  fun upsertContractStep(
+    reader: ContractDefinitionReader,
+    processor: UpsertContractProcessor,
+  ): Step {
+    return stepBuilderFactory.get("upsertContractStep")
+      .chunk<ContractDefinition, Intervention>(10)
+      .reader(reader)
+      .processor(processor)
+      .writer {}
+      .build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ComplexityLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ComplexityLevel.kt
@@ -10,6 +10,7 @@ import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
+import javax.validation.constraints.NotNull
 
 @Entity
 @TypeDefs(
@@ -25,6 +26,9 @@ data class ComplexityLevel(
   @Enumerated(EnumType.STRING)
   @Column(name = "complexity")
   val complexity: Complexity,
+  @NotNull
+  @Column(name = "service_category_id")
+  val serviceCategoryId: UUID? = null,
 )
 
 enum class Complexity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
@@ -48,10 +48,14 @@ data class DynamicFrameworkContract(
   @JoinColumn(name = "prime_provider_id")
   val primeProvider: ServiceProvider,
 
-  @NotNull val startDate: LocalDate,
-  @NotNull val endDate: LocalDate,
+  @Deprecated("use referralStartDate (hideBefore) instead")
+  @NotNull
+  val startDate: LocalDate,
+  @Deprecated("use referralEndAt (hideAfter) instead")
+  @NotNull
+  val endDate: LocalDate,
 
-  @NotNull val referralStartDate: LocalDate,
+  @NotNull var referralStartDate: LocalDate,
   var referralEndAt: OffsetDateTime? = null,
 
   @ManyToOne
@@ -75,7 +79,7 @@ data class DynamicFrameworkContract(
     joinColumns = [JoinColumn(name = "dynamic_framework_contract_id")],
     inverseJoinColumns = [JoinColumn(name = "subcontractor_provider_id")],
   )
-  val subcontractorProviders: Set<ServiceProvider> = setOf(),
+  val subcontractorProviders: MutableSet<ServiceProvider> = mutableSetOf(),
 
   @NotNull
   @ManyToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Intervention.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Intervention.kt
@@ -14,8 +14,8 @@ data class Intervention(
   val id: UUID,
   @NotNull val createdAt: OffsetDateTime,
 
-  @NotNull val title: String,
-  @NotNull val description: String,
+  @NotNull var title: String,
+  @NotNull var description: String,
   @NotNull val incomingReferralDistributionEmail: String,
 
   @NotNull

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ComplexityLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ComplexityLevelRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ComplexityLevel
 import java.util.UUID
 
-interface ComplexityLevelRepository : JpaRepository<ComplexityLevel, UUID>
+interface ComplexityLevelRepository : JpaRepository<ComplexityLevel, UUID> {
+  fun findByServiceCategoryId(serviceCategoryId: UUID): List<ComplexityLevel>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ContractTypeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ContractTypeRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ContractType
 import java.util.UUID
 
-interface ContractTypeRepository : JpaRepository<ContractType, UUID>
+interface ContractTypeRepository : JpaRepository<ContractType, UUID> {
+  fun findByCode(code: String): ContractType?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ServiceCategoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ServiceCategoryRepository.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 
 interface ServiceCategoryRepository : CrudRepository<ServiceCategory, UUID> {
   fun findByIdIn(serviceCategoryIds: List<UUID>): Set<ServiceCategory>
+  fun findByName(name: String): ServiceCategory?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -87,7 +87,7 @@ class DraftReferralService(
     // PPs can't create referrals for service users they are not allowed to see
     serviceUserAccessChecker.forProbationPractitionerUser(crn, user)
 
-    val intervention = interventionRepository.getById(interventionId)
+    val intervention = interventionRepository.getReferenceById(interventionId)
     val serviceCategories = intervention.dynamicFrameworkContract.contractType.serviceCategories
     val selectedServiceCategories = if (serviceCategories.size == 1) serviceCategories.toMutableSet() else null
 
@@ -97,7 +97,7 @@ class DraftReferralService(
         createdAt = overrideCreatedAt ?: OffsetDateTime.now(),
         createdBy = authUserRepository.save(user),
         serviceUserCRN = crn,
-        intervention = interventionRepository.getById(interventionId),
+        intervention = interventionRepository.getReferenceById(interventionId),
         selectedServiceCategories = selectedServiceCategories,
       ),
     )

--- a/src/main/resources/contracts/CCS_0001.json
+++ b/src/main/resources/contracts/CCS_0001.json
@@ -1,0 +1,138 @@
+{
+  "internal_contract_id": "bfe8d1fe-3290-43a2-a6e2-7a4af5960ca4",
+  "contract_reference": "CCS_0001",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": "2022-12-01T12:00:00+00:00"
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "2d898791-38f1-4c69-9ab8-bb38539d8c1f",
+  "intervention_title": "Women's Services for London (north)",
+  "short_description": "Advance Minerva only support women living or returning to the following London boroughs: Barking and Dagenham, Barnet,Bexley, Brent, Camden, Ealing, Enfield, Greenwich, Hackney, Hammersmith and Fulham, Haringey, Harrow, Havering, Hillingdon, Hounslow, Islington, Kensington and Chelsea, Kingston, Newham, Redbridge, Richmond, Tower Hamlets, Waltham Forest, Westminster.                                                                                                                                                                          \n \nA holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "West London, North London, East London"
+    }
+  ]
+}

--- a/src/main/resources/contracts/CCS_0002.json
+++ b/src/main/resources/contracts/CCS_0002.json
@@ -1,0 +1,258 @@
+{
+  "internal_contract_id": "e48620cb-bed9-4468-94d4-ae6fc6304548",
+  "contract_reference": "CCS_0002",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": "2022-12-01T12:00:00+00:00"
+  },
+  "providers": {
+    "prime_provider_code": "WOMEN_IN_PRISON",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "49921343-519b-4f69-9d0e-6c6330748e7c",
+  "intervention_title": "Women's Services for London (south)",
+  "short_description": "Women in Prison only support women living or returning to the following London boroughs: Bromley, Croydon, Lambeth, Lewisham, Merton, Southwark, Sutton, Wandsworth.                                                                                                                                                                                                                                                                                             \n\nA holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention and management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Finding new/suitable accommodation",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Benefit Assistance",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tailored practical housing support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Peer mentor supprt applying for education/training opportunities",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Applying for education/training opportunities",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job application guidance",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Tailored practical ETE support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse advice and guidance",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse practical support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Coffee Morning",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse emotional support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse risk management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Addiction clinic",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Mindfulness workshop",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications and management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Peer mentor emotional support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health risk management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness workshop",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Coffee Morning",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse advice and guidance, and support.",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse risk management",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse legal remedies",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childcare proceedings supoprt advice and guidance",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Legal support regarding child contact and childcare proceedings",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Emotional support regarding child removal and childcare proceedings",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Peer Mentor Lifestyle support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle support",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Weekly Drop In",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Coffee Morning",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Theatre Workshops",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Art Fridays",
+      "delivery_method": "Group",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reducing barriers to social inclusion",
+      "delivery_method": "One to one",
+      "delivery_location": "Lambeth, Wandsworth, Croydon, Sutton, Lewisham, Southwark, Bromley, Merton"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN535743.json
+++ b/src/main/resources/contracts/DN535743.json
@@ -1,0 +1,36 @@
+{
+  "internal_contract_id": "bdf5341c-9686-469f-9958-36e7903dffeb",
+  "contract_reference": "DN535743",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ACHIEVE_NW",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "a5206eeb-897d-4c6c-bbc8-dca0bde5148a",
+  "intervention_title": "GM - ETE",
+  "short_description": "The service is to deliver Education, Training & Employment (ETE) for POPs sentenced to an ETE RAR or with an ETE need, currently on licence or a community order. The Probation practitioner will identify complexity level and send the completed referral form to GM-ETE via the Refer & Monitor system - Dependent upon complexity, GM-ETE will deliver 121 work; group work; job clubs and digital interventions to support the POP with ETE:\n\nGM-ETE will deliver:\n\n1.2.1 Sessions - CV building, disclosure advice, mock interviews, job searching, application forms. ID, bank accounts, referral on to other services, identifying training needs and support for training, further learning advice and support\n\nGroup Work sessions - Employability support, job clubs, accredited courses focussing on employability e.g. Award in Skills for Further Learning \n\nJob Club - Weekly drop-in sessions delivering employability support - including, but not limited to - job search, application form support, CV and cover letter support, job hunting techniques, mock interviews, disclosure letters \n\nDigital Delivery - Innovative online learning portal ‘ConnectMyCareer’ which enables SUs 24/7 access to a library of learning materials, EMSI labour market data, and further employability resources. Digital platforms (e.g., Zoom) will support online delivery, and we will facilitate access to IT equipment for PoPs who require it \n\nEmployer Engagement - Liasion with employers to identify job opportunities, advocacy on behalf of PoP, referral and support with interview -  Meeting employer and PoP needs with regards to training and qualifications. \n\n\nEligibility Criteria - All People on Probation (PoP), male and female, aged 18+\n\nComplexity Levels:\n\nLow complexity – Service User has satisfactory basic numeracy & literacy skills. The Service User has previously been employed though there may be gaps with periods of inactivity due to redundancy/periods of imprisonment. There has been no critical development need to find a new job in their previous field of competence. The Service User values benefits of working but needs guidance to re-enter the workforce, change jobs or career path.\n \nMedium complexity – Service User has gaps in basic numeracy and literacy skills. The Service User has no or limited working experience. The Service User has partially completed vocational training but requires support with building confidence and motivation to develop training and/or employability skills, and also require support and coaching to develop or enhance skills to obtain and sustain employment. The Service User may require significant support to improve  their self-belief.\n\nHigh complexity – Service User lacks basic literacy & numeracy skills and/or may have Learning Difficulties and/or Learning Disabilities. The Service User has no or limited working experience and/or have no qualifications or current qualifications and/or may have many barriers and restrictions to employment due to the nature of their offences (e.g. sexual, violent, or fraud/deception offences). The Service User requires significant support and coaching to build motivation, confidence and basic skills to enter employment / training. The Service User may have multiple complex needs linked to trauma, poor mental health, previous or ongoing experience of abuse and requires significant additional support to move forward.\n\n\nGM-ETE staff will be co-located in each Probation Office on a date and time agreed to meet the needs of each individual Centre",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Employment, Training, Education",
+      "delivery_method": "1:2:1, Group Work, Job Clubs, Digital Delivery, Employer Engagement",
+      "delivery_location": "Manchester, Oldham, Trafford, Salford, Tameside, Bury, Bolton, Rochdale, Wigan, Stockport"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN545200.json
+++ b/src/main/resources/contracts/DN545200.json
@@ -1,0 +1,36 @@
+{
+  "internal_contract_id": "3ee80341-b449-45a1-8190-8e1c2690ae69",
+  "contract_reference": "DN545200",
+  "contract_type_id": "MTR",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "COMMUNITY_LED_INIT",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "d09b9c4a-e374-4121-a522-5718bacd676a",
+  "intervention_title": "CLI - Peer Support",
+  "short_description": "The service is to deliver a Peer Support service in Manchester, Salford, Trafford. Oldham, Tameside, Stockport, Bolton, Bury, Rochdale Wigan.   The Probation practitioner will identify complexity levels and send the completed referral to CLI via the Refer & Monitor  system.\n\nCLI will engage with and provide intensive support to PoP; offering needs-led, emotional and practical support around accommodation and finance, health and well-being, motivation, family and relationships, accessing services, building confidence and self-esteem. \n\nCLI provide personalised 1:1 Peer Mentoring support to work alongside people and guide them on their desistance or recovery journey.  This mentoring relationships provide the practical and emotional support needed to make and sustain positive change. \n\nCLI can support with:\n\n•Advice on accessing support in the community - GP, Drug & Alcohol, Mental Health, Dentist\n•Finances, benefit and/or debt support \n•Navigating the housing system; housing benefit support, housing advice\n•Building routine/structure with positive activities in the community\n•Support/advice on employment; how to access support in the community\n•Support to access Courses/Education\n•Support with attending appointments\n•Person-centred provision motivating/supporting/empowering individuals to change direction\n\nEligibility Criteria - All people on Probation (PoP), male and female, aged 18+\n\nComplexity Levels:\n\nLow complexity - Service User has worries or issues and feels unable to cope but is not socially isolated and interacts with others. Service User has no known psychological issues or history of depression and poor mental health\n\nMedium complexity - Service User has diagnosed documented psychological problems that are being managed well but requires support to maintain engagement. Service User has coping strategies but needs assistance. Service User shows signs of stress in meetings and requires support to effectively engage.\n\nHigh complexity - Service User has suffered psychological and mental health problems over a period of time which is documented and needs significant level of support to engage with service provision. Service User is socially isolated and struggles with numerous aspects of daily life.\n\nCLI Mentors will be co-located in each Probation Office on a date and time agreed to meet the needs of each individual Centre.",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Peer Support",
+      "delivery_method": "One to one",
+      "delivery_location": "Manchester, Oldham, Trafford, Salford, Tameside, Bury, Bolton Rochdale, Wigan, Stockport"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN545698.json
+++ b/src/main/resources/contracts/DN545698.json
@@ -1,0 +1,103 @@
+{
+  "internal_contract_id": "767024f3-6aa5-4ca6-a3fa-dddd4b5c4d99",
+  "contract_reference": "DN545698",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "MANCHESTER_ATHENA",
+      "ACORN"
+    ]
+  },
+  "internal_intervention_id": "2cee9965-0247-4459-9e68-40bc73984eaa",
+  "intervention_title": "GM - Accommodation Support Service",
+  "short_description": "This is the GMIRS Accommodation Service delivered by Ingeus.\n\nServices are available for people on probation on licence/post-sentence supervision. From April 2022 there is an opportunity if referral numbers stay within agreed levels that this will be extended to community referrals for those Service Users who are subject to a Community Order or a Suspended Sentence order. They will also be delivered pre-release for those who will be under probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including: direct delivery of interventions, support and advocacy, advice and guidance. \n\nInterventions will be tailored to reflect the complexity of a person on probation’s needs and should aim to secure one or more of the following outcomes:\n•\tPeople on probation obtain or maintain suitable accommodation\n•\tPeople on probation overcome barriers to obtaining/maintaining suitable accommodation\n•\tPeople on probation are prevented from becoming homeless.\n\nCore Activities \n\nThe Supplier should provide the following activities and deliver those activities applicable to each Person on Probation as set out in each Action Plan and which are tailored for each Person on Probation’s specific needs and Complexity Level.\n\nFor the low complexity cohort, the Supplier is only expected to provide professional advice and signposting to the Probation Practitioner. This may be in the form of direct telephone advice line. \n\nFor those that are assessed as medium or high complexity it is expected that the Supplier will take an active caseload supporting the individual at point of reception, focusing on providing support pre-release and will continue to provide support in the community towards the end of sentence in order to progress sustainable accommodation outcomes with the individual. \n\nPre-Release expectations\n\tSupport to avoid or manage accommodation arrears through direct negotiation, or advice on options for the Person on Probation to undertake, and the provision of follow-up support.\n\n\tAdvocacy and liaison with accommodation providers to maintain accommodation and mitigate the risk of eviction.\n\n\tAdvocacy and Advice to enable Person on Probation to access accommodation via a range of identified housing pathways including, but not limited to, Local Authorities, Housing Providers, National and Local charities and voluntary organisations, Private Landlords.\n\n\tSupport to understand and comply with any tenancy obligations, including liaison with the housing provider if required.\n\n\tSupport and assistance with completion of accommodation applications and provision of additional information as required.\n\n\tSupport and Guidance (Including liaison) to ensure continuation of an existing tenancy.\n\n\tProvide Advice, Information and Guidance to relinquish, maintain where appropriate or secure tenancies and other housing provision.\n\n\tSupport and Deliver work to avoid and reduce housing related debt being accrued and/or homelessness on release.  \n\n\tSupport and assistance with the completion of applications for Housing Benefit and other related benefits.\n\n\tSupport to access rent and bond schemes by providing information and assisting the Person on Probation throughout the application process as required.\n\n\tSupport to obtain accommodation for Persons on Probation due for release at Licence Expiry Date/Sentence End Date in partnership with the Probation Practitioner",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for maintaining tenancy",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support to relinquish tenancy and",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support to secure new tenancies on release",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with completion of accommodation applications",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Duty to refer",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Emergency support",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Work with partners to achieve result",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Assess need and access to relevant support service",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation on release",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support individuals in the to achieve sustainable accommodation",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Supporting individuals at key transition points",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with move on from temporary accommodation to secure settled accommodation",
+      "delivery_method": "One to one",
+      "delivery_location": "Across GM Prisons and GM PDU offices"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_1.json
+++ b/src/main/resources/contracts/DN547952_1.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "f5dbaa2e-841d-4cd2-80eb-2a76f404dca8",
+  "contract_reference": "DN547952_1",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "JIGSAW_SUPPORT"
+    ]
+  },
+  "internal_intervention_id": "2a5ab460-6e33-4676-9584-1cb99d7664b0",
+  "intervention_title": "GMWSA - Women's Support Service - Tameside",
+  "short_description": "This is the GMWSA service delivered by Jigsaw (Tameside Women's Centre) in Tameside.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Tameside"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_2.json
+++ b/src/main/resources/contracts/DN547952_2.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "b4ab34b8-d426-4a0c-ae28-dcc303001b44",
+  "contract_reference": "DN547952_2",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "POPS"
+    ]
+  },
+  "internal_intervention_id": "db5b1db9-df3f-4276-ac7f-e5475dac8a35",
+  "intervention_title": "GMWSA - Women's Support Service - Oldham",
+  "short_description": "This is the GMWSA service delivered by Partners of Prisoners (POPS) in Oldham.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Oldham"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_3.json
+++ b/src/main/resources/contracts/DN547952_3.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "eb72a9a0-4096-41df-afb5-e47e33fecbc9",
+  "contract_reference": "DN547952_3",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "PETRUS_COMMUNITY"
+    ]
+  },
+  "internal_intervention_id": "d60f4206-c5bd-486d-a53b-be7a3aee579c",
+  "intervention_title": "GMWSA - Women's Support Service - Rochdale",
+  "short_description": "This is the GMWSA service delivered by Petrus in Rochdale.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Rochdale"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_4.json
+++ b/src/main/resources/contracts/DN547952_4.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "87513a02-7fc0-41dc-be0b-5a8bb314774c",
+  "contract_reference": "DN547952_4",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "SALFORD_FOUNDATION"
+    ]
+  },
+  "internal_intervention_id": "c3851ac1-e016-4741-97cf-5fe3b7853b87",
+  "intervention_title": "GMWSA - Women's Support Service - Salford",
+  "short_description": "This is the GMWSA service delivered by Salford Foundation in Salford.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Salford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_5.json
+++ b/src/main/resources/contracts/DN547952_5.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "17f3b0c6-dab5-4b1c-829b-9a07887383e9",
+  "contract_reference": "DN547952_5",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "URBAN_OUTREACH"
+    ]
+  },
+  "internal_intervention_id": "297e3494-6584-4ac3-8644-3691dae6e328",
+  "intervention_title": "GMWSA - Women's Support Service - Bolton",
+  "short_description": "This is the GMWSA service delivered by Urban Outreach in Bolton.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bolton"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_6.json
+++ b/src/main/resources/contracts/DN547952_6.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "2d64c5d5-1f1a-4a92-bbd3-5a14d424636b",
+  "contract_reference": "DN547952_6",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "WOMEN_FOR_WELL_WOMEN"
+    ]
+  },
+  "internal_intervention_id": "205aa08f-9edb-421b-bc17-10069c9ee914",
+  "intervention_title": "GMWSA - Women's Support Service - Wigan and Leigh",
+  "short_description": "This is the GMWSA service delivered by Well Women  in Wigan and Leigh.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Wigan and Leigh"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_7.json
+++ b/src/main/resources/contracts/DN547952_7.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "796e5b73-1495-4d11-8cf5-1b23614d3ed7",
+  "contract_reference": "DN547952_7",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "WOMEN_IN_PRISON"
+    ]
+  },
+  "internal_intervention_id": "bc72c9ff-c3ce-4e21-af07-b3d4905346ee",
+  "intervention_title": "GMWSA - Women's Support Service - Manchester and Trafford",
+  "short_description": "This is the GMWSA service delivered by Women MATTA/Women in Prison, Manchester and Trafford\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Manchester/Trafford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_8.json
+++ b/src/main/resources/contracts/DN547952_8.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "79915b3c-efdf-48a8-8d76-22aeecb3df21",
+  "contract_reference": "DN547952_8",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "WOMEN_OF_WORTH"
+    ]
+  },
+  "internal_intervention_id": "2368c1cf-c274-4ea2-83c6-c1fd1b9a44fa",
+  "intervention_title": "GMWSA - Women's Support Service - Bury",
+  "short_description": "This is the GMWSA service delivered by Women of Worth in Bury.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Bury"
+    }
+  ]
+}

--- a/src/main/resources/contracts/DN547952_9.json
+++ b/src/main/resources/contracts/DN547952_9.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "df6e90b4-166d-4362-9238-ba3ab0c010a1",
+  "contract_reference": "DN547952_9",
+  "contract_type_id": "WSM",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_WOM_SUP_AL",
+    "subcontractor_codes": [
+      "STOCKPORT_WOMENS_CENTRE"
+    ]
+  },
+  "internal_intervention_id": "fda19dd9-d59f-4518-b6ff-dd6a71221a73",
+  "intervention_title": "GMWSA - Women's Support Service - Stockport",
+  "short_description": "This is the GMWSA service delivered by Stockport Women's Centre in Stockport.\n\nThis is an holistic service for women which addresses the following frequently occurring rehabilitative needs: accommodation, ETE, dependency and recovery, finance, benefits and debt, and personal wellbeing.  Having a single women's specific service is intended to ensure that the interventions are responsive to the specific needs and characteristics of females on probation. The service will be delivered in an environment which is safe and suitable for women, and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the supplier personnel.\n\nServices will be available for women on probation on a community/suspended sentence order with a RAR or on licence/post-sentence supervision. The accommodation and social inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released on licence. \n\nAppointments which are part of sentence delivery will be enforceable.\n\nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual and physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change\n\nThe delivery model is separated into six interlinked elements;\n\n•\tLocal trauma-informed service delivery to vulnerable and marginalised women in safe, women-only spaces, in each Borough in GM. \n•\tCo-location of Probation staff, and staff from other key agencies, in our Centres\n•\tSupporting Probation delivery, including Problem Solving Courts\n•\tOverall co-ordination and support from the GM Women’s Support Alliance.\n•\tThe development of a network of partner agencies, including new GMWSA associate members, with whom GMWSA will form clear 2-way referral pathways.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "",
+      "delivery_method": "1:2:1, Group, Digital",
+      "delivery_location": "Stockport"
+    }
+  ]
+}

--- a/src/main/resources/contracts/GMIRSDR_1.json
+++ b/src/main/resources/contracts/GMIRSDR_1.json
@@ -1,0 +1,48 @@
+{
+  "internal_contract_id": "a3898c65-7d4e-4e92-81a7-c211edb75fd9",
+  "contract_reference": "GMIRSDR_1",
+  "contract_type_id": "DNR",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "GM_MH_NHS_FT",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "086d1cf9-9cc7-402a-9f28-cf3380635d98",
+  "intervention_title": "Dependency and Recovery in Bolton, Bury, Salford and Trafford",
+  "short_description": "The Dependency and Recovery Service will provide pre- and post-sentence support for individuals under the supervision of the Probation Service in Greater Manchester identified as having drug and alcohol needs.\nThe key aims of the Dependency and Recovery Service are to:\n· Reduce drug and alcohol related reoffending\n· Reduce drug and alcohol related health harms for the offender\n· Improve community safety by reducing the risk of drug and alcohol related harms to others.                                                                                                                          \n\nDependency and Recovery Key Workers will conduct assessments both pre- and post-sentence and will focus on adressing need and minimising risk. There are dedicated consultation clinics in each GM Probation Delivery Unit. The process of ongoing assessment and review will contribute to ensuring that drug and alcohol related health needs are met inclusive of those contributing to offending risk.                                                                                       Specific objectives and appropriate interventions will be determined that take full account of complexity in addressing individual drug and alcohol related need, supporting social (re)integration, and enabling people to lead meaningful and purposeful lives.\n\nDependency and Recovery Key Workers will have a thorough understanding of the medical and psycho-social interventions provided by specialist substance misuse services and the thresholds and referral pathways for accessing them.                                                                                 Delivered interventions (1:1 or group) will promote recovery and resilience with the overall aim being to reduce drug and alcohol related harm to the POP and the wider community.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-lapse prevention",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Bolton, Bury, Salford and Trafford PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Delivery of Drug and/or Alcohol Extended Brief Interventions",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Bolton, Bury, Salford and Trafford PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Provision of additional Support for high complexity POP's",
+      "delivery_method": "One to one",
+      "delivery_location": "Bolton, Bury, Salford and Trafford PDU's"
+    }
+  ]
+}

--- a/src/main/resources/contracts/GMIRSDR_2.json
+++ b/src/main/resources/contracts/GMIRSDR_2.json
@@ -1,0 +1,48 @@
+{
+  "internal_contract_id": "d14ca1df-f3fe-425c-b708-e152bbd5972e",
+  "contract_reference": "GMIRSDR_2",
+  "contract_type_id": "DNR",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGE_GROW_LIVE_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "fcf7806b-3eb4-4469-a08c-02ac06974275",
+  "intervention_title": "Dependency and Recovery in Manchester and Tameside",
+  "short_description": "The Dependency and Recovery Service will provide pre- and post-sentence support for individuals under the supervision of the Probation Service in Greater Manchester identified as having drug and alcohol needs.\nThe key aims of the Dependency and Recovery Service are to:\n· Reduce drug and alcohol related reoffending\n· Reduce drug and alcohol related health harms for the offender\n· Improve community safety by reducing the risk of drug and alcohol related harms to others.                                                                                                                          \n\nDependency and Recovery Key Workers will conduct assessments both pre- and post-sentence and will focus on adressing need and minimising risk. There are dedicated consultation clinics in each GM Probation Delivery Unit. The process of ongoing assessment and review will contribute to ensuring that drug and alcohol related health needs are met inclusive of those contributing to offending risk.                                                                                       Specific objectives and appropriate interventions will be determined that take full account of complexity in addressing individual drug and alcohol related need, supporting social (re)integration, and enabling people to lead meaningful and purposeful lives.\n\nDependency and Recovery Key Workers will have a thorough understanding of the medical and psycho-social interventions provided by specialist substance misuse services and the thresholds and referral pathways for accessing them.                                                                                 Delivered interventions (1:1 or group) will promote recovery and resilience with the overall aim being to reduce drug and alcohol related harm to the POP and the wider community.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-lapse prevention",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Manchester and Tameside PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Delivery of Drug and/or Alcohol Extended Brief Interventions",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Manchester and Tameside PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Provision of additional Support for high complexity POP's",
+      "delivery_method": "One to one",
+      "delivery_location": "Manchester and Tameside PDU's"
+    }
+  ]
+}

--- a/src/main/resources/contracts/GMIRSDR_3.json
+++ b/src/main/resources/contracts/GMIRSDR_3.json
@@ -1,0 +1,48 @@
+{
+  "internal_contract_id": "12c2f34e-bc78-4e84-ba9f-56b03405659e",
+  "contract_reference": "GMIRSDR_3",
+  "contract_type_id": "DNR",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ROAR_TURNING_POINT",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "ce5b3aae-78c5-474c-a3ad-b0a8b51cb336",
+  "intervention_title": "Dependency and Recovery in Oldham and Rochdale",
+  "short_description": "The Dependency and Recovery Service will provide pre- and post-sentence support for individuals under the supervision of the Probation Service in Greater Manchester identified as having drug and alcohol needs.\nThe key aims of the Dependency and Recovery Service are to:\n· Reduce drug and alcohol related reoffending\n· Reduce drug and alcohol related health harms for the offender\n· Improve community safety by reducing the risk of drug and alcohol related harms to others.                                                                                                                          \n\nDependency and Recovery Key Workers will conduct assessments both pre- and post-sentence and will focus on adressing need and minimising risk. There are dedicated consultation clinics in each GM Probation Delivery Unit. The process of ongoing assessment and review will contribute to ensuring that drug and alcohol related health needs are met inclusive of those contributing to offending risk.                                                                                       Specific objectives and appropriate interventions will be determined that take full account of complexity in addressing individual drug and alcohol related need, supporting social (re)integration, and enabling people to lead meaningful and purposeful lives.\n\nDependency and Recovery Key Workers will have a thorough understanding of the medical and psycho-social interventions provided by specialist substance misuse services and the thresholds and referral pathways for accessing them.                                                                                 Delivered interventions (1:1 or group) will promote recovery and resilience with the overall aim being to reduce drug and alcohol related harm to the POP and the wider community.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-lapse prevention",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Oldham and Rochdale PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Delivery of Drug and/or Alcohol Extended Brief Interventions",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Oldham and Rochdale PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Provision of additional Support for high complexity POP's",
+      "delivery_method": "One to one",
+      "delivery_location": "Oldham and Rochdale PDU's"
+    }
+  ]
+}

--- a/src/main/resources/contracts/GMIRSDR_4.json
+++ b/src/main/resources/contracts/GMIRSDR_4.json
@@ -1,0 +1,48 @@
+{
+  "internal_contract_id": "13ca0794-a2e1-4973-a11d-c93c205b3991",
+  "contract_reference": "GMIRSDR_4",
+  "contract_type_id": "DNR",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "PENNINE_CARE_NHS_FT",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "8c87797e-630c-463d-b6e1-365af15d05c9",
+  "intervention_title": "Dependency and Recovery in Stockport",
+  "short_description": "\"The Dependency and Recovery Service will provide pre- and post-sentence support for individuals under the supervision of the Probation Service in Greater Manchester identified as having drug and alcohol needs.\nThe key aims of the Dependency and Recovery Service are to:\n· Reduce drug and alcohol related reoffending\n· Reduce drug and alcohol related health harms for the offender\n· Improve community safety by reducing the risk of drug and alcohol related harms to others.                                                                                                                          \n\nDependency and Recovery Key Workers will conduct assessments both pre- and post-sentence and will focus on adressing need and minimising risk. There are dedicated consultation clinics in each GM Probation Delivery Unit. The process of ongoing assessment and review will contribute to ensuring that drug and alcohol related health needs are met inclusive of those contributing to offending risk.                                                                                       Specific objectives and appropriate interventions will be determined that take full account of complexity in addressing individual drug and alcohol related need, supporting social (re)integration, and enabling people to lead meaningful and purposeful lives.\n\nDependency and Recovery Key Workers will have a thorough understanding of the medical and psycho-social interventions provided by specialist substance misuse services and the thresholds and referral pathways for accessing them.                                                                                 Delivered interventions (1:1 or group) will promote recovery and resilience with the overall aim being to reduce drug and alcohol related harm to the POP and the wider community.  \"",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-lapse prevention",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Stockport PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Delivery of Drug and/or Alcohol Extended Brief Interventions",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Stockport PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Provision of additional Support for high complexity POP's",
+      "delivery_method": "One to one",
+      "delivery_location": "Stockport PDU's"
+    }
+  ]
+}

--- a/src/main/resources/contracts/GMIRSDR_5.json
+++ b/src/main/resources/contracts/GMIRSDR_5.json
@@ -1,0 +1,48 @@
+{
+  "internal_contract_id": "9c4fd592-a4f5-471c-9644-84e8f80a8077",
+  "contract_reference": "GMIRSDR_5",
+  "contract_type_id": "DNR",
+  "region": {
+    "nps_region_code": "L",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WITH_YOU_WIGAN_LEIGH",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "0e5b951a-51dd-4930-a7b7-d64a4213ece3",
+  "intervention_title": "Dependency and Recovery in Wigan",
+  "short_description": "\"The Dependency and Recovery Service will provide pre- and post-sentence support for individuals under the supervision of the Probation Service in Greater Manchester identified as having drug and alcohol needs.\nThe key aims of the Dependency and Recovery Service are to:\n· Reduce drug and alcohol related reoffending\n· Reduce drug and alcohol related health harms for the offender\n· Improve community safety by reducing the risk of drug and alcohol related harms to others.                                                                                                                          \n\nDependency and Recovery Key Workers will conduct assessments both pre- and post-sentence and will focus on adressing need and minimising risk. There are dedicated consultation clinics in each GM Probation Delivery Unit. The process of ongoing assessment and review will contribute to ensuring that drug and alcohol related health needs are met inclusive of those contributing to offending risk.                                                                                       Specific objectives and appropriate interventions will be determined that take full account of complexity in addressing individual drug and alcohol related need, supporting social (re)integration, and enabling people to lead meaningful and purposeful lives.\n\nDependency and Recovery Key Workers will have a thorough understanding of the medical and psycho-social interventions provided by specialist substance misuse services and the thresholds and referral pathways for accessing them.                                                                                 Delivered interventions (1:1 or group) will promote recovery and resilience with the overall aim being to reduce drug and alcohol related harm to the POP and the wider community.  \"",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-lapse prevention",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Wigan PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Delivery of Drug and/or Alcohol Extended Brief Interventions",
+      "delivery_method": "Both group and One to one",
+      "delivery_location": "Wigan PDU's"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Provision of additional Support for high complexity POP's",
+      "delivery_method": "One to one",
+      "delivery_location": "WiganPDU's"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5428.json
+++ b/src/main/resources/contracts/PRJ_5428.json
@@ -1,0 +1,145 @@
+{
+  "internal_contract_id": "1ef6e659-558c-4c9c-b2a1-e9e7d4f01df6",
+  "contract_reference": "PRJ_5428",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "A",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "LEONARD_CHESHIRE"
+    ]
+  },
+  "internal_intervention_id": "f5b72831-dddd-42e3-9209-35442b385b01",
+  "intervention_title": "ETE Services for the North East",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Employability Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Motivation and Confidence",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Applications",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Interview Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CV Production",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job, Training and Education Club",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Existing Employer Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE options and their impact on benefits",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment Brokerage",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Support Service Users to secure accreditations required for entry into relevant markets.",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Literacy and Numeracy Skills",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Funding",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Apprenticeships and Placements",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Learning Needs Assessments",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Enhanced physical and learning difficulties / disabilities support.",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Voluntary placements",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Enhanced Sexual, Violence, Fraud/Deception Support",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "One Stop Shop",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Middlesbrough, Stockton, Redcar, Darlington, Durham, Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields, Other NPS locations dependant on demand and availability of resource."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5430.json
+++ b/src/main/resources/contracts/PRJ_5430.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "e3bc47e8-9997-433f-8ccc-8e3974ff732a",
+  "contract_reference": "PRJ_5430",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "B",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "MAXIMUS_UK",
+    "subcontractor_codes": [
+      "INSPIRE_CUMBRIA_LTD"
+    ]
+  },
+  "internal_intervention_id": "976807a0-4567-4c66-b5aa-4aa0471039ae",
+  "intervention_title": "ETE Services for the North West",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5455.json
+++ b/src/main/resources/contracts/PRJ_5455.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "740b232b-4d8a-4193-85f6-9b5a5c4ba6b3",
+  "contract_reference": "PRJ_5455",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "E",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "MAXIMUS_UK",
+    "subcontractor_codes": [
+      "WILLOWDENE"
+    ]
+  },
+  "internal_intervention_id": "d3a30c69-a218-47a2-bda7-9da82b88c965",
+  "intervention_title": "ETE Services for the West Midlands",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5462.json
+++ b/src/main/resources/contracts/PRJ_5462.json
@@ -1,0 +1,62 @@
+{
+  "internal_contract_id": "4f14bb52-a5a3-4a4b-a072-13bdcccf93d4",
+  "contract_reference": "PRJ_5462",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "I",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "KAREN_MACKEY",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "51484f4c-ba48-429b-9043-41610598cdc4",
+  "intervention_title": "ETE Services for the East of England",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Job Club",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrock, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Bury St Edmunds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure and overcoming barriers workshop",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrock, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Bury St Edmunds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Preparation for Work",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrock, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Bury St Edmunds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Neurodiversity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrock, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Bury St Edmunds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education and Training",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrock, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Bury St Edmunds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5466.json
+++ b/src/main/resources/contracts/PRJ_5466.json
@@ -1,0 +1,145 @@
+{
+  "internal_contract_id": "35a03d0b-6a81-4f42-8a6d-d9273d8f215c",
+  "contract_reference": "PRJ_5466",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "F",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "LEONARD_CHESHIRE"
+    ]
+  },
+  "internal_intervention_id": "5c4f9e30-8393-4571-8582-77e99164019d",
+  "intervention_title": "ETE Services for the East Midlands",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Employability Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Motivation and Confidence",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Applications",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Interview Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CV Production",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job, Training and Education Club",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Existing Employer Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE options and their impact on benefits",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment Brokerage",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Support Service Users to secure accreditations required for entry into relevant markets.",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Literacy and Numeracy Skills",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Funding",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Apprenticeships and Placements",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Learning Needs Assessments",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Enhanced physical and learning difficulties / disabilities support.",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Voluntary placements",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Enhanced Sexual, Violence, Fraud/Deception Support",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "One Stop Shop",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness, Derby, Chesterfield, Other NPS locations dependant on demand and availability of resource."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5467.json
+++ b/src/main/resources/contracts/PRJ_5467.json
@@ -1,0 +1,120 @@
+{
+  "internal_contract_id": "cc11f280-468d-45c9-84eb-a263ab8bbf6d",
+  "contract_reference": "PRJ_5467",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "C",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_GROWTH_COMPANY_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "c697670b-2e4e-464e-8f5a-d4bc1dd1f48a",
+  "intervention_title": "ETE Services for Yorkshire & Humber",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Preparing for employment course",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job retention advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Registration session",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Motivation, Confidence and Resilience course",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CV Support",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Application forms",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Jobsearching",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Transferable Skills",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Interview Techniques",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure letters and Spent Convictions.",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Money Management",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Goals and action planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Gaining suitable ID for employment.",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Jobsearching for Service Users with IT/Internet restrictions",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Club",
+      "delivery_method": "Group",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Northallerton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe, Skipton, Harrogate, Knaresborough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5468.json
+++ b/src/main/resources/contracts/PRJ_5468.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "87e49461-2450-4e2c-9c54-98cf835c1427",
+  "contract_reference": "PRJ_5468",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "MAXIMUS_UK",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "ca452f1d-9b35-4a5f-9ada-7cd463c6a779",
+  "intervention_title": "ETE Services for London",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5469.json
+++ b/src/main/resources/contracts/PRJ_5469.json
@@ -1,0 +1,62 @@
+{
+  "internal_contract_id": "afee90f4-355b-4d77-a058-0cc0d3ff5f85",
+  "contract_reference": "PRJ_5469",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "G",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "KAREN_MACKEY",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "dc2c87b6-f0fe-45ba-aef7-3d4ef9f6ec97",
+  "intervention_title": "ETE Services for the South West",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\n\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\n\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n\n· Service User's obtain suitable training, education and employment.\n\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n\n· Service User's maintain suitable training, education and employment.\n\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Job Club",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston Super Mare, Bristol, Yeovil, Bridgwater, Bournemouth, Taunton, Poole, Plymouth, Torquay, Exeter, St Austell"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure and overcoming barriers workshop",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston Super Mare, Bristol, Yeovil, Bridgwater, Bournemouth, Taunton, Poole, Plymouth, Torquay, Exeter, St Austell"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Preparation for Work",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston Super Mare, Bristol, Yeovil, Bridgwater, Bournemouth, Taunton, Poole, Plymouth, Torquay, Exeter, St Austell"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Neurodiversity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston Super Mare, Bristol, Yeovil, Bridgwater, Bournemouth, Taunton, Poole, Plymouth, Torquay, Exeter, St Austell"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education and Training",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston Super Mare, Bristol, Yeovil, Bridgwater, Bournemouth, Taunton, Poole, Plymouth, Torquay, Exeter, St Austell"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5470.json
+++ b/src/main/resources/contracts/PRJ_5470.json
@@ -1,0 +1,62 @@
+{
+  "internal_contract_id": "6319857e-52bf-488c-8b21-7432e1cb7fcd",
+  "contract_reference": "PRJ_5470",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "K",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "KAREN_MACKEY",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "11a6eada-335e-4548-ad6d-673dacf29aaf",
+  "intervention_title": "ETE Services for Kent, Surrey & Sussex",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Job Club",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Ashford, Folkestone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guilford, Staines, Redhill, Brighton, Crawley, Hastings, Worthing"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure and overcoming barriers workshop",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Ashford, Folkestone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guilford, Staines, Redhill, Brighton, Crawley, Hastings, Worthing"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Preparation for Work",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Ashford, Folkestone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guilford, Staines, Redhill, Brighton, Crawley, Hastings, Worthing"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Neurodiversity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Ashford, Folkestone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guilford, Staines, Redhill, Brighton, Crawley, Hastings, Worthing"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education and Training",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Ashford, Folkestone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guilford, Staines, Redhill, Brighton, Crawley, Hastings, Worthing"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5471.json
+++ b/src/main/resources/contracts/PRJ_5471.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "4056ba86-2e09-4227-b883-727b2597c0c2",
+  "contract_reference": "PRJ_5471",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "D",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "MAXIMUS_UK",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "0e420d0c-22a1-449c-8907-d8847915fa9f",
+  "intervention_title": "ETE Services for Wales",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5549.json
+++ b/src/main/resources/contracts/PRJ_5549.json
@@ -1,0 +1,121 @@
+{
+  "internal_contract_id": "49a75337-d136-47b5-bb82-7e47048d6c96",
+  "contract_reference": "PRJ_5549",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "F",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NACRO",
+    "subcontractor_codes": [
+      "THE_BRIDGE_EM",
+      "SHELTER"
+    ]
+  },
+  "internal_intervention_id": "81914298-27f3-4bc6-a230-af4d7c08b44a",
+  "intervention_title": "Accommodation Services - East Midlands",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.\n· Service User makes progress in obtaining accommodation.\n· Service User is helped to secure social or supported housing.\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation.\n· Service User is prevented from becoming homeless.\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment courses",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sourcing Accommodation: Support & Advocacy (S&A)",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sourcing Accommodation: Information and Guidance (IAG)",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Application Assistance: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Application Assistance: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Continuation of existing tenancy: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Continuation of existing tenancy: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with housing-related benefits: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with housing-related benefits: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Rent deposit: S&A",
+      "delivery_method": "",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Rent deposit: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for those with additional needs",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Short-term accommodation: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Financial sustainability: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Nottingham City, Mansfield, Leicester, Loughborough, Coalville, Boston, Grantham, Lincoln, Skegness, Derby, Buxton"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5552.json
+++ b/src/main/resources/contracts/PRJ_5552.json
@@ -1,0 +1,73 @@
+{
+  "internal_contract_id": "71ef36f3-b4f3-4e2d-97b5-93d61c5a18bd",
+  "contract_reference": "PRJ_5552",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "I",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "b577cac6-440e-460e-99e4-b1ab9830e8df",
+  "intervention_title": "Accommodation Services - East of England",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed\n· Service User makes progress in obtaining accommodation\n· Service User is helped to secure social or supported housing\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation\n· Service User is prevented from becoming homeless\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Pre-tenancy training session",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sustaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Outreach Locations",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Bedfordshire, Northants, Essex, Norfolk, Suffolk, Cambridgeshire & Hertfordshire with physical offices in Luton, Northampton, Bedford, Colchester, Chelmsford, Basildon, Southend, Thurrok, Harlow, Norwich, Kings Lynn, Ipswich, Lowestoft, Burry St Edmonds, Peterborough, Cambridge, Huntingdon, St Albans, Watford, Cheshunt, Stevenage"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5553.json
+++ b/src/main/resources/contracts/PRJ_5553.json
@@ -1,0 +1,73 @@
+{
+  "internal_contract_id": "e618f0d6-efc2-486b-80fd-41185bf11cc3",
+  "contract_reference": "PRJ_5553",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "K",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "d15c0727-e98b-4e95-ad82-a23bccc66b01",
+  "intervention_title": "Accommodation Services - Kent, Surrey and Sussex",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed\n· Service User makes progress in obtaining accommodation\n· Service User is helped to secure social or supported housing\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation\n· Service User is prevented from becoming homeless\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Pre-tenancy training session",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sustaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Outreach Locations",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are in Kent, Surrey & Sussex with physical locations in the towns listed, Ashford, Folkstone, Medway, Isle of Sheppey, Thanet, Canterbury, Sittingbourne, Maidstone, Guildford, Staines, Redhill, Brighton, Crawley, Hastings, Chichester, Worthing."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5555.json
+++ b/src/main/resources/contracts/PRJ_5555.json
@@ -1,0 +1,29 @@
+{
+  "internal_contract_id": "f05529f0-f382-4bee-bf23-159d0cf06f62",
+  "contract_reference": "PRJ_5555",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "A",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THIRTEEN_HOUSING_GROUP",
+    "subcontractor_codes": [
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "183fad4d-31b6-443c-9803-e7f2de04c280",
+  "intervention_title": "Accommodation Services - North East",
+  "short_description": null,
+  "activities": null
+}

--- a/src/main/resources/contracts/PRJ_5556.json
+++ b/src/main/resources/contracts/PRJ_5556.json
@@ -1,0 +1,73 @@
+{
+  "internal_contract_id": "d2eb080a-cacd-4c0b-9006-6fed288b39d7",
+  "contract_reference": "PRJ_5556",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "B",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "2667d900-4299-44a1-8ea7-7c2e1a6326bb",
+  "intervention_title": "Accommodation Services - North West",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed\n· Service User makes progress in obtaining accommodation\n· Service User is helped to secure social or supported housing\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation\n· Service User is prevented from becoming homeless\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Pre-tenancy training session",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sustaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Outreach Locations",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Cheshire, Lancashire, Merseyside and Cumbria with physical offices in the towns indicated in the list to the right."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5559.json
+++ b/src/main/resources/contracts/PRJ_5559.json
@@ -1,0 +1,73 @@
+{
+  "internal_contract_id": "73ffc0ca-84f5-4537-9ae8-b8d27eee9925",
+  "contract_reference": "PRJ_5559",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "G",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "c75589a1-8dda-4605-9e2b-dbee84b7e25e",
+  "intervention_title": "Accommodation Services - South West",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed\n· Service User makes progress in obtaining accommodation\n· Service User is helped to secure social or supported housing\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation\n· Service User is prevented from becoming homeless\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Pre-tenancy training session",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Guidance",
+      "delivery_method": "Group, Online, 1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sustaining Accommodation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Outreach Locations",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by this contract are Gloucestershire, Wiltshire, Somerset, Dorset, Devon and Cornwall with physical offices in the towns of Cheltenham, Gloucester, Swindon, Salisbury, Bath, Weston-Super-Mare, Bristol, Yeovil, Bridgewater, Bournmouth, Taunton, Kingswood/Staple Hill, Frome, Poole, Weymouth, Plymouth, Dartmoor, Torquay, Exeter, Barnstable, Bodmin, Cambourne, Truro, St Austell, RedRuth, Bude."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5560.json
+++ b/src/main/resources/contracts/PRJ_5560.json
@@ -1,0 +1,120 @@
+{
+  "internal_contract_id": "98021507-e414-4064-a79a-c805b3461426",
+  "contract_reference": "PRJ_5560",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "E",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NACRO",
+    "subcontractor_codes": [
+      "YSS"
+    ]
+  },
+  "internal_intervention_id": "95749add-3ded-4f5b-99e9-44d74376abf8",
+  "intervention_title": "Accommodation Services - West Midlands",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.\n· Service User makes progress in obtaining accommodation.\n· Service User is helped to secure social or supported housing.\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation.\n· Service User is prevented from becoming homeless.\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment courses",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sourcing Accommodation: Support & Advocacy (S&A)",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sourcing Accommodation: Information and Guidance (IAG)",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Application Assistance: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Application Assistance: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Continuation of existing tenancy: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Continuation of existing tenancy: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with housing-related benefits: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with housing-related benefits: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Rent deposit: S&A",
+      "delivery_method": "",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Rent deposit: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for those with additional needs",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Short-term accommodation: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Financial sustainability: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Kitts Green, Central Birmingham, Sandwell, Wolverhampton, Coventry, Leamington, Stoke, Worcester, Hereford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5591.json
+++ b/src/main/resources/contracts/PRJ_5591.json
@@ -1,0 +1,277 @@
+{
+  "internal_contract_id": "230b8868-3f84-4baa-b026-e10c4882232e",
+  "contract_reference": "PRJ_5591",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "north-wales"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": 25
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "33b04fd7-f8bd-49e1-b6ef-4ba0f464fce4",
+  "intervention_title": "Personal Wellbeing Services in North Wales (18-25)",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all young adult male Service Users (aged 18-25 years), irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme.",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Staying Positive",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Wellbeing Workbook",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Relationships & Significant Others workbook 1",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family & Significant Others Workbook 2",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Role Models, Conflict Resolution and Boundaries",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Child and Drugs Exploitation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5595.json
+++ b/src/main/resources/contracts/PRJ_5595.json
@@ -1,0 +1,253 @@
+{
+  "internal_contract_id": "331cd39b-37bf-47aa-a94c-6326616d85f9",
+  "contract_reference": "PRJ_5595",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-wales"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": 25
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "071831af-c0cd-4860-aee7-a53934f0a78b",
+  "intervention_title": "Personal Wellbeing Services in South Wales (18-25)",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all young adult male Service Users (aged 18-25 years), irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Role Models, Conflict Resolution and Boundaries",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Child and Drugs Exploitation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5596.json
+++ b/src/main/resources/contracts/PRJ_5596.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "366d7963-eff8-4969-8bec-0a094d74b174",
+  "contract_reference": "PRJ_5596",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "nottinghamshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "4cd77c6b-4f8f-4488-ae4b-5363f9e13c9b",
+  "intervention_title": "Personal Wellbeing Services in Nottinghamshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Nottingham, Mansfield"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5597.json
+++ b/src/main/resources/contracts/PRJ_5597.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "127fc64e-086a-4bf9-8cba-921c9756b967",
+  "contract_reference": "PRJ_5597",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "derbyshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "15f2e798-8cf2-40e8-aa05-5f878a1944d6",
+  "intervention_title": "Personal Wellbeing Services in Derbyshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Derby, Chesterfield"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5598.json
+++ b/src/main/resources/contracts/PRJ_5598.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "1d28acdd-1179-4c8d-aa74-56ce3340d771",
+  "contract_reference": "PRJ_5598",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "leicestershire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "3cd41117-57db-456e-ab80-76ba19a701f0",
+  "intervention_title": "Personal Wellbeing Services in Leicestershire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leicester, Loughborough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5600.json
+++ b/src/main/resources/contracts/PRJ_5600.json
@@ -1,0 +1,155 @@
+{
+  "internal_contract_id": "03708ec5-2a4e-41e9-83b3-263afcb4fb33",
+  "contract_reference": "PRJ_5600",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "lincolnshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "LINCS_ACTION_TRUST"
+    ]
+  },
+  "internal_intervention_id": "5ebc3f85-74af-4969-b5a7-d37728c9e373",
+  "intervention_title": "Personal Wellbeing Services in Lincolnshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Boston, Grantham, Lincoln, SkegnessHMP Lincoln, HMP North Sea Camp"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Lincoln HMP North Sea Camp"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Lincoln HMP North Sea Camp"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5601.json
+++ b/src/main/resources/contracts/PRJ_5601.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "31a7726e-e424-4c49-8571-1aa136e55697",
+  "contract_reference": "PRJ_5601",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "west-midlands"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "4aa67eaf-8626-434f-b81e-b8a9471820f8",
+  "intervention_title": "Personal Wellbeing Services in the West Midlands",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Coventry, Kitts Green, Central Birmingham, Sandwell, Wolverhampton"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5603.json
+++ b/src/main/resources/contracts/PRJ_5603.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "5ec6ce79-b4dc-491d-ad05-7fec5a7de873",
+  "contract_reference": "PRJ_5603",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "staffordshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "cc95e028-b3a3-4751-8d4c-14036f3b36f8",
+  "intervention_title": "Personal Wellbeing Services in Staffordshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Stoke on Trent, Stafford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5604.json
+++ b/src/main/resources/contracts/PRJ_5604.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "f9d083d7-aa68-41f6-8e2b-5d407dbc37a3",
+  "contract_reference": "PRJ_5604",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "west-mercia"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "2c330e23-2c35-4863-94b3-a7eca46e0f92",
+  "intervention_title": "Personal Wellbeing Services in West Mercia",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Worcester, Hereford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5606.json
+++ b/src/main/resources/contracts/PRJ_5606.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "f336b0fd-c32f-4a82-8725-dd2d74b962eb",
+  "contract_reference": "PRJ_5606",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "hertfordshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NACRO",
+    "subcontractor_codes": [
+      "ORMISTON_FAMILIES"
+    ]
+  },
+  "internal_intervention_id": "3c810c89-9e17-45c3-983f-b8c617cc6514",
+  "intervention_title": "Personal Wellbeing Services in Hertfordshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Strengths-based conversational interventions",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Families Count course",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Supporting & Empowering at risk SUs",
+      "delivery_method": "One to one (face-to-face, virtual, telephone calls, written guidance) Group sessions",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Supporting & Empowering SU to foster positive relationships",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "'Being Home' Course",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building Stronger Families Course",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Managing Emotions",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships and parenting education courses",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Narrative coaching",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivational interviewing",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "'Divert' module",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Reflection sessions",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Exploration of positive interests",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Accompaniment",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "CRSS Advocacy",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personalised encouragement",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Coaching in diversionary activity",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Harm minimisation techniques",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Targeted coaching",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict resolution training",
+      "delivery_method": "Group",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive community interaction",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Narrative coaching",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Motivational interview techniques",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Minds, Healthy Me course",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Peer support: 'If I can, you can'",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Intensive coaching",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Independent Living Group workshop",
+      "delivery_method": "Group",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "IAG sessions",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Accompaniment to appointments",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reflection sessions",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "First 48 hours workbook",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Structured coaching and mentoring",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Self-esteem and motivation support sessions",
+      "delivery_method": "One to one",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Confidence building workshops",
+      "delivery_method": "Group",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Effective communication workshops",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Stevenage, Watford, St Albans, Cheshunt"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5615.json
+++ b/src/main/resources/contracts/PRJ_5615.json
@@ -1,0 +1,157 @@
+{
+  "internal_contract_id": "8aeeea30-0bc3-4667-969e-88e842bcca3e",
+  "contract_reference": "PRJ_5615",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "essex"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "GANGSLINE",
+      "GROUNDWORK_EAST",
+      "COMMUNITY_LED_INIT"
+    ]
+  },
+  "internal_intervention_id": "bfeb9cd3-3213-4013-8b80-840eee6b51fd",
+  "intervention_title": "Personal Wellbeing Services in Essex",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Colchester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "36893",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon, HMP Colchester"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon, HMP Colchester"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon, HMP Colchester"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Colchester, Chelmsford, Harlow, Basildon, HMP Colchester"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5619.json
+++ b/src/main/resources/contracts/PRJ_5619.json
@@ -1,0 +1,29 @@
+{
+  "internal_contract_id": "b56ce337-ebe5-42c6-a988-a1c4cfb70cc7",
+  "contract_reference": "PRJ_5619",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "northamptonshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NACRO",
+    "subcontractor_codes": [
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "61d71702-8426-4475-93f5-299bec46604f",
+  "intervention_title": "Personal Wellbeing Services in Northamptonshire",
+  "short_description": null,
+  "activities": null
+}

--- a/src/main/resources/contracts/PRJ_5621.json
+++ b/src/main/resources/contracts/PRJ_5621.json
@@ -1,0 +1,158 @@
+{
+  "internal_contract_id": "2e8a782b-fbf9-4472-ae55-4ad05eee37eb",
+  "contract_reference": "PRJ_5621",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "norfolk"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "GANGSLINE",
+      "GROUNDWORK_EAST",
+      "COMMUNITY_LED_INIT",
+      "EVOLVE_EAST_ANGLIA"
+    ]
+  },
+  "internal_intervention_id": "e9723963-5fad-4b54-bc0b-36b847849b09",
+  "intervention_title": "Personal Wellbeing Services in Norfolk",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Norwich, King’s Lynn"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Norwich King’s Lynn"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Norwich King’s Lynn, HMP Norwich"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Norwich King’s Lynn, HMP Norwich"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Norwich King’s Lynn, HMP Norwich"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Norwich King’s Lynn, HMP Norwich"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Norwich King’s Lynn, HMP Norwich"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5622.json
+++ b/src/main/resources/contracts/PRJ_5622.json
@@ -1,0 +1,157 @@
+{
+  "internal_contract_id": "50c2ec5c-4ac3-410b-9fe5-a4b2d8538740",
+  "contract_reference": "PRJ_5622",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "bedfordshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "GANGSLINE",
+      "GROUNDWORK_EAST",
+      "COMMUNITY_LED_INIT"
+    ]
+  },
+  "internal_intervention_id": "e0854498-4ca9-4838-b629-897e32e24fd9",
+  "intervention_title": "Personal Wellbeing Services in Bedfordshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "36893.0",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Luton, Bedford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Luton, Bedford, HMP Bedford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Luton, Bedford, HMP Bedford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5623.json
+++ b/src/main/resources/contracts/PRJ_5623.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "32b9648b-b418-449b-8609-a2026a632045",
+  "contract_reference": "PRJ_5623",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "suffolk"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NACRO",
+    "subcontractor_codes": [
+      "ORMISTON_FAMILIES"
+    ]
+  },
+  "internal_intervention_id": "01d0aea5-68f4-433e-91ea-7b38777d07b9",
+  "intervention_title": "Personal Wellbeing Services in Suffolk",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Strengths-based conversational interventions",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Families Count course",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Supporting & Empowering at risk SUs",
+      "delivery_method": "One to one (face-to-face, virtual, telephone calls, written guidance) Group sessions",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Supporting & Empowering SU to foster positive relationships",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "'Being Home' Course",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building Stronger Families Course",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Managing Emotions",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships and parenting education courses",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Narrative coaching",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivational interviewing",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "'Divert' module",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Reflection sessions",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Exploration of positive interests",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Accompaniment",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "CRSS Advocacy",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personalised encouragement",
+      "delivery_method": "One to one, Group (face-to-face, online/paper-based resources/workbooks/activities)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Coaching in diversionary activity",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Harm minimisation techniques",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Targeted coaching",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict resolution training",
+      "delivery_method": "Group",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive community interaction",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Narrative coaching",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Motivational interview techniques",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Minds, Healthy Me course",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Peer support: 'If I can, you can'",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Intensive coaching",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Independent Living Group workshop",
+      "delivery_method": "Group",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "IAG sessions",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Accompaniment to appointments",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reflection sessions",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "First 48 hours workbook",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Structured coaching and mentoring",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Self-esteem and motivation support sessions",
+      "delivery_method": "One to one",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Confidence building workshops",
+      "delivery_method": "Group",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Effective communication workshops",
+      "delivery_method": "One to one, Group (virtual, face-to-face)",
+      "delivery_location": "Ipswich, Bury St Edmunds, Lowestoft"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5624.json
+++ b/src/main/resources/contracts/PRJ_5624.json
@@ -1,0 +1,157 @@
+{
+  "internal_contract_id": "1b53aceb-a4de-4119-bcd2-2d077d0a0bfe",
+  "contract_reference": "PRJ_5624",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cambridgeshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "GANGSLINE",
+      "GROUNDWORK_EAST",
+      "COMMUNITY_LED_INIT"
+    ]
+  },
+  "internal_intervention_id": "a9b7b05c-ce0e-46ca-8694-27eced8c84bf",
+  "intervention_title": "Personal Wellbeing Services in Cambridgeshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "36893",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Peterborough, Huntington, Cambridge."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Peterborough, Huntington, Cambridge, HMP Peterborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Peterborough, Huntington, Cambridge. HMP Peterborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Peterborough, Huntington, Cambridge, HMP Peterborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Peterborough, Huntington, Cambridge HMP Peterborough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5625.json
+++ b/src/main/resources/contracts/PRJ_5625.json
@@ -1,0 +1,181 @@
+{
+  "internal_contract_id": "3cc9a2cd-968e-4d00-8bff-e2fe764710c5",
+  "contract_reference": "PRJ_5625",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "surrey"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "SAFE_GROUND",
+      "SUSSEX_PATHWAYS",
+      "SPARK_INSIDE"
+    ]
+  },
+  "internal_intervention_id": "6284295f-6735-4a4a-800b-3e7da2597813",
+  "intervention_title": "Personal Wellbeing Services in Surrey",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion.  \n\n  \n\nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable.  \n\n  \n\nA range of approaches will be used including: \n\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs.  \n\n  \n\nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users:  \n\nimproved pro-social self-identity and ability to access community-based support networks  \n\nsustained engagement in pro-social leisure interests and purposeful activities  \n\nreduced engagement with pro-criminal associates and activities  \n\na decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups.  \n\nengaged in their community and able to make a positive contribution.  \n\npositive family relationships and avoids harmful relationships are developed or maintained.   \n\nconfident and responsible parenting behaviours are demonstrated (where applicable).  \n\nImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.   \n\npositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.   \n\ncompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes.  \n\ndevelopment of:   \n\ncoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations.  \n\nlevels of self-efficacy, resilience and confidence  \n\nability to access and engage with mental health services.  \n\nability to recognise and manage triggers to worsening wellbeing.  \n\nability to build and maintain appropriate social interactions.  \n\ncompliance with any medication/treatment/therapy programmes  \n\nsocial networks to reduce initial social isolation are developed or sustained.  \n\nearly post-release engagement with community-based services is secured.  \n\nresilience and perseverance to cope with challenges and barriers on return to the community is developed ",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Guildford, Staines, Redhill, HMP Coldingley, HMP High Down."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Guildford, Staines, Redhill, HMP Coldingley, HMP High Down."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Guildford, Staines, Redhill, HMP Coldingley, HMP High Down."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Guildford, Staines, Redhill, HMP Coldingley, HMP High Down."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Heros Journey",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Guildford, Staines, Redhill"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Heros Journey",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Guildford, Staines, Redhill, HMP Coldingley, HMP High Down."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5626.json
+++ b/src/main/resources/contracts/PRJ_5626.json
@@ -1,0 +1,129 @@
+{
+  "internal_contract_id": "fadf83ab-a2f9-43ed-99bd-1c86f0db51f0",
+  "contract_reference": "PRJ_5626",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "kent"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "PRISON_ADVICE_CARE_TRST",
+      "THE_FORWARD_TRUST",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "8bd0dbee-2306-45b7-bb47-21f55e2a64b4",
+  "intervention_title": "Personal Wellbeing Services in Kent",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Personal Wellbeing",
+      "activity": "Individualised Action Plan",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Personal Wellbeing",
+      "activity": "Formal monthly Monitoring Reviews",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle and Associates Sessions",
+      "delivery_method": "1-2-1 and group",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle and Associates Workshops",
+      "delivery_method": "1-2-1 and group",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Extremism Sessions",
+      "delivery_method": "Group session",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ERASE Module",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Rochester, HMP Elmley, HMP Standford Hill"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Rochester, HMP Elmley, HMP Standford Hill"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Being Home",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence & Assertiveness",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing your worry",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Moving On",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "New Beginnings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "PACT PSHE",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Building stronger relationships",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Families & Significant Others",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Thanet, Ashford, Folkestone, Canterbury, Maidstone, Medway, Sittingbourne, Isle of Sheppey"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5627.json
+++ b/src/main/resources/contracts/PRJ_5627.json
@@ -1,0 +1,181 @@
+{
+  "internal_contract_id": "b8c100a5-e440-4f72-bd2a-ab427dd433c4",
+  "contract_reference": "PRJ_5627",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "sussex"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "MAGISTRA",
+      "REFORM_RESTORE_RESPECT",
+      "RFEA",
+      "UP_BEAT_LIFE",
+      "DVIP_RICHMOND",
+      "SAFE_GROUND",
+      "SUSSEX_PATHWAYS",
+      "SPARK_INSIDE"
+    ]
+  },
+  "internal_intervention_id": "5221ca4e-a20f-4773-955e-706437c1e268",
+  "intervention_title": "Personal Wellbeing Services in Sussex",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Ties Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist Legal Advice",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Facliated Family meetings",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Violence Programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Conflict and Communication Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Male identity programmes",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Activity Workshops",
+      "delivery_method": "Groups",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responding to challenging Situations",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Step Back violence reduction programme",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing my emotions workshops:",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental wellbeing workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building resiliance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Denial Workshops",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Proactive Engagement",
+      "delivery_method": "1-2-1,",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement in positive activities",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Mentoring",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District , HMP Lewes and Ford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Release planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District, HMP Lewes and Ford"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Heros Journey",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District, HMP Lewes and Ford"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Heros Journey",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton, Hastings, Crawley, Worhting, Chichester District, HMP Lewes and Ford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5628.json
+++ b/src/main/resources/contracts/PRJ_5628.json
@@ -1,0 +1,282 @@
+{
+  "internal_contract_id": "c4f3c1d6-ea4e-4bda-b2d1-306d3f354faa",
+  "contract_reference": "PRJ_5628",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY",
+      "AIR_SPORTS_NETWORK_LTD"
+    ]
+  },
+  "internal_intervention_id": "5636832f-a914-44da-9d67-a1236431835a",
+  "intervention_title": "Personal Wellbeing Services in London",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Borough, Stockwell, Croydon, Hounslow, Richmond, Shepherd’s Bush, Clerkenwell, Ealing, Uxbridge Middlesex, Wimbledon, Wandsworth, Willesden, West Hendon, Hackney (Stoke Newington), Tower Hamlets (Bethnal Green), Tottenham, Enfield, Stratford, Ilford, Leytonstone, Hornchurch"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5629.json
+++ b/src/main/resources/contracts/PRJ_5629.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "9bb92fef-1361-4d9b-9111-c39550caf0f3",
+  "contract_reference": "PRJ_5629",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "northumbria"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "d81acbce-dab6-4028-8058-7fbf526f0b58",
+  "intervention_title": "Personal Wellbeing Services in Northumbria",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gateshead, Sunderland, South Shields, Newcastle, Ashington, North Shields"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5630.json
+++ b/src/main/resources/contracts/PRJ_5630.json
@@ -1,0 +1,35 @@
+{
+  "internal_contract_id": "552421bb-6cf4-475b-945a-65d99975269a",
+  "contract_reference": "PRJ_5630",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cleveland"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "NEPACS",
+      "RETHINK_MI_LTD",
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD",
+      "THIRTEEN_HOUSING_GROUP"
+    ]
+  },
+  "internal_intervention_id": "441a694e-f323-4110-8fbb-d59f51c298a8",
+  "intervention_title": "Personal Wellbeing Services in Cleveland",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion.  \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable.  \n A range of approaches will be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs.   \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users\nimproved pro-social self-identity and ability to access community-based support networks  \nsustained engagement in pro-social leisure interests and purposeful activities  \nreduced engagement with pro-criminal associates and activities  \na decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups.  \nengaged in their community and able to make a positive contribution.  \npositive family relationships and avoids harmful relationships are developed or maintained.   \nconfident and responsible parenting behaviours are demonstrated (where applicable).  \nImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.   \npositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.   \ncompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes.  \ndevelopment of:   \ncoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations.  \nlevels of self-efficacy, resilience and confidence  \nability to access and engage with mental health services.  \nability to recognise and manage triggers to worsening wellbeing.  \nability to build and maintain appropriate social interactions.  \ncompliance with any medication/treatment/therapy programmes  \nsocial networks to reduce initial social isolation are developed or sustained.  \nearly post-release engagement with community-based services is secured.  \nresilience and perseverance to cope with challenges and barriers on return to the community is developed ",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5631.json
+++ b/src/main/resources/contracts/PRJ_5631.json
@@ -1,0 +1,45 @@
+{
+  "internal_contract_id": "0deeff8b-df60-4dbe-a904-45b0c1f6d891",
+  "contract_reference": "PRJ_5631",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "durham"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "NEPACS",
+      "RETHINK_MI_LTD",
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "5712ef65-a131-4701-a005-20f4103eeca3",
+  "intervention_title": "Personal Wellbeing Services in Durham",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion.  \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable.   \nA range of approaches will be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs.   \n\nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users:  \nimproved pro-social self-identity and ability to access community-based support networks  \nsustained engagement in pro-social leisure interests and purposeful activities \nreduced engagement with pro-criminal associates and activities  \na decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups.  \nengaged in their community and able to make a positive contribution.  \npositive family relationships and avoids harmful relationships are developed or maintained. \nconfident and responsible parenting behaviours are demonstrated (where applicable).  \nImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills. \npositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated. \ncompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes.  \ndevelopment of:   \ncoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations.  \nlevels of self-efficacy, resilience and confidence  \nability to access and engage with mental health services.  \nability to recognise and manage triggers to worsening wellbeing.  \nability to build and maintain appropriate social interactions.  \ncompliance with any medication/treatment/therapy programmes  \nsocial networks to reduce initial social isolation are developed or sustained.  \nearly post-release engagement with community-based services is secured.  \nresilience and perseverance to cope with challenges and barriers on return to the community is developed ",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Relationships Course",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Empowerment Support",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5632.json
+++ b/src/main/resources/contracts/PRJ_5632.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "1ded2793-3692-4da8-8560-6d4ec3730eb7",
+  "contract_reference": "PRJ_5632",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "west-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "db7413ab-154b-4af4-94bc-77c6eb9b0bf8",
+  "intervention_title": "Personal Wellbeing Services in West Yorkshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5633.json
+++ b/src/main/resources/contracts/PRJ_5633.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "9945fae3-cef0-4bad-b713-154481c73ec7",
+  "contract_reference": "PRJ_5633",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "humberside"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "CHANGE_GROW_LIVE_LTD",
+      "PACT_FUTURES_CIC"
+    ]
+  },
+  "internal_intervention_id": "6048f666-7d71-4667-a71e-69a7bf40a85e",
+  "intervention_title": "Personal Wellbeing Services in Humberside",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5634.json
+++ b/src/main/resources/contracts/PRJ_5634.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "09470283-0456-47ed-9b93-dfc58b274fe7",
+  "contract_reference": "PRJ_5634",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "north-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "FOUNDATION",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST"
+    ]
+  },
+  "internal_intervention_id": "e59c4125-35f4-4760-9eb5-394127a019aa",
+  "intervention_title": "Personal Wellbeing Services in North Yorkshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5635.json
+++ b/src/main/resources/contracts/PRJ_5635.json
@@ -1,0 +1,36 @@
+{
+  "internal_contract_id": "c7e7c14d-41f8-4c54-9b19-eb4916cbf09b",
+  "contract_reference": "PRJ_5635",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_GROWTH_COMPANY_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "93a0dd39-68d2-4982-af93-efd86b72acf1",
+  "intervention_title": "Personal Wellbeing Services in South Yorkshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Develop and Sustain Parenting Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Sheffield, Doncaster, Rotherham, Barnsley, Outreach venues if applicable"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5636.json
+++ b/src/main/resources/contracts/PRJ_5636.json
@@ -1,0 +1,117 @@
+{
+  "internal_contract_id": "ae8f64a3-56d2-46e6-a5d6-820bfb72411c",
+  "contract_reference": "PRJ_5636",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cheshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SEETEC_BUS_TECH_CTR_LTD",
+    "subcontractor_codes": [
+      "KSS_CRC",
+      "PRISON_ADVICE_CARE_TRST",
+      "THE_FORWARD_TRUST",
+      "PLUSS_ORG_CIC"
+    ]
+  },
+  "internal_intervention_id": "208d5b21-0102-4bc6-8615-a0f094692543",
+  "intervention_title": "Personal Wellbeing Services in Cheshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including: direct delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated(where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle and Associates Sessions",
+      "delivery_method": "1-2-1 and group",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle and Associates Workshops",
+      "delivery_method": "1-2-1 and group",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Extremism Sessions",
+      "delivery_method": "Group session",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ERASE Module",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Risley, HMP Thorncross"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Risley, HMP Thorncross"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Being Home",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence & Assertiveness",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing your worry",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Moving On",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "New Beginnings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "PACT PSHE",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Building stronger relationships",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Families & Significant Others",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Locations covered by the contract are in Cheshire with physical offices in the following towns:, Chester, Northwich, Crewe, Macclesfield, Warrington, Halton"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5638.json
+++ b/src/main/resources/contracts/PRJ_5638.json
@@ -1,0 +1,36 @@
+{
+  "internal_contract_id": "99af4fb3-b095-46ab-8208-d3a974271c7e",
+  "contract_reference": "PRJ_5638",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "merseyside"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_GROWTH_COMPANY_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "7628eca5-b5d0-4ba9-9745-1d9fc6d68f22",
+  "intervention_title": "Personal Wellbeing Services in Merseyside",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Develop and Sustain Parenting Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Market Wells, Market St Birkenhead CH41 6JN, The Kirkby Centre, Norwich Way, Kirkby, L32 8SE, Mersey Care NHS Foundation Trust, The Life Rooms, Evered Avenue, Liverpool L9 2AF, Kuumba Imani Centre 4 Princes Road, Liverpool L8 1TH, Park Road Adult Learning Centre, 155-163 Park Road, Liverpool L8 6SE, The Community Hub, Spellow Ln, Liverpool L4 4DA, Knowsley Works, 43 Derby Road, Liverpool, L36 9UQ, Brunswick Community Centre, Marsh Lane, Liverpool, L20 4QJ, REACH Employability Hub , South Liverpool Homes, Parklands, Speke, Liverpool L24 0TY, Speke Training & Education Centre (STEC), Unit House, Speke Boulevard, Liverpool, L24 9HZ, Newton community centre Park Rd South, Newton-le-Willows, WA12 8EX, Newton Fire Station, 34 Borron Road, Newton-le-Willows WA12 0EW, Prescot Library, 1 High St, Prescot L34 3LD, The Life Rooms, Merseycare NHS Foundation Trust 23-25 Scarisbrick Avenue, Southport, PR8 1NW, Starting Point, 4-6 Hardshaw Street, St Helens WA10 1RE, Peter Street Community Centre, Peter Street, St Helens WA10 2EQ, Blackbrook Rugby Club Boardmans Lane, St. Helens, Merseyside WA11 9BB, Saints Foundation. McManus Way (accessible), St Helens, WA9 3AL, Wirral Ways to Recovery 151-153 Brighton Street, Wallasey CH44 8DU"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5639.json
+++ b/src/main/resources/contracts/PRJ_5639.json
@@ -1,0 +1,36 @@
+{
+  "internal_contract_id": "a954d002-4109-4ab3-a988-9391b872d003",
+  "contract_reference": "PRJ_5639",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "lancashire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_GROWTH_COMPANY_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "8ed2fd38-6bb6-4436-8d0b-99e93a96bc41",
+  "intervention_title": "Personal Wellbeing Services in Lancashire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Develop and Sustain Parenting Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Blackpool, Burnley, Accrington, Skelmersdale, Preston, Chorley, Blackburn with Darwen"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5641.json
+++ b/src/main/resources/contracts/PRJ_5641.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "0dbbac58-3e7d-492f-af04-2e54807245b3",
+  "contract_reference": "PRJ_5641",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "hampshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "c5936291-20c8-47ad-b24b-f92e81b1674b",
+  "intervention_title": "Personal Wellbeing Services in Hampshire",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest area, Portsmouth, Isle of Wight"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5643.json
+++ b/src/main/resources/contracts/PRJ_5643.json
@@ -1,0 +1,282 @@
+{
+  "internal_contract_id": "f945e2fe-3ffa-4cb9-923d-1adda03ee433",
+  "contract_reference": "PRJ_5643",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "thames-valley"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY",
+      "THAMES_VALLEY_PART"
+    ]
+  },
+  "internal_intervention_id": "b8dc115c-77dc-45ec-9d78-d8d90c3c5494",
+  "intervention_title": "Personal Wellbeing Services in Thames Valley",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5646.json
+++ b/src/main/resources/contracts/PRJ_5646.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "2886fa71-635a-4952-b554-5fe3206cca8f",
+  "contract_reference": "PRJ_5646",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "dorset"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "eb564d25-58cd-4178-ac8d-225daf363278",
+  "intervention_title": "Personal Wellbeing Services in Dorset",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bournemouth, Weymouth, Poole, Sherbourne, Gillingham"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5649.json
+++ b/src/main/resources/contracts/PRJ_5649.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "7633b5ad-4060-4e9f-93ad-d9bcda5702b2",
+  "contract_reference": "PRJ_5649",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "avon-and-somerset"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "2c69e5ca-c5ef-43bd-a5fc-cc63ff0a4626",
+  "intervention_title": "Personal Wellbeing Services in Avon and Somerset",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Bristol, Kingswood/Staple Hill, North Bristol including Southmead/Filton, Bridgwater, Taunton, Yeovil, Frome, Weston-super-Mare & Bath"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5650.json
+++ b/src/main/resources/contracts/PRJ_5650.json
@@ -1,0 +1,266 @@
+{
+  "internal_contract_id": "90e054ea-2432-4272-8506-6c2fbd0e7a71",
+  "contract_reference": "PRJ_5650",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "north-wales"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 26,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "CAIS_LTD",
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "aa246017-323e-4552-b682-c988b1c73703",
+  "intervention_title": "Personal Wellbeing Services in North Wales (26 plus)",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Staying Positive",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Wellbeing Workbook",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Relationships & Significant Others workbook 1",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family & Significant Others Workbook 2",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caernarfon, Bangor, Colwyn Bay, Flint, Wrexham, Lilangeni, Blaenau, Dolgellau, Holyhead"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5653.json
+++ b/src/main/resources/contracts/PRJ_5653.json
@@ -1,0 +1,242 @@
+{
+  "internal_contract_id": "55381bbb-f4ee-41e6-80a4-daf78c5645aa",
+  "contract_reference": "PRJ_5653",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-wales"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 26,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "RESTORATIVE_WALES",
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "c985a51a-a0aa-4f39-890c-8d67e1ed93e6",
+  "intervention_title": "Personal Wellbeing Services in South Wales (26 plus)",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bridgend, Cardiff, Merthyr, Pontypridd, Swansea, HMP Cardiff, HMP Swansea, HMP Parc"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5750.json
+++ b/src/main/resources/contracts/PRJ_5750.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "4d2ec507-9ab7-413f-af2d-6aeb0125be65",
+  "contract_reference": "PRJ_5750",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "avon-and-somerset"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_NELSON_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "9f55da6f-4a64-4736-8586-36cc4cb147f5",
+  "intervention_title": "Women's Services in Avon and Somerset",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1 Delivery.",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1, Group online & Group face-2-face",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1 Delivery.",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance assessment, planning, support to implement plans and signposting",
+      "delivery_method": "1-2-1, Group online & Group face-2-face .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education, Training, completion of qualifications & implementation of plans",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment pathway development including volunteering, apprenticeships and job opportunities",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency & recovery accessing external support",
+      "delivery_method": "1-2-1.",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency internal specialist support",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family & Significant others support and advocacy",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle & Associates offer",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Wellbeing assessment, planning and implementation",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion assessment, planning and implementation",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Bath & North East Somerset, Bristol, Somerset, South Gloucestershire, and outreach as required"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5751.json
+++ b/src/main/resources/contracts/PRJ_5751.json
@@ -1,0 +1,143 @@
+{
+  "internal_contract_id": "2c02b50c-e848-4258-acf0-ec028d64f3d3",
+  "contract_reference": "PRJ_5751",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "bedfordshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "BEDFORD_WOMENS_CENTRE",
+      "HIBISCUS_INIT",
+      "WORKING_CHANCE_LTD",
+      "AURORA_NEW_DAWN",
+      "CAMBS_WMNS_RESOURCE_CTR",
+      "STEPPINGSTONES_LUTON"
+    ]
+  },
+  "internal_intervention_id": "f58e3b05-36ed-41b7-80cd-eea79778acc9",
+  "intervention_title": "Women's Services in Bedfordshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Luton, Bedford and local hubs across the region including mandated locations"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5752.json
+++ b/src/main/resources/contracts/PRJ_5752.json
@@ -1,0 +1,230 @@
+{
+  "internal_contract_id": "65b78598-9e4a-4f3d-8900-8b8dd451a83e",
+  "contract_reference": "PRJ_5752",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cambridgeshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD",
+      "ANGLIA_CARE_TRUST"
+    ]
+  },
+  "internal_intervention_id": "6f2632ec-a5c3-4767-a701-df4ee314f5b4",
+  "intervention_title": "Women's Services in Cambridgeshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP) - Pre release",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "HMP Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation pre release",
+      "delivery_method": "one-to-one",
+      "delivery_location": "HMP Peterborough"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough. HMP Peterborough"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough. HMP Peterborough"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough. HMP Peterborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Low Intensity",
+      "delivery_method": "",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Medium Intensity",
+      "delivery_method": "",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE High Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Low Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Cambridgeshire - Cambridge, Huntingdon and Peterborough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5753.json
+++ b/src/main/resources/contracts/PRJ_5753.json
@@ -1,0 +1,463 @@
+{
+  "internal_contract_id": "f4279de9-be0d-4123-a9e0-a5ba2f6f0cb2",
+  "contract_reference": "PRJ_5753",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cheshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "PSS_UK",
+    "subcontractor_codes": [
+      "THE_GROWTH_COMPANY_LTD",
+      "TOMORROWS_WOMEN_WIRRAL"
+    ]
+  },
+  "internal_intervention_id": "4fc56ed4-8a62-478d-ac83-3d5acd3d48e4",
+  "intervention_title": "Women's Services in Cheshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtain and maintain suitable tenancy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Agency Drop Ins",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Pathways to Employment Group",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "New Leaf",
+      "delivery_method": "1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Qualification Led Courses",
+      "delivery_method": "Group / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment Agency Drop Ins",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "RISE Programme ( recovery, intervention, support and education)",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support and advocacy for dependency external support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Warrington & Cheshire East"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol & Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Positive Women around Substance Misuse",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance Misuse Support Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Develop or enhance pathways around money management",
+      "delivery_method": "1-2-1 / remote (phone) / referral to specialist agencies",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial Advice Drop Ins",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Your Emotions",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Positive Solutions",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Group",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom Programme",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Changing Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Finding Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Happy Healthy Homes Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "My Child and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Bereavement Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Life Steps",
+      "delivery_method": "Group / 1-2-1",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Alcohol & Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Changing Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Victim Awareness Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Exercise",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Legal Advise Surgeries",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness",
+      "delivery_method": "group / 1-2-1",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Ruby Project Domestic abuse drop in",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Warrington, Cheshire East"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "A Better You Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "A More Confident You Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Bazaar Marketplace - CBT Course",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Colours Programme",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Wellbeing and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Red to Pink Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Working with Self Harm Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Exercise",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Crafts",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Horticulture/Gardening Club",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Reading Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Performance Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Meditation and Mindfulness",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Coping with Bipolar Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Bereavement Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Domestic Abuse Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Family Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Positive Women around Substance Misuse",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Legal Advise Surgeries",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental Health Surgeries",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Positive You Portfolio",
+      "delivery_method": "1:1",
+      "delivery_location": "Warrington & Cheshire East"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Activity Hubs",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Warrington"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Positive You Portfolio",
+      "delivery_method": "1:1",
+      "delivery_location": "Warrington & Cheshire East"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Directory of services",
+      "delivery_method": "Ad hoc / 1:1",
+      "delivery_location": "Warrington & Cheshire East"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Wellbeing and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Exercise",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Crafts",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Horticulture/Gardening Club",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reading Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Performance Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Meditation and Mindfulness",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Coping with Bipolar Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Bereavement Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Domestic Abuse Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Family Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Merseyside Police Drop In",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Cheshire West / Chester / Wirral"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5764.json
+++ b/src/main/resources/contracts/PRJ_5764.json
@@ -1,0 +1,270 @@
+{
+  "internal_contract_id": "d5e84209-e44c-4834-b45c-67390404501e",
+  "contract_reference": "PRJ_5764",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cleveland"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+      "A_WAY_OUT"
+    ]
+  },
+  "internal_intervention_id": "37d8924e-e5fc-400b-8b59-aed4336f91e4",
+  "intervention_title": "Women's Services in Cleveland",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Award in Employability",
+      "delivery_method": "Group basis only, participants must be ready to take on the requirement of an accredited progamme., Participants may benefit from completing the functional skills award in Maths and English first.",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Functional Skills Award (Literacy and Numeracy)",
+      "delivery_method": "Group basis only, participants must be ready to take on the requirements of an accredited progamme.",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Springboard Trust - NCFE Award in Mental Health",
+      "delivery_method": "One to one online",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Industry standard qualifications",
+      "delivery_method": "Group basis, with external participants., Provider will put on an internal only course specifically for a cohort of learners if there are enough participants.",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CFO3: Overcoming barriers to ETE",
+      "delivery_method": "One-to-one and Group basis, Only available to those who are unemployed and have right to work in the UK, Can be for the duration of the Order/Licence, Available until November 2022",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "One to one",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Grant Applications",
+      "delivery_method": "One to one or on behalf of the individual, approximately 2 hours session.",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management Course",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Good Tenant Portfolio",
+      "delivery_method": "One to one or Group basis, in person on online",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough, HMP Low Newton"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "Approximately 2 hours duration, One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "Group basis, with any follow-up undertaken One to one",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Helping Women to Recover (Introduction)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Gambling support",
+      "delivery_method": "Group or One to one basis, ongoing support on needs led basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services - Outreach support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Preparing for Treatment",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnerships and Pathways",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safety Planning and Safeguarding",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse Outreach",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Beyond Trauma",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis, expected to be a minimum of 10 hours intervention",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Respect",
+      "delivery_method": "Group or One to one basis.",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Keeping Safe Online and Presenting yourself on Social Media",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Future Steps (for Young Adults)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Making Good Programme",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Chrysalis Programme",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Self Belief",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health and Wellbeing",
+      "delivery_method": "Group basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition from Custody to Community",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one basis",
+      "delivery_location": "Stockton,, Hartlepool,, Redcar,, Middlesbrough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5776.json
+++ b/src/main/resources/contracts/PRJ_5776.json
@@ -1,0 +1,138 @@
+{
+  "internal_contract_id": "b2a291f1-4025-4e58-ac67-9b79b4f901ba",
+  "contract_reference": "PRJ_5776",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "derbyshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WOMENS_WORK_DERBS_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "88939945-6d05-4d0a-a23b-3b9f7382be07",
+  "intervention_title": "Women's Services in Derbyshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Education, Training & Employment (1) Low Complexity",
+      "activity": "ETE Advise & Support Service including Job Club and workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Education, Training & Employment (2) Medium Complexity",
+      "activity": "ETE Advise & Support Service including Job Club and workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Education, Training & Employment (3) High Complexity",
+      "activity": "ETE Advise & Support Service - multi-agecy approach to support and acccess specialist agencies",
+      "delivery_method": "1-1, via face to face or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Accommodation (1) Low Complexity",
+      "activity": "Accomodation Advise and Support, Service including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Accommodation (2) Medium Complexity",
+      "activity": "Accomodation Advice and Support Service including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Accommodation (3) High Complexity",
+      "activity": "Accomodation Advise & Support Service - multi-agency approach to support and acccess accomodation",
+      "delivery_method": "1-1, via face to face or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Accommodation (4) Pre-release activities",
+      "activity": "Pre-release Accomodation Advice and Support Service - multi-agency approach to support to acccess accomodation",
+      "delivery_method": "<html><b>Pre-release activities - Service Users being released from HMP Foston Hall</b> - Visits, phone contact or video link, <b>Pre-release activities - Service Users being released from other prisons to Derbyshire</b> - Phone contact or video link</html>",
+      "delivery_location": "<html><b>HMP Foston Hal</b>l and other prisons releasing women to Derbyshire</html>"
+    },
+    {
+      "need_area": "Finance, Benefit & Debt (1) Low Intensity",
+      "activity": "Finance, Benefit & Debt Advice and Support, Service including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Finance, Benefit & Debt (2) Medium Intensity",
+      "activity": "Finance, Benefit & debt Advice and Support, Service including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Finance, Benefit & Debt (3) High Intensity",
+      "activity": "Finance, Benefit & Debt, Advice and Support Service - multi-agency approach and support to acccess specialist agencies",
+      "delivery_method": "1-1, via face to face or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Dependency & Recovery (1), Low Complexity",
+      "activity": "Dependancy & Recovery Advice and Support, Service including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Dependency & Recovery (2), Medium Complexity",
+      "activity": "Dependancy & Recovery Advice and Support, Service including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Dependency & Recovery (3), High Complexity",
+      "activity": "Dependancy & Recovery Advice and Support Service - multi-agency approach and support to acccess specialist agencies",
+      "delivery_method": "1-1, via face to face or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Family & Significant Others Core Activities",
+      "activity": "<html>Family Advice & Support Services including the <b>Freedom Programme</b></html>",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Lifestyle & Associates Core Activities",
+      "activity": "Lifestyle & Associates Advice and Support Services including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Emotional Wellbeing Core Activities",
+      "activity": "Emotional Wellbeing Advice and Support Services with Counselling Services and workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, virtual or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Social Inclusion Core Activities",
+      "activity": "Social Inclusion Advice and Support Services including workshops",
+      "delivery_method": "1-1 or group sessions, via face to face, online or telephone",
+      "delivery_location": "Derby, Chesterfield, Buxton, Swadlincote"
+    },
+    {
+      "need_area": "Social Inclusion Pre-release",
+      "activity": "Pre-release Social Inclusion Services",
+      "delivery_method": "<html><b>Pre-release activities - Service Users being released from HMP Foston Hall</b> - Visits, phone contact or video link, <b>Pre-release activities - Service Users being released from other prisons to Derbyshire</b> - Phone contact or video link</html>",
+      "delivery_location": "<html><b>HMP Foston Hal</b>l and other prisons releasing women to Derbyshire</html>"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5779.json
+++ b/src/main/resources/contracts/PRJ_5779.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "941e23ec-8ba8-4028-9f8c-d1232a17800c",
+  "contract_reference": "PRJ_5779",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "devon-and-cornwall"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WOMENS_CTR_CORNWALL",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "92b22475-9708-4ad5-9052-d77b74c8b206",
+  "intervention_title": "Women's Services in Devon and Cornwall",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Relationships Course",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Being a good tenant programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job retention advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Open Service - Pre-release",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Open Service - Community",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Open Service - Pre-release",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "Plymouth, Cornwall and Isles of Scilly, Devon & Torbay, Including outreach in rural areas"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5780.json
+++ b/src/main/resources/contracts/PRJ_5780.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "f57cdff9-d509-4e08-a7d5-bc2636652ca6",
+  "contract_reference": "PRJ_5780",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "dorset"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WOMENS_CTR_CORNWALL",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "fd4beacb-cb18-4a24-b5c7-903bb66b8317",
+  "intervention_title": "Women's Services in Dorset",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Relationships Course",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Being a good tenant programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job retention advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Open Service - Pre-release",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Open Service - Community",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Open Service",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Open Service - Pre-release",
+      "delivery_method": "1-2-1. The number of sessions depends upon complexity levels and categories selected. The action plan is regularly reviewed and updated in consultation with the Responsible Officer, responding dynamically to the woman's changing needs, and additional information she discloses as trust develops.",
+      "delivery_location": "All of Dorset including Bournemouth, Christchurch and Poole and outreach in rural areas"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5781.json
+++ b/src/main/resources/contracts/PRJ_5781.json
@@ -1,0 +1,33 @@
+{
+  "internal_contract_id": "af58d97b-20dd-4be8-8901-39169d1e4665",
+  "contract_reference": "PRJ_5781",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "durham"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "THE_WISE_GROUP_LTD",
+      "HUMANKIND",
+      "ST_GILES_TRUST"
+    ]
+  },
+  "internal_intervention_id": "8dea8f2e-2fa6-44d0-93e9-ab5d0903084b",
+  "intervention_title": "Women's Services in Durham",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5789.json
+++ b/src/main/resources/contracts/PRJ_5789.json
@@ -1,0 +1,142 @@
+{
+  "internal_contract_id": "790ecc70-4cfe-4522-ad86-c69a7019b10b",
+  "contract_reference": "PRJ_5789",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "essex"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "HIBISCUS_INIT",
+      "WORKING_CHANCE_LTD",
+      "AURORA_NEW_DAWN",
+      "BIRTH_COMPANIONS",
+      "SAFER_PLACES"
+    ]
+  },
+  "internal_intervention_id": "215751a3-c09d-43ae-aedf-eec1c1ff6f68",
+  "intervention_title": "Women's Services in Essex",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Harlow, Colchester and local hubs across the region including mandated locations"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5790.json
+++ b/src/main/resources/contracts/PRJ_5790.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "9801447e-f5ca-4987-a05e-b3191bc73507",
+  "contract_reference": "PRJ_5790",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "gloucestershire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_NELSON_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "61e9550a-30c7-47a2-8f28-478dfec2d2ee",
+  "intervention_title": "Women's Services in Gloucestershire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1 Delivery.",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1, Group online & Group face-2-face .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1 Delivery.",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance assessment, planning, support to implement plans and signposting",
+      "delivery_method": "1-2-1, Group online & Group face-2-face .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education, Training, completion of qualifications & implementation of plans",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment pathway development including volunteering, apprenticeships and job opportunities",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency & recovery accessing external support",
+      "delivery_method": "1-2-1.",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency internal specialist support",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family & Significant others support and advocacy",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle & Associates offer",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Wellbeing assessment, planning and implementation",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion assessment, planning and implementation",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Gloucester stroud, Tewkesbury, Cotswolds Forest of Dean"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5791.json
+++ b/src/main/resources/contracts/PRJ_5791.json
@@ -1,0 +1,143 @@
+{
+  "internal_contract_id": "2397773b-6abd-4c7c-ab90-5a9b7a65fd6e",
+  "contract_reference": "PRJ_5791",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "hampshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "INCLUSION",
+      "HIBISCUS_INIT",
+      "WORKING_CHANCE_LTD",
+      "AURORA_NEW_DAWN",
+      "BIRTH_COMPANIONS",
+      "ONE_SMALL_THING"
+    ]
+  },
+  "internal_intervention_id": "2fdfbddf-97bf-4479-84df-6f8102ba0329",
+  "intervention_title": "Women's Services in Hampshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•\tAccommodation \n•\tETE  \n•\tDependency and Recovery  \n•\tFinance, Benefits and Debt  \n•\tEmotional Wellbeing   \n•\tFamily and Significant Others \n•\tLifestyle and Associates \n•\tSocial Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Portsmouth, Southampton, Isle of Wight and local hubs across the region including mandated locations"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5792.json
+++ b/src/main/resources/contracts/PRJ_5792.json
@@ -1,0 +1,142 @@
+{
+  "internal_contract_id": "4c8b1575-8ef3-4d2a-8e8c-37fca6d6cb94",
+  "contract_reference": "PRJ_5792",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "hertfordshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "HIBISCUS_INIT",
+      "WORKING_CHANCE_LTD",
+      "AURORA_NEW_DAWN",
+      "BIRTH_COMPANIONS",
+      "SAFER_PLACES"
+    ]
+  },
+  "internal_intervention_id": "55e39330-f0a5-4bd6-b383-535b9188c0e2",
+  "intervention_title": "Women's Services in Hertfordshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Broxbourne and local hubs across the region including mandated locations"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5793.json
+++ b/src/main/resources/contracts/PRJ_5793.json
@@ -1,0 +1,362 @@
+{
+  "internal_contract_id": "aea78365-7b57-40d8-90a4-49d3c58df992",
+  "contract_reference": "PRJ_5793",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "humberside"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "TOGETHER_WOMEN_PROJECT",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "SHELTER",
+      "LINCS_ACTION_TRUST"
+    ]
+  },
+  "internal_intervention_id": "2a4b94f7-0e38-44a5-a330-8caf7bd1ee60",
+  "intervention_title": "Women's Services in Humberside",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation retention, advocacy and support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support to secure funding",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Homeless Support Drop In",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "My Property course",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for benefits process",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Jocentre Plus",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Club",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Support and Advocacy",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Pathways into college/training providers",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Work experience provision",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Accredited learning courses",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Specialist ETE support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD workshops",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt Advocacy",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Advice & Guidance",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Specialist support & advice",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": ""
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Freedom Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Stop Theft Activity Requirement (STAR) programme",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Constructive substitute activities",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Peer-led SMART recovery group",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief/Extended Brief interventions and wrap-around support",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Targeted Abstinence/Relapse support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Relapse specialist support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Specialist Support",
+      "delivery_method": "1-to- 1; Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Specialist Support",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Focussed resilience support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Post Adoption Support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Child Sexual Exploitation trauma advice",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Counselling",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist legal advice",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Right Track Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Better Solutions Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Stop Theft Activity Requirement (STAR) programme",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social activities",
+      "delivery_method": "1-to-1; Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Improvement Workshops",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Specialist Agency Referrals",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Peer mentoring",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mentoring and Advocacy Service",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Anxiety (RAR) Programme",
+      "delivery_method": "Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing My Emotions programme",
+      "delivery_method": "1-to-1; Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anger Management Programme",
+      "delivery_method": "1-to-1; Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1; Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Trauma-informed counselling",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Adverse Childhood Experience recovery toolkit",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sexual Violence recovery toolkit",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Trauma support programme referral",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence and Self-esteem sessions",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Community support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "RAR programmes",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Hull; Beverley; Bridlington; Goole; Grimsby; Scunthorpe"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5794.json
+++ b/src/main/resources/contracts/PRJ_5794.json
@@ -1,0 +1,144 @@
+{
+  "internal_contract_id": "e240405c-6302-4613-a5c3-1d14d85451f0",
+  "contract_reference": "PRJ_5794",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "kent"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "BWC",
+      "CHOICES",
+      "HIBISCUS_INIT",
+      "WORKING_CHANCE_LTD",
+      "AURORA_NEW_DAWN",
+      "BIRTH_COMPANIONS",
+      "RISING_SUN_DVA"
+    ]
+  },
+  "internal_intervention_id": "6a7109e0-ec7b-4180-8aa7-0468b13055f3",
+  "intervention_title": "Women's Services in Kent",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Maidstone, Canterbury and local hubs across the region including mandated locations"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5795.json
+++ b/src/main/resources/contracts/PRJ_5795.json
@@ -1,0 +1,162 @@
+{
+  "internal_contract_id": "9a987887-77f0-49ee-91cb-c9e02b634ad3",
+  "contract_reference": "PRJ_5795",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "lancashire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "LANCASHIRE_WOMEN",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "3013e917-be40-48af-8091-ed23331c0f4b",
+  "intervention_title": "Women's Services in Lancashire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Advocacy - High",
+      "delivery_method": "one-to-one, face to face in community/custody or remotely when not possible.",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Support - Medium",
+      "delivery_method": "one-to-one, face to face in community/custody or remotely when not possible.",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accomodation advice and guidance - Low",
+      "delivery_method": "Face to face/online group - 8 weeks",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE - Achieve - community",
+      "delivery_method": "one-to-one, face to face in or remotely when not possible.",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE - LW Employment Advice and Guidance services - Medium",
+      "delivery_method": "one-to-one, face to face or remotely when not possible.",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE - Essential Skills - Finding Your Future - Low",
+      "delivery_method": "Group, 1-2-1, Online/Face to Face",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "D&R Specific Caseworker Support - High",
+      "delivery_method": "One-to-one face to face or remotely if not possible.",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Caseworker Advocacy - medium",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Essential Skills - Addiction Awareness - Low",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Caseworker Support - High",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "LW Money Advice Support - Medium",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Esential Skills - Money Matters - Low",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Caseworker Advocacy - High",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Therapeutic Interventions - Medium",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Therapeutic Interventions - Low",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Caseworker Advocacy - High",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Eyes Wide Open - Med",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Essential Skills: Respecting Relationships - Low",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Caseworker Advocacy - High",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Peer Support - Med",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Essential Skills - Low",
+      "delivery_method": "Group face to face or online",
+      "delivery_location": "Lancashire"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Resettlement Support",
+      "delivery_method": "One to one, face to face or remotely if not possible",
+      "delivery_location": "Lancashire"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5798.json
+++ b/src/main/resources/contracts/PRJ_5798.json
@@ -1,0 +1,234 @@
+{
+  "internal_contract_id": "c9061aaa-89d2-401e-bdcc-9bc938321595",
+  "contract_reference": "PRJ_5798",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "leicestershire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+      "NEWDAWN_NEWDAY"
+    ]
+  },
+  "internal_intervention_id": "24af69f4-eb7b-4847-a4bb-e26c30253c29",
+  "intervention_title": "Women's Services in Leicestershire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "IAG",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "Group Workshops, 1-2-1, Online, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "1-2-1, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation",
+      "delivery_method": "1-2-1, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Grant Applications",
+      "delivery_method": "1-2-1 or on behalf of the individual",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Independent Living Skills Development",
+      "delivery_method": "1-2-1, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Preventing Homelessness",
+      "delivery_method": "One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis with any follow-up undertaken One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Trauma informed intervention - Womens Emotional Managemnet",
+      "delivery_method": "Group",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Peer Support Group",
+      "delivery_method": "Group",
+      "delivery_location": ""
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Well-being Workshops",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Barriers to Change",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "IAG",
+      "delivery_method": "One to one indivdual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safeguarding and Safety Planning",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse wraparound",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic / sexual abuse",
+      "delivery_method": "Group basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationship",
+      "delivery_method": "Group basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis,",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal development activities",
+      "delivery_method": "Group basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "healthier lifestyle and Boundaries",
+      "delivery_method": "One to one",
+      "delivery_location": ""
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Wellbeing Programme",
+      "delivery_method": "Group",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Group or One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness",
+      "delivery_method": "Group or One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer Support Group",
+      "delivery_method": "One to one",
+      "delivery_location": "Leicester"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one",
+      "delivery_location": "Leicester"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5799.json
+++ b/src/main/resources/contracts/PRJ_5799.json
@@ -1,0 +1,505 @@
+{
+  "internal_contract_id": "817618b8-75a0-4d79-a115-2f9c0ee40ce8",
+  "contract_reference": "PRJ_5799",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "merseyside"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "PSS_UK",
+    "subcontractor_codes": [
+      "THE_GROWTH_COMPANY_LTD",
+      "TOMORROWS_WOMEN_WIRRAL"
+    ]
+  },
+  "internal_intervention_id": "d3c492fa-bffb-4b73-aadb-c9f61fecf0a6",
+  "intervention_title": "Women's Services in Merseyside",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtain and maintain suitable tenancy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Agency Drop Ins",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Pathways to Employment Group",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Liverpool, Sefon, Knowsley, St Helens"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Support and advocacy for additional ETE external provision.",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Liverpool, Sefon, Knowsley, St Helens"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Qualification Led Courses",
+      "delivery_method": "Group / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment Agency Drop Ins",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "RISE Programme ( recovery, intervention, support and education)",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Liverpool, Sefon, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support and advocacy for dependency external support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Liverpool, Sefon, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol & Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Positive Women around Substance Misuse",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance Misuse Support Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Develop or enhance pathways around money management",
+      "delivery_method": "1-2-1 / remote (phone) / referral to specialist agencies",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "access to specialist money advice services",
+      "delivery_method": "drop in by appointment",
+      "delivery_location": "Liverpool"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial Advice Drop Ins",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Your Emotions",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Trauma informed counselling",
+      "delivery_method": "1-2-1 / face to face / remote",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Specialist Criminal Justice Mental health teams drop in",
+      "delivery_method": "1-2-1 / face to face / remote appointment only",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "A Better You Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "A More Confident You Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Bazaar Marketplace - CBT Course",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Colours Programme",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Wellbeing and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Red to Pink Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Working with Self Harm Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Exercise",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Crafts",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Horticulture/Gardening Club",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Reading Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Performance Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Meditation and Mindfulness",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Coping with Bipolar Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Bereavement Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Domestic Abuse Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Family Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Positive Women around Substance Misuse",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Legal Advise Surgeries",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental Health Surgeries",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Solutions",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Alcohol & Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Changing Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Victim Awareness Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Exercise",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Legal Advise Surgeries",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Group",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom Programme",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "The Gateway Programme",
+      "delivery_method": "Group / 1-2-1 /",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "The Gateway Programme",
+      "delivery_method": "Group / 1-2-1 /",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Life Steps",
+      "delivery_method": "Group / 1-2-1",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse drop in",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family solicitors",
+      "delivery_method": "1-2-1 appointment only",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Changing Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Finding Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Happy Healthy Homes Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "My Child and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Bereavement Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "drop in",
+      "delivery_method": "weekly drop in",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "peer support group",
+      "delivery_method": "Monthly and remote when needed",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "support and advocacy",
+      "delivery_method": "1:1",
+      "delivery_location": "Liverpool"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Positive You Portfolio",
+      "delivery_method": "1:1",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Positive You Portfolio",
+      "delivery_method": "1:1",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Directory of services",
+      "delivery_method": "Ad hoc / 1:1",
+      "delivery_location": "Liverpool, Sefton, Knowsley, St Helens"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Little Steps Work",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Wellbeing and Me Course",
+      "delivery_method": "Group / 1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Exercise",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Crafts",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Horticulture/Gardening Club",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reading Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Performance Groups",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Meditation and Mindfulness",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Coping with Bipolar Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Bereavement Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Domestic Abuse Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Family Support Group",
+      "delivery_method": "Group",
+      "delivery_location": "Wirral"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Merseyside Police Drop In",
+      "delivery_method": "1-1 / remote delivery",
+      "delivery_location": "Wirral"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5802.json
+++ b/src/main/resources/contracts/PRJ_5802.json
@@ -1,0 +1,33 @@
+{
+  "internal_contract_id": "d3dfc493-3bc0-4802-815e-7575ff07deb1",
+  "contract_reference": "PRJ_5802",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "norfolk"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "THE_WISE_GROUP_LTD",
+      "ANGLIA_CARE_TRUST",
+      "ST_GILES_TRUST"
+    ]
+  },
+  "internal_intervention_id": "2b38132c-a34b-4653-a8e0-7f7f1e649bd6",
+  "intervention_title": "Women's Services in Norfolk",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5803.json
+++ b/src/main/resources/contracts/PRJ_5803.json
@@ -1,0 +1,231 @@
+{
+  "internal_contract_id": "a7256d64-2cc5-4736-a67a-fd7a80d4de79",
+  "contract_reference": "PRJ_5803",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "north-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "THE_WISE_GROUP_LTD",
+      "FOUNDATION",
+      "IDAS",
+      "ST_GILES_TRUST"
+    ]
+  },
+  "internal_intervention_id": "8edacb61-ba49-413a-a6d0-8315563c2a29",
+  "intervention_title": "Women's Services in North Yorkshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP) - Pre release",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "HMP Askham Grange"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation pre release",
+      "delivery_method": "one-to-one",
+      "delivery_location": "HMP Askham Grange"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE High Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Low Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "North Yorkshire, Scarborough, Harrogate, York"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5806.json
+++ b/src/main/resources/contracts/PRJ_5806.json
@@ -1,0 +1,300 @@
+{
+  "internal_contract_id": "1d5d8993-3a98-4f9b-b552-d33fa43b0ca7",
+  "contract_reference": "PRJ_5806",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "northumbria"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "2d9018bb-df44-4f4f-b9de-d89323a445c5",
+  "intervention_title": "Women's Services in Northumbria",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employability Accredited Award",
+      "delivery_method": "Group basis only, participants must be ready to take on the requirement of an accredited progamme., Participants may benefit from completing the functional skills award in Maths and English first.",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Functional Skills (literacy and numeracy)",
+      "delivery_method": "Group basis only, participants must be ready to take on the requirements of an accredited progamme.",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Springboard Trust - NCFE Award in Mental Health",
+      "delivery_method": "One to one online",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Industry standard qualifications",
+      "delivery_method": "Group basis, with external participants., Provider will put on an internal only course specifically for a cohort of learners if there are enough participants.",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CFO3: Overcoming barriers to ETE",
+      "delivery_method": "One-to-one and Group basis, Only available to those who are unemployed and have right to work in the UK, Can be for the duration of the Order/Licence, Available until November 2022",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "One to one",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Grant Applications",
+      "delivery_method": "One to one or on behalf of the individual, approximately 2 hours session.",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management Course",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead, HMP Low Newton"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Good Tenant Portfolio",
+      "delivery_method": "One to one or Group basis, in person on online",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead, HMP Low Newton"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "Approximately 2 hours duration, One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "Group basis, with any follow-up undertaken One to one",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Matters",
+      "delivery_method": "Group basis, with external participants., Provider will put on an internal only course specifically for a cohort of learners if there are enough participants.",
+      "delivery_location": "South Tyneside only"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Helping Women to Recover (Introduction)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Gambling support",
+      "delivery_method": "Group or One to one basis, ongoing support on needs led basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services - Outreach support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Preparing for Treatment",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnerships and Pathways",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Women in Recovery",
+      "delivery_method": "Weekly, group basis with external participants",
+      "delivery_location": "South Tyneside only"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safeguarding and Safety Planning",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse Outreach Support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Beyond Trauma (Programme)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis, expected to be a minimum of 10 hours intervention",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Law Legal Advice",
+      "delivery_method": "One to one, individual basis",
+      "delivery_location": "South Tyneside only"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Respect",
+      "delivery_method": "Group or One to one basis.",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Keeping Safe Online and Presenting yourself on Social Media",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Future Steps (for Young Adults)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Making Good Programme",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Chrysalis Programme",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Self Belief",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health and Wellbeing",
+      "delivery_method": "Group basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Memory Group",
+      "delivery_method": "Group basis",
+      "delivery_location": "South Tyneside only"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental Health",
+      "delivery_method": "Group basis, can include external participants",
+      "delivery_location": "Gateshead Only"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Gateshead and South Tyneside"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition from Custody to Community",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one basis",
+      "delivery_location": "Ashington,, North Tyneside,, Newcastle,, South Tyneside,, Sunderland,, Gateshead"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5809.json
+++ b/src/main/resources/contracts/PRJ_5809.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "cda97fb8-ebd4-4c2a-a930-6727e38ffea7",
+  "contract_reference": "PRJ_5809",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "nottinghamshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NOTT_WOMENS_CENTRE",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "96a74e8b-3b4a-46b4-89c7-f20534b15a0f",
+  "intervention_title": "Women's Services in Nottinghamshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5813.json
+++ b/src/main/resources/contracts/PRJ_5813.json
@@ -1,0 +1,204 @@
+{
+  "internal_contract_id": "be7c44c2-5e41-44e1-b56d-87b72e1287e4",
+  "contract_reference": "PRJ_5813",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "lincolnshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "LINCS_ACTION_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "33e536e0-cdb2-4385-a5ab-f617e87635f5",
+  "intervention_title": "Women's Services in Lincolnshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Advocacy and advice to access and sustain accommodation",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support to access relevant benefits",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Access to rent deposit and rent advance schemes.",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Independent living skills",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtain support for essential household items.",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Advocacy with existing and potential employers.",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Advice and Guidance about ETE",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employability skills",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Discretionary funding.",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial capability support",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Budgeting skills development",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Access to specialist debt advice:",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Enhance financial literacy skills:",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support to reduce dependency",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support to engage with treatment providers",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Support to manage family relationships",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Support to understand legal proceedings",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Support to manage feelings/situations that trigger offending behaviour",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Development of positive friendships, new social bonds",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement with community activities and social integration",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Support to develop coping strategies",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Skills training to foster confidence and self-belief",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress management",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Access to community mental health support",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mentoring and coaching support",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Support to engage and attend appointments",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Compliance with licence requirements",
+      "delivery_method": "Group work and 1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional support for release",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Building social skills",
+      "delivery_method": "1:1",
+      "delivery_location": "Lincolnshire:, Lincoln, Boston, Grantham"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5815.json
+++ b/src/main/resources/contracts/PRJ_5815.json
@@ -1,0 +1,271 @@
+{
+  "internal_contract_id": "cda7996f-3507-424d-ba90-659499def371",
+  "contract_reference": "PRJ_5815",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+      "GROW",
+      "TOGETHER_WOMEN_PROJECT"
+    ]
+  },
+  "internal_intervention_id": "d39051f2-d1d4-4967-ba31-a394e0bfd328",
+  "intervention_title": "Women's Services in South Yorkshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online (tbc)",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online (tbc)",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "OCN Career Prep",
+      "delivery_method": "Group basis.",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "OCN Employability and Development Skills",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Industry standard qualifications",
+      "delivery_method": "Group basis, with external participants.",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "IAG",
+      "delivery_method": "One-to-one and Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "One to one",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Grant Applications",
+      "delivery_method": "One to one or on behalf of the individual, approximately 2 hours session.",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management Course",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Good Tenant Portfolio",
+      "delivery_method": "One to one or Group basis, in person on online",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "Approximately 2 hours duration, One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "Group basis, with any follow-up undertaken One to one",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Helping Women to Recover (introduction)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Gambling support",
+      "delivery_method": "Group or One to one basis, ongoing support on needs led basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services - Outreach support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Preparing for Treatment",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnerships and Pathways",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safety Planning and Safeguarding",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse Outreach",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Beyond Trauma",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis, expected to be a minimum of 10 hours intervention",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Group basis",
+      "delivery_location": "Sheffield only"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Respect",
+      "delivery_method": "Group or One to one basis.",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Keeping Safe Online and Presenting yourself on Social Media",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Future Steps (for Young Adults)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Making Good Programme",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Chrysalis Programme",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Self Belief",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health and Wellbeing",
+      "delivery_method": "Group basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition from Custody to Community",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one basis",
+      "delivery_location": "Barnsley,, Doncaster,, Rotherham,, Sheffield."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5817.json
+++ b/src/main/resources/contracts/PRJ_5817.json
@@ -1,0 +1,230 @@
+{
+  "internal_contract_id": "cadcf866-fbda-4fe5-87e4-325683943e55",
+  "contract_reference": "PRJ_5817",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "suffolk"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "THE_WISE_GROUP_LTD",
+      "ANGLIA_CARE_TRUST",
+      "ST_GILES_TRUST"
+    ]
+  },
+  "internal_intervention_id": "6a7e673e-9110-45f1-b491-950e10c8fc13",
+  "intervention_title": "Women's Services in Suffolk",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP) - Pre release",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "HMP Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation pre release",
+      "delivery_method": "one-to-one",
+      "delivery_location": "HMP Peterborough"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE High Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Low Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Suffolk,, Ipswich,Lowesoft, Bury Saint Edmunds"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5818.json
+++ b/src/main/resources/contracts/PRJ_5818.json
@@ -1,0 +1,222 @@
+{
+  "internal_contract_id": "f8d9cb6f-70ef-486b-9e72-5b75e44c69e8",
+  "contract_reference": "PRJ_5818",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "surrey"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WOMEN_IN_PRISON",
+    "subcontractor_codes": [
+      "WOMENSSUPPORTCTR_SURREY"
+    ]
+  },
+  "internal_intervention_id": "2d8816ea-2256-4c03-b8b4-b5123355aabe",
+  "intervention_title": "Women's Services in Surrey",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention and management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Finding new/suitable accommodation",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Benefit Assistance",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tailored practical housing support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Applying for education/training opportunities",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job application guidance",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Tailored practical ETE support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse advice and guidance",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse practical support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse emotional support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Substance misuse risk management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "SMART group",
+      "delivery_method": "Group",
+      "delivery_location": "Woking, but available to all women across Surrey"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications and management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health risk management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse advice and guidance, and support.",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse risk management",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic abuse legal remedies",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom Progamme",
+      "delivery_method": "Group",
+      "delivery_location": "Woking, but available to all women across Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Recovery Toolkit",
+      "delivery_method": "Group",
+      "delivery_location": "Woking, but available to all women across Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childcare proceedings supoprt advice and guidance",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Legal support regarding child contact and childcare proceedings",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Emotional support regarding child removal and childcare proceedings",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle support",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Weekly Drop In",
+      "delivery_method": "Group",
+      "delivery_location": "Woking, but available to all women across Surrey"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Art Fridays",
+      "delivery_method": "Group",
+      "delivery_location": "Woking, but available to all women across Surrey"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reducing barriers to social inclusion",
+      "delivery_method": "One to one",
+      "delivery_location": "Surrey"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5819.json
+++ b/src/main/resources/contracts/PRJ_5819.json
@@ -1,0 +1,278 @@
+{
+  "internal_contract_id": "8b34f0f1-96ae-4930-bf3a-b9b26fd8b8a2",
+  "contract_reference": "PRJ_5819",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "sussex"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "BWC",
+    "subcontractor_codes": [
+      "SHELTER",
+      "CHANGE_GROW_LIVE_LTD",
+      "WORKING_CHANCE_LTD"
+    ]
+  },
+  "internal_intervention_id": "5c6e569e-f202-46a8-9a18-8f46633a748d",
+  "intervention_title": "Women's Services in Sussex",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•\tAccommodation \n•\tETE  \n•\tDependency and Recovery  \n•\tFinance, Benefits and Debt  \n•\tEmotional Wellbeing   \n•\tFamily and Significant Others \n•\tLifestyle and Associates \n•\tSocial Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Onward referral for emergencies",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Bespoke gender-specific support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Addressing underlying causes",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Bespoke gender-specific support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Emergency support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Advocacy and referrals",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job application support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Service User Forums",
+      "delivery_method": "Group",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Volunteering opportunities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Nursery, clothes and expenses support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE development workshops",
+      "delivery_method": "Group",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Brighton, Eastbourne, and St Leonards-on-Sea"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Specialst dependancy support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Brighton, Eastbourne, and St Leonards-on-Sea"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Increased awareness and understanding",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt and financial support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial exploitation support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Onward referral for debt support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial relief",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Therapy",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Psychosocial support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "50+ referral routes",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Support for suicidal ideation and self harm",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Emotional support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Gender-based violence informed support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safety planning",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family law support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childcare support",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Brighton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Familial relationship support",
+      "delivery_method": "Group",
+      "delivery_location": "Brighton"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Onward referral for familial support",
+      "delivery_method": "Group",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea and Worthing"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Peer relationship support",
+      "delivery_method": "Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea and Worthing"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Onward referral for continued recovery",
+      "delivery_method": "1-2-1; Group or online when necessary",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Community and belonging",
+      "delivery_method": "Group, Online",
+      "delivery_location": "Brighton"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Pro-social programmes",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social inclusion support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Identifying pro-social goals",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social connection activities",
+      "delivery_method": "Groups, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea and Worthing"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Navigation and transition support",
+      "delivery_method": "1-2-1, Group, Online",
+      "delivery_location": "Brighton, Eastbourne, St Leonards-on-Sea, Worthing and Crawley"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5821.json
+++ b/src/main/resources/contracts/PRJ_5821.json
@@ -1,0 +1,282 @@
+{
+  "internal_contract_id": "c82df197-0915-45dc-966e-91b9f3e68022",
+  "contract_reference": "PRJ_5821",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "warwickshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+      "ACCORD_HOUSING_ASSOC"
+    ]
+  },
+  "internal_intervention_id": "788671c6-b1f1-41bb-a6c5-aaed8356269f",
+  "intervention_title": "Women's Services in Warwickshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nuneaton,, Rugby."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nuneaton,, Rugby."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Breakthrough",
+      "delivery_method": "Group or One to one., Duration depends on the needs of the group/individuals",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Key Skills",
+      "delivery_method": "Group basis or One to one online",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Industry standard qualifications",
+      "delivery_method": "Group basis, with external participants.",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Volunteering",
+      "delivery_method": "Group on One to one basis, full time placements for two weeks",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "IAG",
+      "delivery_method": "One-to-one and Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "One to one",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Grant applications",
+      "delivery_method": "One to one or on behalf of the individual, approximately 2 hours session.",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management Course",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Good Tenant Portfolio",
+      "delivery_method": "One to one or Group basis, in person on online",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "Approximately 2 hours duration, One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "Group basis, with any follow-up undertaken One to one",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "LIFE programme",
+      "delivery_method": "Group or One to one basis, each modular lasts 2 hours",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Helping Women to Recover (introduction)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Gambling support",
+      "delivery_method": "Group or One to one basis, ongoing support on needs led basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services - Outreach support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Preparing for Treatment",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnerships and Pathways",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safety Planning and Safeguarding",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse Outreach",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Beyond Trauma",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis, expected to be a minimum of 10 hours intervention",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Group basis 5 sessions each of 2 hours duration",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Respect",
+      "delivery_method": "Group or One to one basis.",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Keeping Safe Online and Presenting yourself on Social Media",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Future Steps (for Young Adults)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Making Good Programme",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Chrysalis Programme",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Self Belief",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Emotions",
+      "delivery_method": "Group basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition from Custody to Community",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one basis",
+      "delivery_location": "Nuneaton,, Rugby"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5822.json
+++ b/src/main/resources/contracts/PRJ_5822.json
@@ -1,0 +1,162 @@
+{
+  "internal_contract_id": "1f3110de-fc2b-4766-bf7a-e6c34b703e4c",
+  "contract_reference": "PRJ_5822",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "west-mercia"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WILLOWDENE",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "66929e9e-2faf-45bd-969d-af76ed782621",
+  "intervention_title": "Women's Services in West Mercia",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Addressing barriers to accessing or maintaining accommodation",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Applications for accommodation or financial support in relation to accommodation needs.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for accommodation interviews.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Partnership work to address accommodation issues",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Skills development in accommodation related needs.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Addressing barriers to accessing and maintaining employment, education and training",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills training and qualifications",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job readiness and job search support",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Addressing barriers to Finance, Benefit and Debt planning and action.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications and advice",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Development of money management skills.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Access to specialist finance and debt services.",
+      "delivery_method": "",
+      "delivery_location": ""
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Development of self-care skills",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Supported access to partnership services.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationship skills.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Partnership work to address relationship issues.",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery skills",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnership work for recovery",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Partnership work for lifestyle change",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Skills for lifestyle change",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Engagement with partners and community activities.",
+      "delivery_method": "One to one",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations and women's custodial estate."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "One to one",
+      "delivery_location": "Willowdene Women's Centre, Worcester, Redditch, Telford, Shrewsbury, Hereford, mobile locations and women's custodial estate."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5823.json
+++ b/src/main/resources/contracts/PRJ_5823.json
@@ -1,0 +1,296 @@
+{
+  "internal_contract_id": "01f90f16-44a5-4513-8732-12651bad0f2f",
+  "contract_reference": "PRJ_5823",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "west-midlands"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+      "ANAWIM",
+      "BLACK_COUNTRY_WA",
+      "ACCORD_HOUSING_ASSOC"
+    ]
+  },
+  "internal_intervention_id": "f488d55f-9d75-4dcf-9e5c-d3fd4d2d9f0a",
+  "intervention_title": "Women's Services in West Midlands",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Literacy and Numeracy",
+      "delivery_method": "Group, one-to-one, online",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Work Placements",
+      "delivery_method": "Business in the Community Full time for 2 weeks, Women's Iniative flexible",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Industry standard qualifications",
+      "delivery_method": "Group basis, with external participants., Provider will put on an internal only course specifically for a cohort of learners if there are enough participants.",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "IAG",
+      "delivery_method": "One-to-one and Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "One to one",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Grant Applications",
+      "delivery_method": "One to one or on behalf of the individual, approximately 2 hours session.",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management Course",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Good Tenant Portfolio",
+      "delivery_method": "One to one or Group basis, in person online",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "Approximately 2 hours duration, One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "Group basis, with any follow-up undertaken One to one",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Helping Women to Recover (Introduction)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Gambling support",
+      "delivery_method": "Group or One to one basis, ongoing support on needs led basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services - Outreach support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Preparing for Treatment",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnerships and Pathways",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Safety Planning and Safeguarding",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse Outreach",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "Group or One to one basis, 5 sessions of up to 2 hours per session",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Overcoming Trauma",
+      "delivery_method": "Group 12-20 sessions",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis, expected to be a minimum of 10 hours intervention",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Respect",
+      "delivery_method": "Group or One to one basis.",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Keeping Safe Online and Presenting yourself on Social Media",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Future Steps (for Young Adults)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Changes Programme",
+      "delivery_method": "one-to-one and Group basis, 12 weeks",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Making Good Programme",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Chrysalis Programme",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Self Belief",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health and Wellbeing",
+      "delivery_method": "Group basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Emotions",
+      "delivery_method": "group or One to one basis, five sessions of up to two hours duration",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Changes Programme",
+      "delivery_method": "group or One to one basis, 3 sessions",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition from Custody to Community",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one basis",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Side by Side",
+      "delivery_method": "Group, up to 10 sessions",
+      "delivery_location": "Birmingham,, Coventry,, Dudley,, Leamington Spa,, Sandwell,, Walsall,, Wolverhampton."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5824.json
+++ b/src/main/resources/contracts/PRJ_5824.json
@@ -1,0 +1,417 @@
+{
+  "internal_contract_id": "da0bae6a-c9b7-424e-aa3a-1df9adf857e1",
+  "contract_reference": "PRJ_5824",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "west-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "TOGETHER_WOMEN_PROJECT",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "KHIDMAT_CENTRE",
+      "SHELTER",
+      "TOUCHSTONE_LEEDS"
+    ]
+  },
+  "internal_intervention_id": "8c19e4af-8783-4e71-bfe5-21d849c24bb9",
+  "intervention_title": "Women's Services in West Yorkshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation retention advocacy/support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "West Yorkshire Accommodation Scheme",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "My Property course",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for Benefits Processes",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Help to Secure Funding",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Club",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Support and Advocacy",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Pathways into college/training providers",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ESOL Conversation English",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Provision for women with learning difficulties",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "JobCentre Plus",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Work experience provision",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Accredited learning courses",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Specialist ETE support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Stop Theft Activity Requirement (STAR)",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD workshops",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt Advocacy",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Advice & Guidance",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing Money",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Freedom Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Specialist Financial support and Advice",
+      "delivery_method": "",
+      "delivery_location": ""
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Specialist support & advice",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery Group",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Constructive substitute activities",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Stop Theft Activity Requirement (STAR)",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Peer-led SMART recovery group",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief/Extended Brief interventions and wrap-around support",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Targeted Abstinence/Relapse support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Relapse specialist support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Specialist Support",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Specialist Support",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Other Specialist Support",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Focussed resilience support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Post Adoption Support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Child Sexual Exploitation trauma advice",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Counselling",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Specialist legal advice",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Better Solutions (RAR) Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Specialist support & advice",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social activities",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Right Track Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Stop Theft Activity Requirement (STAR)",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Improvement Workshops",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Specialist Agency Referrals",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Peer mentoring",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mentoring and Advocacy Service",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mindfulness Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Anxiety (RAR) programme",
+      "delivery_method": "1 to 1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing My Emotions programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anger Management Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Specialist support & advice",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Trauma-informed counselling",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WELL Women's Empowerment Course (18-25 year olds)",
+      "delivery_method": "Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Trauma support programme referral",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence and Self-esteem sessions",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Community support",
+      "delivery_method": "1-to-1",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ready for the Challenge Programme",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "RAR programmes",
+      "delivery_method": "1-to-1, Group",
+      "delivery_location": "Leeds; Wakefield; Bradford; Huddersfield; Halifax; Dewsbury"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_5825.json
+++ b/src/main/resources/contracts/PRJ_5825.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "1c95fb3a-cf62-422e-b646-5e4ac2a6d99e",
+  "contract_reference": "PRJ_5825",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "wiltshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_NELSON_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "a295d1d5-d35e-42fe-be26-6e1b90325ed0",
+  "intervention_title": "Women's Services in Wiltshire",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1 Delivery.",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1, Group online & Group face-2-face .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation assessment, planning, support and advocacy to implement plans",
+      "delivery_method": "1-2-1 Delivery.",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance assessment, planning, support to implement plans and signposting",
+      "delivery_method": "1-2-1, Group online & Group face-2-face .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education, Training, completion of qualifications & implementation of plans",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment pathway development including volunteering, apprenticeships and job opportunities",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency & recovery accessing external support",
+      "delivery_method": "1-2-1.",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency internal specialist support",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family & Significant others support and advocacy",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Lifestyle & Associates offer",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Wellbeing assessment, planning and implementation",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion assessment, planning and implementation",
+      "delivery_method": "1-2-1, Group online, Group face-2-face, Individual work online .",
+      "delivery_location": "Swindon, Sailsbury, Trowbridge, Chippenham, melksham"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6157.json
+++ b/src/main/resources/contracts/PRJ_6157.json
@@ -1,0 +1,120 @@
+{
+  "internal_contract_id": "0a1119ac-cb45-4614-a0f1-6596afb165be",
+  "contract_reference": "PRJ_6157",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "north-wales"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "NACRO",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "94e3b666-f55b-4c33-a627-5c846e0af196",
+  "intervention_title": "Accommodation Services for North Wales",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.\n· Service User makes progress in obtaining accommodation.\n· Service User is helped to secure social or supported housing.\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation.\n· Service User is prevented from becoming homeless.\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment courses",
+      "delivery_method": "One to one, Group",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Caernarfon group (fortnightly)\t–\tBangor, Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Blaenau group(fortnightly), –\tBangor, Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Dolgellau group (fortnightly)\t–\tBangor, Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Bangor group (fortnightly), –\tBangor Community site, Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Llangefni group (fortnightly )\t––\tLlangefni Community site, Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Holyhead group (Monthly), –\tHolyhead Community site, Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Rhyl group (Monthly), –\tRhyl Community site, Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Flint group (fortnightly), –\tFlint NPS, Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk), Wrexham group (fortnightly), –\tWrexham NPS"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sourcing Accommodation: Support & Advocacy (S&A)",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Sourcing Accommodation: Information and Guidance (IAG)",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Application Assistance: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": ""
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Application Assistance: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Continuation of existing tenancy: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Continuation of existing tenancy: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with housing-related benefits: S&A",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging)",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with housing-related benefits: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Rent deposit: S&A",
+      "delivery_method": "36923",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support with Rent deposit: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support for those with additional needs",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Short-term accommodation: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Financial sustainability: IAG",
+      "delivery_method": "One to one (face-to-face, virtual, telephone, email, messaging), Group sessions.",
+      "delivery_location": "Caernarfon 121 (fortnightly)\t–, Caernarfon Community site (low/medium risk), Caernarfon NPS (high risk), Blaenau 121(fortnightly), –, Blaenau Community site (low/medium risk), Blaenau possibly police station / Bangor, (high risk), Dolgellau 121(fortnightly), –, Dolgellau Community site (low/medium risk), Dolgellau possibly police station / Bangor, (high risk), Bangor 121(Weekly Day TBC)\t–\tBangor Community site (low/medium risk), Bangor NPS/ Approved premises, (high risk), Llangefni 121 (Weekly Day TBC) –, Llangefni Community site (low/medium risk), Llangefni possibly police station Bangor, (high risk), Holyhead 121 (fortnightly )\t–\tHolyhead Community site (low/medium risk), Llangefni possibly police station / Bangor, (high risk), Colwyn Bay 121 (Weekly Day TBC), –\tColwyn Bay Community site / NPS (low/medium risk), Colwyn Bay NPS (high risk), Colwyn Bay, group (fortnightly ) –\tColwyn Bay Community site, Rhyl 121 (fortnightly), –\tRhyl, Community site (low/medium risk), Colwyn Bay NPS (high risk), Flint 121(Weekly Day TBC), –\tFlint NPS (low/medium/ high risk), Wrexham 121 (Weekly Day TBC), –\tWrexham NPS (low/medium/ high risk)"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6158.json
+++ b/src/main/resources/contracts/PRJ_6158.json
@@ -1,0 +1,108 @@
+{
+  "internal_contract_id": "22e19a63-8606-45a7-89ea-0dc34b967c91",
+  "contract_reference": "PRJ_6158",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "dyfed-powys"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "KALEIDOSCOPE"
+    ]
+  },
+  "internal_intervention_id": "6975ff03-8364-4c0e-9de8-7b99007b2bc6",
+  "intervention_title": "Accommodation Services - Dyfed-Powys",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.\n· Service User makes progress in obtaining accommodation.\n· Service User is helped to secure social or supported housing.\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation.\n· Service User is prevented from becoming homeless.\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "",
+      "delivery_location": "Aberystwyth, Newtown, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newtown, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advocacy",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Emergency support",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "Groups",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Aberystwyth, Newton, Brecon, Carmarthen, Haverfordwest, Llandrindor, Llanelli"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6163.json
+++ b/src/main/resources/contracts/PRJ_6163.json
@@ -1,0 +1,108 @@
+{
+  "internal_contract_id": "cb039ae4-6abf-4168-8185-1d0f07dd983b",
+  "contract_reference": "PRJ_6163",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "gwent"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "KALEIDOSCOPE"
+    ]
+  },
+  "internal_intervention_id": "fb3667d2-7a3b-4123-88a2-df20dcedbe3a",
+  "intervention_title": "Accommodation Services - Gwent",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.\n· Service User makes progress in obtaining accommodation.\n· Service User is helped to secure social or supported housing.\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation.\n· Service User is prevented from becoming homeless.\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk, HMP Prescoed"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advocacy",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Emergency support",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "Groups",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Newport, Caerphilly, Ebbw Vale, East Gwent, HMP Usk"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6166.json
+++ b/src/main/resources/contracts/PRJ_6166.json
@@ -1,0 +1,108 @@
+{
+  "internal_contract_id": "6f217dc5-735f-4717-8799-11eb82937a43",
+  "contract_reference": "PRJ_6166",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-wales"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "KALEIDOSCOPE"
+    ]
+  },
+  "internal_intervention_id": "4a57c742-db78-447f-a813-926877381764",
+  "intervention_title": "Accommodation for South Wales",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.\n· Service User makes progress in obtaining accommodation.\n· Service User is helped to secure social or supported housing.\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation.\n· Service User is prevented from becoming homeless.\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advocacy",
+      "delivery_method": "1-2-1. online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support and Advocacy",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Emergency support",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "Groups",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Advice and guidance",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Design and deliver",
+      "delivery_method": "1-2-1, Group and online",
+      "delivery_location": "Cardiff, Swansea,Bridgend, Merthyr, Pontypridd, HMP Cardiff, Swansea, Parc"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6262.json
+++ b/src/main/resources/contracts/PRJ_6262.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "960d69b3-eaa2-42e7-b8f6-f1eee85d3e50",
+  "contract_reference": "PRJ_6262",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "H",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "e4c81676-c001-49d0-9d4e-2936b1a235b1",
+  "intervention_title": "Accommodation Services for South Central",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable. \nA range of approaches need to be used including direct delivery of interventions, support and advocacy, and advice and guidance. \nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes: \n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed. \n\n· Service User makes progress in obtaining accommodation. \n\n· Service User is helped to secure social or supported housing. \n\n· Service User is helped to secure a tenancy in the private rented sector (PRS) \n\n· Service User is helped to sustain existing accommodation. \n\n· Service User is prevented from becoming homeless. \n\n· Service User at risk of losing their tenancy are successfully helped to retain it \n\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months) \n\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accessing Accommodation (low)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy and Eviction Support (low)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Budgeting, Benefits and Arrears (low)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accessing Accommodation (medium)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Budgeting, Benefits and Arrears (medium)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy and Eviction Support (medium)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accessing Accommodation (high)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Specialised Accommodation Need (high)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Liaison (custody)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy on Release (custody)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness and Emergency Support at Release (custody)",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Clinic",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6263.json
+++ b/src/main/resources/contracts/PRJ_6263.json
@@ -1,0 +1,114 @@
+{
+  "internal_contract_id": "07753dfc-166f-4744-b666-e9f6dea458e3",
+  "contract_reference": "PRJ_6263",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_MUNGOS",
+    "subcontractor_codes": [
+      "SHP"
+    ]
+  },
+  "internal_intervention_id": "5ec4e0ef-258e-4156-b3ae-ea6b504aef74",
+  "intervention_title": "Accommodation Services for London",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed\n· Service User makes progress in obtaining accommodation\n· Service User is helped to secure social or supported housing\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation\n· Service User is prevented from becoming homeless\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield, HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield, HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Sustainment advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield, HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "Group",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield, HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield, HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing Sustainment advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Bexleyheath, Lewisham, Orpington, Hackney, Clerkenwell, Tower hamlets, Stratford, Ilford, Leytonstone, Hornchurch, Borough, Stockwell, Shepherds Bush, Hounslow, Richmond, Ealing, Uxbridge, Croydon, Wimbledon, Wandswroth, Willesden, West Hendon, Tottenham, Enfield HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Sustainment advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation planning and implementation of plans",
+      "delivery_method": "1-2-1",
+      "delivery_location": "HMP Belmarsh, HMP Thamside, HMP Pentonville, HMP Isis, HMP Brixton, HMP Wandsworth, HMP Wormwood Scrubs, HMP Feltham"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6267.json
+++ b/src/main/resources/contracts/PRJ_6267.json
@@ -1,0 +1,79 @@
+{
+  "internal_contract_id": "d16c95ef-d571-4370-8f5d-bbf2aef466fd",
+  "contract_reference": "PRJ_6267",
+  "contract_type_id": "ACC",
+  "region": {
+    "nps_region_code": "C",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "SHELTER",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "NACRO"
+    ]
+  },
+  "internal_intervention_id": "bdeae720-f18a-47f5-9a13-8efe92b9eeb0",
+  "intervention_title": "Accommodation Services for Yorkshire and The Humber",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They are also available to be delivered pre-release for those who will be under Probation supervision on release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: direct delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· All barriers as identified in the Service User Action Plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed\n· Service User makes progress in obtaining accommodation\n· Service User is helped to secure social or supported housing\n· Service User is helped to secure a tenancy in the private rented sector (PRS)\n· Service User is helped to sustain existing accommodation\n· Service User is prevented from becoming homeless\n· Service User at risk of losing their tenancy are successfully helped to retain it\n· Service User has Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)\n· Service User has a strong prospect of sustaining Settled Accommodation for at least three months (including for those serving custodial sentences of less than 6 months)",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Being a good tenant programme",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing retention advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Nottingham, Mansfield, Derby, Buxton, Leicester, Loughborough, Boston, Grantham, Lincoln, Skegness"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing accommodation: low intensity",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Harrogate, Northallerton, Skipton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Maintaining accommodation: low intensity",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Harrogate, Northallerton, Skipton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing accommodation: medium intensity",
+      "delivery_method": "1-2-1, Group",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Harrogate, Northallerton, Skipton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Maintaining accommodation: medium intensity",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Harrogate, Northallerton, Skipton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing and maintaining accommodation: High complexity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Harrogate, Northallerton, Skipton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Pre-release activity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Barnsley, Rotherham, Sheffield, Doncaster, Leeds, Wakefield, Huddersfield, Dewsbury, Bradford, Halifax, York, Scarborough, Harrogate, Northallerton, Skipton, Hull, Bridlington, Goole, Beverley, Grimsby, Scunthorpe"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6310.json
+++ b/src/main/resources/contracts/PRJ_6310.json
@@ -1,0 +1,144 @@
+{
+  "internal_contract_id": "09da067e-9f30-44d6-a367-c61fc2a45db2",
+  "contract_reference": "PRJ_6310",
+  "contract_type_id": "ETE",
+  "region": {
+    "nps_region_code": "H",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "LEONARD_CHESHIRE"
+    ]
+  },
+  "internal_intervention_id": "8faec875-1d66-4265-b851-de0c88e8ab0d",
+  "intervention_title": "ETE for South Central",
+  "short_description": "Services are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. They will not be delivered pre-release. Appointments which are part of sentence delivery will be enforceable.\nA range of approaches need to be used including: \ndirect delivery of interventions, support and advocacy, and advice and guidance.\nInterventions need to be tailored to reflect the complexity of a Service User’s needs and should aim to secure one or more of the following outcomes:\n· Service User's obtain suitable training, education and employment.\n· Service User overcomes barriers to obtaining/maintaining suitable training, education and employment.\n· Service User's maintain suitable training, education and employment.\n· Service User's demonstrate improvement in the skills and attitude which enable self-development and increase employability.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Employability Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Disclosure",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Motivation and Confidence",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job Applications",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Interview Skills",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CV Production",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Job, Training and Education Club",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Existing Employer Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE options and their impact on benefits",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment Brokerage",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Support Service Users to secure accreditations required for entry into relevant markets.",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Literacy and Numeracy Skills",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Funding",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Apprenticeships and Placements",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Learning Needs Assessments",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Enhanced physical and learning difficulties / disabilities support.",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Voluntary placements",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Enhanced Sexual, Violence, Fraud/Deception Support",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    },
+    {
+      "need_area": "ETE",
+      "activity": "One Stop Shop",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Gosport, Havant, Basingstoke, Southampton, New Forest/Lymington, Portsmouth, Isle of Wight, Oxford, Bicester, High Wycombe, Milton Keynes (Bletchley), Aylesbury, Slough, Bracknell, Reading, Newbury, Other NPS locations dependant on demand and availability of resource."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6521.json
+++ b/src/main/resources/contracts/PRJ_6521.json
@@ -1,0 +1,242 @@
+{
+  "internal_contract_id": "bf7a7f57-e641-47b7-a83a-10ff0b67393a",
+  "contract_reference": "PRJ_6521",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "dyfed-powys"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 26,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "bc235f7f-8963-4491-af8d-b13e0a713064",
+  "intervention_title": "Personal Wellbeing Services in Dyfed-Powys DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme.",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6527.json
+++ b/src/main/resources/contracts/PRJ_6527.json
@@ -1,0 +1,241 @@
+{
+  "internal_contract_id": "81348c2b-072a-4d99-a5e5-d9a441476d83",
+  "contract_reference": "PRJ_6527",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "gwent"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 26,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "99ea5941-f5bc-4c94-b3a5-0393dc83179c",
+  "intervention_title": "Personal Wellbeing Services in Gwent DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme.",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6528.json
+++ b/src/main/resources/contracts/PRJ_6528.json
@@ -1,0 +1,252 @@
+{
+  "internal_contract_id": "f7b5abdd-acd8-4372-8dde-840d1c73906d",
+  "contract_reference": "PRJ_6528",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "dyfed-powys"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": 25
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST"
+    ]
+  },
+  "internal_intervention_id": "5a565eac-b3fc-4f10-b632-2b7f51a69c4f",
+  "intervention_title": "Personal Wellbeing Services for Young Adults in Dyfed-Powys DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all young adult male Service Users (aged 18-25 years), irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Role Models, Conflict Resolution and Boundaries",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Child and Drugs Exploitation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Aberystwyth, Brecon, Carmarthen, Haverfordwest, Llandrindod, Llanelli, Newtown"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6530.json
+++ b/src/main/resources/contracts/PRJ_6530.json
@@ -1,0 +1,253 @@
+{
+  "internal_contract_id": "84748538-da5c-4eb6-949d-a03319de949c",
+  "contract_reference": "PRJ_6530",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "gwent"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": 25
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "1d57ca79-2d3b-4461-8d4d-aa23896a8388",
+  "intervention_title": "Personal Wellbeing Services for Young Adults in Gwent DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all young adult male Service Users (aged 18-25 years), irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "ReACT Programme",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Victim Awareness",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Restorative Family Group Meetings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "WRAP - Netcare",
+      "delivery_method": "Group",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Negative feelings",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "WRAP - Wellbeing",
+      "delivery_method": "Group, 1-2-1, Virtual (pre-recorder)",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety, Mood, and Coping Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting Skills",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Role Models, Conflict Resolution and Boundaries",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Substance Misuse and Addiction",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Child and Drugs Exploitation",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Values and Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Day 1 of Release",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who am I?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who’s important to me?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the positive and negatives in my life?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Who impacts and inputs to my life?",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Where am I now and where do I want to be?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s my future and how I’m going to get there?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "What’s the consequence?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Wider Impacts?",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to parent effectively",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to handle conflict",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "How to positively participate",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Helping to overcome difficulties and adversities",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Undertaking and Accessing Treatment",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Me",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding My Emotions",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding and Developing Coping Strategies",
+      "delivery_method": "1-2-1, Group Work",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Social Impacts",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Society, it’s impacts and my place",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Services and what I need",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Strengthening and thriving",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Caerphilly, East Gwent, Ebbw Vale, Newport"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6531.json
+++ b/src/main/resources/contracts/PRJ_6531.json
@@ -1,0 +1,133 @@
+{
+  "internal_contract_id": "ce0be839-f8ff-4dc5-8221-72853238736d",
+  "contract_reference": "PRJ_6531",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "warwickshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "PACT_FUTURES_CIC",
+      "CHANGE_GROW_LIVE_LTD"
+    ]
+  },
+  "internal_intervention_id": "a608d2da-c4f9-471b-b70b-d3371ac6aed0",
+  "intervention_title": "Personal Wellbeing Services in Warwickshire DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Managing Me",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Resilience",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Health Trainer Support",
+      "delivery_method": "1-2-1, Online",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Foundations of Wellbeing",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Adult Transitions",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Get a Life not a Knife",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Individual and/or family casework",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Building stronger families",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Being Home",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Dads Reconnected",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Personal Wellbeing Mentor Support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Ingeus Peer Mentor Academy",
+      "delivery_method": "Group",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition and Hope",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Reset",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Departure Lounges",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Arts and Performance",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Positive Interaction",
+      "delivery_method": "Group, 1-2-1",
+      "delivery_location": "Leamington/Warwick, North Warwickshire, Rugby, Stratford on Avon, Nuneaton & Bedworth"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6532.json
+++ b/src/main/resources/contracts/PRJ_6532.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "305470d4-54b4-4521-8203-00bbaf6d45b2",
+  "contract_reference": "PRJ_6532",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cumbria"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_GROWTH_COMPANY_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "c16bc7e1-9f38-4b10-bfe8-73ea3637cd55",
+  "intervention_title": "Personal Wellbeing Services in Cumbria DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6533.json
+++ b/src/main/resources/contracts/PRJ_6533.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "56e7d1cf-f3f7-4315-aa5a-0001c2da97ee",
+  "contract_reference": "PRJ_6533",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "devon-and-cornwall"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "d321b6a2-baf3-48d9-8330-b85770a4c860",
+  "intervention_title": "Personal Wellbeing Services in Devon & Cornwall DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•\timproved pro-social self-identity and ability to access community-based support networks \n•\tsustained engagement in pro-social leisure interests and purposeful activities \n•\treduced engagement with pro-criminal associates and activities \n•\ta decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•\tengaged in their community and able to make a positive contribution. \n•\tpositive family relationships and avoids harmful relationships are developed or maintained.  \n•\tconfident and responsible parenting behaviours are demonstrated (where applicable). \n•\tImproved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•\tpositive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•\tcompliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•\tdevelopment of:  \n\tcoping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n\tlevels of self-efficacy, resilience and confidence \n\tability to access and engage with mental health services. \n\tability to recognise and manage triggers to worsening wellbeing. \n\tability to build and maintain appropriate social interactions. \n•\tcompliance with any medication/treatment/therapy programmes \n•\tsocial networks to reduce initial social isolation are developed or sustained. \n•\tearly post-release engagement with community-based services is secured. \n•\tresilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Plymouth, Dartmoor, Bodmin, Camborne, Truro, St Austell, Poole, Redruth, Liskeard, Bude, Exeter, Torquay, Barnstaple"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6534.json
+++ b/src/main/resources/contracts/PRJ_6534.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "e5e14556-acf8-4315-9885-8e0127ad4297",
+  "contract_reference": "PRJ_6534",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "wiltshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "44da2888-c658-4cf4-a44b-f42e3eb36a03",
+  "intervention_title": "Personal Wellbeing Services in Wiltshire DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n        levels of self-efficacy, resilience and confidence \n        ability to access and engage with mental health services. \n        ability to recognise and manage triggers to worsening wellbeing. \n        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Swindon, Trowbridge/Salisbury"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6535.json
+++ b/src/main/resources/contracts/PRJ_6535.json
@@ -1,0 +1,281 @@
+{
+  "internal_contract_id": "a4889d46-14d7-4a40-9a3c-161899271127",
+  "contract_reference": "PRJ_6535",
+  "contract_type_id": "PWB",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "gloucestershire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+      "WILLOWDENE",
+      "JUDAH_ARMANI",
+      "ALLIANCE_SPORT",
+      "RISE_MUTUAL_CIC",
+      "CIRCLES_UK",
+      "OFFPLOY"
+    ]
+  },
+  "internal_intervention_id": "a8783da4-1834-4698-b4bd-439b417e3ed6",
+  "intervention_title": "Personal Wellbeing Services in Gloucestershire DA",
+  "short_description": "A holistic service which addresses the following rehabilitative needs: Emotional Wellbeing, Family and Significant Others, Lifestyle and Associates and Social Inclusion. \n \nServices are available for all adult male Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision The Social Inclusion ‘mentoring’ service will also be available pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including:\ndirect delivery of interventions, support and advocacy, and advice and guidance. Interventions will be tailored to reflect the complexity of an individual Service User’s needs. \n \nInterventions will be tailored to reflect the complexity of needs and should aim to secure one or more of the following outcomes for Service Users: \n•        improved pro-social self-identity and ability to access community-based support networks \n•        sustained engagement in pro-social leisure interests and purposeful activities \n•        reduced engagement with pro-criminal associates and activities \n•        a decreased reliance on negative peer relationships or networks, such as organised crime groups or extremism groups. \n•        engaged in their community and able to make a positive contribution. \n•        positive family relationships and avoids harmful relationships are developed or maintained.  \n•        confident and responsible parenting behaviours are demonstrated (where applicable). \n•        Improved ability to develop positive intimate relationships including communication, resilience, negotiation and assertiveness skills.  \n•        positive coping strategies in the event of temporary or irretrievable breakdown of familial or other relationships are demonstrated.  \n•        compliance with any voluntary or mandatory family or relationship-focused therapeutic/behavioural change programmes. \n•        development of:  \n-        coping skills and strategies to regulate mood and demonstrate perspective-taking and self-care by avoiding risky situations. \n-        levels of self-efficacy, resilience and confidence \n-        ability to access and engage with mental health services. \n-        ability to recognise and manage triggers to worsening wellbeing. \n-        ability to build and maintain appropriate social interactions. \n•        compliance with any medication/treatment/therapy programmes \n•        social networks to reduce initial social isolation are developed or sustained. \n•        early post-release engagement with community-based services is secured. \n•        resilience and perseverance to cope with challenges and barriers on return to the community is developed",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships Matter",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Behaving to Succeed",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Who are you?",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mastering Your Inner Soundtrack",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Live Like You Mean It",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Build Your Future",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "REASON",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Rehabilitation Offering Another Direction (R.O.A.D)",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Take Care",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Be The Boss Of You",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Uncovering the meaning of your life",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Time Out",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Solve it",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Play To Your Strengths",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Resilience 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Stress 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Happiness 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Motivation 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Optimism 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Personal Impact 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Work-life Balance 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Relationships 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Communication 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Sleep 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Physical Health 101",
+      "delivery_method": "Digital distance learning, Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Decision Making and Consequential Thinking",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Thought Chains",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Impact",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Responsibility",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Problem Solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional Management",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Communication Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Agression vs Assertiveness",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Effective Relationships",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Social Identity and Stereotypes",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Impulsivity",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery, Self-study",
+      "delivery_location": "Gloucester, Cheltenham"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6553.json
+++ b/src/main/resources/contracts/PRJ_6553.json
@@ -1,0 +1,142 @@
+{
+  "internal_contract_id": "5e86290d-1dbd-4568-8f34-45295e7de194",
+  "contract_reference": "PRJ_6553",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "thames-valley"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "PACT",
+      "HIBISCUS_INIT",
+      "WORKING_CHANCE_LTD",
+      "AURORA_NEW_DAWN",
+      "BIRTH_COMPANIONS"
+    ]
+  },
+  "internal_intervention_id": "179e1efc-ad7a-4069-b0ae-96484bc0ea22",
+  "intervention_title": "Women's Services in Thames Valley DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1-2-1; Group where appropriate",
+      "delivery_location": "Reading, Oxfordshire and local hubs across the region including mandated locations"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6554.json
+++ b/src/main/resources/contracts/PRJ_6554.json
@@ -1,0 +1,264 @@
+{
+  "internal_contract_id": "49ec003c-3037-4816-805b-0796c20cd184",
+  "contract_reference": "PRJ_6554",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "staffordshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGING_LIVES",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "61e5fdec-2907-4291-a2c8-dbbc78729040",
+  "intervention_title": "Women's Services in Staffordshire DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Introduction toTraining and Employability Package",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Skills for Employment",
+      "delivery_method": "Group, 1-2-1, Online",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Key Skills (Literacy and Numeracy)",
+      "delivery_method": "Group basis or One to one online",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Industry standard qualifications",
+      "delivery_method": "Group basis, with external participants.",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "CFO3: Overcoming barriers to ETE",
+      "delivery_method": "One-to-one and Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Safeguard Existing ETE",
+      "delivery_method": "One to one",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure accommodation for those homeless/at risk of homelessness/living situation is unsafe/unsuitable",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Support SUs to apply for financial assistance",
+      "delivery_method": "One to one or on behalf of the individual, approximately 2 hours session.",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy Management Course",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Good Tenant Portfolio",
+      "delivery_method": "One to one or Group basis, in person on online",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Welfare Benefits",
+      "delivery_method": "Approximately 2 hours duration, One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing your money",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Advice",
+      "delivery_method": "Group basis, with any follow-up undertaken One to one",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Awarness",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Helping Women to Recover (Introduction)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Gambling support",
+      "delivery_method": "Group or One to one basis, ongoing support on needs led basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Commissioned Services - Outreach support",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Preparing for Treatment",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnerships and Pathways",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse - Safety Planning",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Domestic Abuse Outreach",
+      "delivery_method": "One to one, individual needs basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Relationships",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Beyond Trauma",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Childrens Safeguarding",
+      "delivery_method": "One to one, individual needs basis, expected to be a minimum of 10 hours intervention",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Sex Work and Exploitation",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Positive Parenting",
+      "delivery_method": "Group basis 5 sessions each of 2 hours duration",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Respect",
+      "delivery_method": "Group or One to one basis.",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Keeping Safe Online and Presenting yourself on Social Media",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Future Steps (for Young Adults)",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Making Good Programme",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Neuro-diverse needs",
+      "delivery_method": "One to one",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Chrysalis Programme",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Self Belief",
+      "delivery_method": "Group or One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Emotions",
+      "delivery_method": "Group basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Listening Ear",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Transition from Custody to Community",
+      "delivery_method": "One to one basis",
+      "delivery_location": "Staffordshire"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Mentoring",
+      "delivery_method": "Group and One to one basis",
+      "delivery_location": "Staffordshire"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6555.json
+++ b/src/main/resources/contracts/PRJ_6555.json
@@ -1,0 +1,169 @@
+{
+  "internal_contract_id": "faa061db-fd1f-4b45-9ab6-20c5c74ec1a6",
+  "contract_reference": "PRJ_6555",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "cumbria"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WOMENS_COMM_MATTERS",
+    "subcontractor_codes": [
+      "GATEWAY_4_WOMEN",
+      "WOMEN_OUT_WEST"
+    ]
+  },
+  "internal_intervention_id": "64dd8872-1814-42d3-9bd9-93679b368f6c",
+  "intervention_title": "Women's Services in Cumbria DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:   \nAccommodation  \nETE   \nDependency and Recovery   \nFinance, Benefits and Debt   \nEmotional Wellbeing    \nFamily and Significant Others  \nLifestyle and Associates  \nSocial Inclusion, including mentoring  \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel.  \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable.  \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change. ",
+  "activities": [
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "My Relationships/Saftey and Me",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Butterfly",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "<html><b>Cumbria</b>, Barrow, Kendal </html>"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Women First",
+      "delivery_method": "Group",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "PETALS",
+      "delivery_method": "1 -2 1",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Women First",
+      "delivery_method": "Group",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Volunteering Opportunities",
+      "delivery_method": "Barista Training/Volunteering, Nail Technician and Beauty Courses (in partnership with Local College), Helping in our Company Charity Shop",
+      "delivery_location": "Carlisle"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Building Better Opportunities",
+      "delivery_method": "group and One to one",
+      "delivery_location": "Barrow and Kendal"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Women First",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Beautiful Women (Part 1), (Personal Development course)",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Beautiful Me (Part 2), (Personal Development Course)",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Inner Strength",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Holistic Group",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "My Relationships/Saftey and Me",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Holistic Group",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Women First",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "PETALS",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Women First",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "PETALS",
+      "delivery_method": "1 -2 1",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Women First",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle, Penrith, Barrow, Kendal, Whitehaven"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Kint and Natter",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Barrow"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Cooking Together",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Barrow"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Creative Crafts",
+      "delivery_method": "Group, One to one",
+      "delivery_location": "Carlisle"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6556.json
+++ b/src/main/resources/contracts/PRJ_6556.json
@@ -1,0 +1,230 @@
+{
+  "internal_contract_id": "8f65de88-f8ca-4265-a01d-38291b63b7b0",
+  "contract_reference": "PRJ_6556",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "northamptonshire"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_GRP",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "C2C",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "950b6f78-910a-47b4-ad86-e7203434c68c",
+  "intervention_title": "Women's Services in Northamptonshire DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n•        Dependency and Recovery  \n•        Finance, Benefits and Debt  \n•        Emotional Wellbeing   \n•        Family and Significant Others \n•        Lifestyle and Associates \n•        Social Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP) - Pre release",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "HMP Peterborough"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy Trusted Relationships and Lifestyle Programme (HTRP)",
+      "delivery_method": "Group / 1:2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation pre release",
+      "delivery_method": "one-to-one",
+      "delivery_location": "HMP Peterborough"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Accommodation High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "ETE High Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Low Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "FBD High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Low Intensity",
+      "delivery_method": "1-2-1",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery Medium Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency and Recovery High Intensity",
+      "delivery_method": "one-to-one",
+      "delivery_location": "Northamptonshire, Northampton, Kettering"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6557.json
+++ b/src/main/resources/contracts/PRJ_6557.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "ae8ee42c-b9a4-4cce-8c0d-94d733925330",
+  "contract_reference": "PRJ_6557",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "gwent"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_NELSON_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "64fa326c-5029-4a63-9906-5392f164c6ad",
+  "intervention_title": "Women's Services in Gwent DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•\tAccommodation \n•\tETE  \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation and domestic abuse) to achieving personal change.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6558.json
+++ b/src/main/resources/contracts/PRJ_6558.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "2776cc9d-3e29-468e-a95e-9eef214f4baa",
+  "contract_reference": "PRJ_6558",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "dyfed-powys"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_NELSON_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "3a455c85-5b58-489b-9302-b186ec683d87",
+  "intervention_title": "Women's Services in Dyfed-Powys DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•        Accommodation \n•        ETE  \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation and domestic abuse) to achieving personal change.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6559.json
+++ b/src/main/resources/contracts/PRJ_6559.json
@@ -1,0 +1,120 @@
+{
+  "internal_contract_id": "2811259b-3f0c-40be-b378-f1069adc29c4",
+  "contract_reference": "PRJ_6559",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "north-wales"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "PSS_UK",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "de6a64c7-93ed-45b6-b261-5813e064578c",
+  "intervention_title": "Women's Services in North Wales DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•\tAccommodation \n•\tETE  \n•\tDependency and Recovery  \n•\tFinance, Benefits and Debt  \n•\tEmotional Wellbeing   \n•\tFamily and Significant Others \n•\tLifestyle and Associates \n•\tSocial Inclusion, including mentoring \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation and Social Inclusion ‘mentoring’ service will also be delivered pre-release for those who will be released under Probation supervision (to be consistent with accommodation one).   Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation, domestic abuse, involvement with the sex industry, childhood sexual & physical abuse, controlling coercive relationships; substance dependency and lack of self-esteem) to achieving personal change.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Obtain and maintain suitable tenancy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Pathways to Employment Group",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "drop in",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "peer support group",
+      "delivery_method": "Monthly and remote when needed",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "support and advocacy",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Positive You Portfolio",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Directory of services",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "RISE Programme ( recovery, intervention, support and education)",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support and advocacy for dependency external support",
+      "delivery_method": "1-2-1",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Understanding Your Emotions",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Positive Solutions",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Family Group",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Freedom Programme",
+      "delivery_method": "Group / 1-2-1 / remote (phone)",
+      "delivery_location": "North Wales"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Life Steps",
+      "delivery_method": "Group / 1-2-1",
+      "delivery_location": "North Wales"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_6560.json
+++ b/src/main/resources/contracts/PRJ_6560.json
@@ -1,0 +1,31 @@
+{
+  "internal_contract_id": "b526e949-7eb8-4153-b4e8-7985348235e0",
+  "contract_reference": "PRJ_6560",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-wales"
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_NELSON_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "bea2a22c-a02f-429b-ac4c-8e3849dbd59a",
+  "intervention_title": "Women's Services in South Wales DA",
+  "short_description": "A holistic service for women which secure improved outcomes in relation to the following rehabilitative needs:  \n•\tAccommodation \n•\tETE  \n \nThe Women's Specific Service is intended to ensure that the Interventions are responsive to the specific needs and characteristics of Women Service Users. The service will be delivered in an environment which is safe and suitable for women and by staff who are trained in trauma-informed and trauma-responsive approaches and also in women-only group(s) and/or with the option for woman member of the Supplier Personnel. \n \nServices are available for female Service Users, irrespective of risk level or complexity level, on a Community/ Suspended Sentence Order with a RAR or on Licence/Post-Sentence Supervision. The Accommodation service will also be delivered pre-release for those who will be released under Probation supervision.  Appointments which are part of sentence delivery will be enforceable. \n \nA range of approaches will be used including direct delivery of interventions, support and advocacy, and advice and guidance. Interventions need to be tailored to reflect the complexity of an individual woman’s needs and to recognise and respond to barriers (including child-care commitments, social isolation, religion, language and other cultural barriers, sexual orientation and domestic abuse) to achieving personal change.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7283_E.json
+++ b/src/main/resources/contracts/PRJ_7283_E.json
@@ -1,0 +1,144 @@
+{
+  "internal_contract_id": "1a6d0fd8-4dd1-4eb1-b0f4-7934e717b2b8",
+  "contract_reference": "PRJ_7283_E",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2022-12-02",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "HIBISCUS_INIT",
+      "HOUSING_4_WOMEN",
+      "WORKING_CHANCE_LTD",
+      "CLEAN_BREAK",
+      "SAFE_GROUND",
+      "INSPIRIT_T_D",
+      "BIRTH_COMPANIONS"
+    ]
+  },
+  "internal_intervention_id": "989d1748-c61e-4e66-9fc4-62118e4cd114",
+  "intervention_title": "Women's Specific Services for London (E/NE)",
+  "short_description": "Accommodation Service\tUser has some capacity and means to secure and/or maintain suitable accommodation but requires support and guidance to do so.\nEducation,Training and Employment\tService User has satisfactory basic numeracy & literacy skils. The Service User has previously been employed though there may be gaps with periods of inactivity due to redundancy/periods of imprisonment .There has been no critical development need to find a new job in their previous field of competence.The Service User values benefits of working , but needs guidance to re-enter the workforce,change jobs or career path.\nDependency and Recovery\tService User who is highly motivated & have had sustained period of abstinence . Service User has successfully engaged in a period of treatment but requires support to sustain recovery.\nFinance, Benefit and Debt\tService User is not overly reliant on friends/family or others to supplement daily living expenses or regular outgoings. Service User's circumstances may be currently leading to significant financial pressure but they are able to support themeselves through legitimate means .Including those invoved in the gambling culture through relevant referrals & signposting to appropriate support organisations.\nLifestyle and Associates\tService User lacks confidence to engage in community activities  and/or spend a significant amount of time alone. Service User recognises the value of strong pro-social support groups but is struggling to develop these fully. Service User has got one or more close friends not involved in criminal activity and/or spends limited time each week with non-offending peers or some affiliation to non- offending groups & activities, but does not have a central role . Service User may recognise that some lifestyle choices & associations have affected their behaviour & may trigger re-offending , such as illegal drug use, alcohol, gambling, peer choice, limited medium & long term goals.\nFamily &Significant others\tService User has positive contact with some family or some significant others  & may have positive support of family members .Service User has previously lost contact with family & recently renewed contacts but there remains some difficulties.\nEmotional Wellbeing\tService User has worries or issues & feels unable to cope but is not socially isolated & interacts with others. Service User has no known psychological issues or history of depression & mental health.\nSocial Inclusion\tUp to 4 sessions for low complexity Service Users ( including 1 to be undertaken prior to Srvice User's release which can be virtual contact). A service User is low risk of reoffending .They have limited family support or engagement with community services & there may be barriers to achieving community integration.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Homelessness prevention",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest) and at the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest) and at the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest) and at the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest) and at the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1:1 and Group",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1:1 and Group",
+      "delivery_location": "Community, All Lot 2 boroughs ( Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest)"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1:1 and Group",
+      "delivery_location": "Custody, delivered at these prisons, Downview, Send, Peterborough, East Sutton Park and Bronzefield for women returning to these boroughs Barking, City of London, Dagenham, Enfield, Hackney, Haringey, Havering, Newham, Redbridge, Tower Hamlets and Waltham Forest"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7283_N.json
+++ b/src/main/resources/contracts/PRJ_7283_N.json
@@ -1,0 +1,138 @@
+{
+  "internal_contract_id": "0b3b960c-9131-4c21-8603-ad7d61015ea1",
+  "contract_reference": "PRJ_7283_N",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2022-12-02",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ADVANCE_CHARITY",
+    "subcontractor_codes": [
+      "HIBISCUS_INIT",
+      "HOUSING_4_WOMEN",
+      "WORKING_CHANCE_LTD",
+      "CLEAN_BREAK",
+      "SAFE_GROUND",
+      "INSPIRIT_T_D",
+      "BIRTH_COMPANIONS"
+    ]
+  },
+  "internal_intervention_id": "14f2eefa-5280-4276-bcf5-ebfed8fc558e",
+  "intervention_title": "Women's Specific Services in London (W/NW)",
+  "short_description": "Accommodation Service\tUser has some capacity and means to secure and/or maintain suitable accommodation but requires support and guidance to do so.\nEducation,Training and Employment\tService User has satisfactory basic numeracy & literacy skils. The Service User has previously been employed though there may be gaps with periods of inactivity due to redundancy/periods of imprisonment .There has been no critical development need to find a new job in their previous field of competence.The Service User values benefits of working , but needs guidance to re-enter the workforce,change jobs or career path.\nDependency and Recovery\tService User who is highly motivated & have had sustained period of abstinence . Service User has successfully engaged in a period of treatment but requires support to sustain recovery.\nFinance, Benefit and Debt\tService User is not overly reliant on friends/family or others to supplement daily living expenses or regular outgoings. Service User's circumstances may be currently leading to significant financial pressure but they are able to support themeselves through legitimate means .Including those invoved in the gambling culture through relevant referrals & signposting to appropriate support organisations.\nLifestyle and Associates\tService User lacks confidence to engage in community activities  and/or spend a significant amount of time alone. Service User recognises the value of strong pro-social support groups but is struggling to develop these fully. Service User has got one or more close friends not involved in criminal activity and/or spends limited time each week with non-offending peers or some affiliation to non- offending groups & activities, but does not have a central role . Service User may recognise that some lifestyle choices & associations have affected their behaviour & may trigger re-offending , such as illegal drug use, alcohol, gambling, peer choice, limited medium & long term goals.\nFamily &Significant others\tService User has positive contact with some family or some significant others  & may have positive support of family members .Service User has previously lost contact with family & recently renewed contacts but there remains some difficulties.\nEmotional Wellbeing\tService User has worries or issues & feels unable to cope but is not socially isolated & interacts with others. Service User has no known psychological issues or history of depression & mental health.\nSocial Inclusion\tUp to 4 sessions for low complexity Service Users ( including 1 to be undertaken prior to Srvice User's release which can be virtual contact). A service User is low risk of reoffending .They have limited family support or engagement with community services & there may be barriers to achieving community integration.",
+  "activities": [
+    {
+      "need_area": "Accommodation",
+      "activity": "Overcoming barriers",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster) and within the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Tenancy sustainment",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster) and within the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Securing appropriate accommodation",
+      "delivery_method": "1:1",
+      "delivery_location": "Custody and community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster) and within the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefit applications",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Debt support",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Finance management",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Education",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Training",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Employment",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Dependency support",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Recovery support",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Emotional wellbeing",
+      "delivery_method": "1:1 and Group",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Mental health",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Children & Famillies",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Healthy relationships",
+      "delivery_method": "1:1",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Healthy lifestyle",
+      "delivery_method": "1:1 and Group",
+      "delivery_location": "Community, All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster)"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Social Inclusion",
+      "delivery_method": "1:1 and Group",
+      "delivery_location": "Custody , All Lot 3 boroughs (Brent, Camden, Chelsea, Fulham, Hammersmith, Hounslow, Islington, Kensington, Kingston, Richmond and Westminster) delivered to women within the following prisons Downview, Send, Peterborough, East Sutton Park and Bronzefield."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7283_S.json
+++ b/src/main/resources/contracts/PRJ_7283_S.json
@@ -1,0 +1,204 @@
+{
+  "internal_contract_id": "ecb4c70a-b126-47da-bf9b-af6ff932de81",
+  "contract_reference": "PRJ_7283_S",
+  "contract_type_id": "WOS",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": true,
+    "allows_male": false,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2022-12-02",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "WOMEN_IN_PRISON",
+    "subcontractor_codes": [
+      "PECAN"
+    ]
+  },
+  "internal_intervention_id": "bdabfee5-4aa2-4695-ba08-588e537ea3da",
+  "intervention_title": "Women's Specific Services for London (S/SE)",
+  "short_description": "Accommodation Service\tUser has some capacity and means to secure and/or maintain suitable accommodation but requires support and guidance to do so.\nEducation,Training and Employment\tService User has satisfactory basic numeracy & literacy skils. The Service User has previously been employed though there may be gaps with periods of inactivity due to redundancy/periods of imprisonment .There has been no critical development need to find a new job in their previous field of competence.The Service User values benefits of working , but needs guidance to re-enter the workforce,change jobs or career path.\nDependency and Recovery\tService User who is highly motivated & have had sustained period of abstinence . Service User has successfully engaged in a period of treatment but requires support to sustain recovery.\nFinance, Benefit and Debt\tService User is not overly reliant on friends/family or others to supplement daily living expenses or regular outgoings. Service User's circumstances may be currently leading to significant financial pressure but they are able to support themeselves through legitimate means .Including those invoved in the gambling culture through relevant referrals & signposting to appropriate support organisations.\nLifestyle and Associates\tService User lacks confidence to engage in community activities  and/or spend a significant amount of time alone. Service User recognises the value of strong pro-social support groups but is struggling to develop these fully. Service User has got one or more close friends not involved in criminal activity and/or spends limited time each week with non-offending peers or some affiliation to non- offending groups & activities, but does not have a central role . Service User may recognise that some lifestyle choices & associations have affected their behaviour & may trigger re-offending , such as illegal drug use, alcohol, gambling, peer choice, limited medium & long term goals.\nFamily &Significant others\tService User has positive contact with some family or some significant others  & may have positive support of family members .Service User has previously lost contact with family & recently renewed contacts but there remains some difficulties.\nEmotional Wellbeing\tService User has worries or issues & feels unable to cope but is not socially isolated & interacts with others. Service User has no known psychological issues or history of depression & mental health.\nSocial Inclusion\tUp to 4 sessions for low complexity Service Users ( including 1 to be undertaken prior to Srvice User's release which can be virtual contact). A service User is low risk of reoffending .They have limited family support or engagement with community services & there may be barriers to achieving community integration.",
+  "activities": [
+    {
+      "need_area": "ETE",
+      "activity": "Workshops,one-to-one support and advice providing assessment tools o target the right people. Self-management",
+      "delivery_method": "1:1 support, groupwork, drop ins",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) and remote delivery"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Develop new skills, and self management",
+      "delivery_method": "Drop Ins,one-to-one sessions, referrals and signposts",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) and remote delivery, community one-to-one meetings"
+    },
+    {
+      "need_area": "ETE",
+      "activity": "Work experience and training",
+      "delivery_method": "1:1 support , groupwork",
+      "delivery_location": "One-to-one support in hubs, communities and remote (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth)"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Secure and sustain tenancies",
+      "delivery_method": "1:1 support , groupwork, drop ins",
+      "delivery_location": "In custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park) and community(Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Women only housing in London",
+      "delivery_method": "1:1 support, drop ins and community",
+      "delivery_location": "In custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park) and community(Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Drop In at Bronzefeild",
+      "delivery_method": "1:1, Support,. Drop ins and community",
+      "delivery_location": "In custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park) and community(Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Accommodation",
+      "activity": "Housing referrals and signposts",
+      "delivery_method": "1:1 support , groupwork",
+      "delivery_location": "In custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park) and community(Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Partnership and pathways to address factos relevent to reoffending and promoting desistance",
+      "delivery_method": "1:1 support, groupwork, drop ins",
+      "delivery_location": "In community (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Partnership and pathways to address factos relevent to reoffending and promoting desistance",
+      "delivery_method": "1:1 support",
+      "delivery_location": "In community (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "problem solving, to address factos relevent to reoffending and promoting desistance",
+      "delivery_method": "1:1 support, groupwork, drop ins",
+      "delivery_location": "In community (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "",
+      "delivery_method": "1:1 support,groupwork,drop ins, community support",
+      "delivery_location": "In community (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Internal services , supporting with thinking attitudes abd behaviours",
+      "delivery_method": "1:1 support, groupwork, drop ins",
+      "delivery_location": "In community (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth) via hubs, in the community and remote"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "12-step recovery groups to address factos relevent to reoffending and promoting desistance",
+      "delivery_method": "1:1 support, groupwork, drop ins",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Partnership working and pathways, to address factos relevent to reoffending and promoting desistance",
+      "delivery_method": "1:1 support,groupwork,drop ins",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Well-being and safety",
+      "delivery_method": "1:1 support,groupwork,drop ins",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Well being- attitudes and behaviour",
+      "delivery_method": "1:1 support,groupwork,drop ins",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Parenting courses , better relationship outcomes",
+      "delivery_method": "1:1 support ,groupworks , community support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Family & Significant Others",
+      "activity": "Out of hours support and immediate/emergency support for families",
+      "delivery_method": "1:1 support, drop ins and community",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Advice and guidance around VAWG",
+      "delivery_method": "1:1 support, groupwork, community support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "Partnership and pathways",
+      "delivery_method": "1:1 support, groupwork, community support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Lifestyle & Associates",
+      "activity": "LGBTQIA & Communites safety support , targeting the right people",
+      "delivery_method": "1:1 support, community support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "motivate and enagage, address factors relevent to reoffending and desistance",
+      "delivery_method": "1;1 support, groupwork,comminity support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Partnership & Pathways",
+      "delivery_method": "1:1 support, groupwork,community support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Emotional Wellbeing",
+      "activity": "Counselling support",
+      "delivery_method": "1:1 support,groupwork,drop ins ,community",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Peer, Mentors, support around thinking,attitudes and offending behaviours",
+      "delivery_method": "1:1 support,groupwork,drop ins, community support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "social networks, self-management",
+      "delivery_method": "1;1 support, groupwork,commuinity support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Foreign National, motivate and engage individuals",
+      "delivery_method": "1:1 support,groupwork,community and custody support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support and in custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park)"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Diability Rights, assessment tools to target the right people",
+      "delivery_method": "1:1 support,groupwork,community and custody support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support and in custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park)"
+    },
+    {
+      "need_area": "Social Inclusion",
+      "activity": "Bespoke Training & support around problem solving, self management",
+      "delivery_method": "1:1 support,groupwork,community and custody support",
+      "delivery_location": "Hubs across South London (Bexley, Bromley, Croydon, Greenwich, Lambeth, Lewisham, Merton, Southwark, Sutton and Wandsworth), remote and community support and in custody (Prisons-Bronzefield, Peterborough, Downview, Send, East Sutton Park)"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7639.json
+++ b/src/main/resources/contracts/PRJ_7639.json
@@ -1,0 +1,84 @@
+{
+  "internal_contract_id": "b0640bd2-d4db-4de8-956e-f4051826f5bb",
+  "contract_reference": "PRJ_7639",
+  "contract_type_id": "FBD-EM",
+  "region": {
+    "nps_region_code": "F",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "ACCESS_2_ADVICE"
+    ]
+  },
+  "internal_intervention_id": "31ca688e-39b1-4df1-8096-d073446fe601",
+  "intervention_title": "Finance, Benefit and Debt Services in the East Midlands",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order or released on licence.  Services can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order. Any Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Medium or High complexity.\n\nA range of delivery methods need to be used including:  designing and delivery, support and advocacy and advice, guidance and information.  \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:  \n\nPerson(s) on probation has access to appropriate financial products, advice and/or services. \n\nPathways are established to help person(s) on probation maintain and sustain an income, safely manage money and reduce debt. \n\nPerson(s) on probation financial management skills are developed and/or enhanced, including online banking skills\n\nPerson(s) on probation can successfully navigate the benefits system\n\nPerson(s) on probation gains quick access to universal credit.",
+  "activities": [
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at Banking",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits calculators",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at budgeting",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at debts",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at loans and sanctions",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at financial awareness",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Quantifying debt and type of debt",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at my budget",
+      "delivery_method": "One to one",
+      "delivery_location": "Boston, Buxton, Derby, Grantham, Leicester, Lincoln, Loughborough, Mansfield, Nottingham, Skegness"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7646.json
+++ b/src/main/resources/contracts/PRJ_7646.json
@@ -1,0 +1,150 @@
+{
+  "internal_contract_id": "303582d1-4ec6-44d0-a6ae-39f25776ea60",
+  "contract_reference": "PRJ_7646",
+  "contract_type_id": "FBD-L",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CATCH_22_CHARITY_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "a7dd65bf-76b0-4866-b1c3-4eb6cea762f8",
+  "intervention_title": "Finance, Benefit and Debt Services in London",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order or released on licence or Post Sentence Supervision.  Services can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order. Any Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Low, Medium or High complexity.\n\nA range of delivery methods need to be used including:  designing and delivery, support and advocacy and advice, guidance and information.  \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probation's Action Plan and aim to secure one or more of the following outcomes:  \n\nPerson(s) on probation has access to appropriate financial products, advice and/or services. \n\nPathways are established to help person(s) on probation maintain and sustain an income, safely manage money and reduce debt. \n\nPerson(s) on probation financial management skills are developed and/or enhanced, including online banking skills.  \n\nPerson(s) on probation can successfully navigate the benefits system. \n\nPerson(s) on probation gains quick access to universal credit.",
+  "activities": [
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Essential Digital Skills: Digital Foundation Skills",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Essential Digital Skills: Communicating",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Essential Digital Skills: Handling information and content",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Essential Digital Skills: Transacting",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Essential Digital Skills: Problem solving",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Essential Digital Skills: Being safe and legal online",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Communication 101",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Confidence 101",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Stress 101",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Goal Setting",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Anxiety 101",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Solve it",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Using Money Day-To-Day",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Budgeting basics",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Taking control of your money",
+      "delivery_method": "Digital group learning, Digital one-to-one learning, Face-to-face group delivery, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial support & advocacy",
+      "delivery_method": "Digital one-to-one learning, Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Appealing benefit entitlement decisions",
+      "delivery_method": "Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Discretionary housing payments",
+      "delivery_method": "Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Managing court fines",
+      "delivery_method": "Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Dealing with and managing debt",
+      "delivery_method": "Face-to-face one-to-one delivery",
+      "delivery_location": "Bexley (heath), Borough, Canning Town (Stratford), Clerkenwell, Croydon, Ealing, Enfield, Hackney (Stoke Newington), Hornchurch , Hounslow, Ilford, Kings Cross, Lewisham, Orpington, Richmond, Shepherds Bush, Stockwell, Stratford, Tottenham, Tower Hamlets, Uxbridge, Walthamstow, Wandsworth, West Hendon , Willesden, Wimbledon"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7647.json
+++ b/src/main/resources/contracts/PRJ_7647.json
@@ -1,0 +1,68 @@
+{
+  "internal_contract_id": "308c0396-44b2-4cb6-82bf-f25cb27ababa",
+  "contract_reference": "PRJ_7647",
+  "contract_type_id": "FBD-NE",
+  "region": {
+    "nps_region_code": "A",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_LTD",
+    "subcontractor_codes": [
+      "RETHINK_MI_LTD",
+      "ST_GILES_TRUST",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "5575e6bf-0eac-4da7-be1c-5ec89a9bbc3b",
+  "intervention_title": "Finance,Benefit and Debt in Custody in the North East",
+  "short_description": "Services are available to all adult males  pre-release who are sentenced.   These services can be delivered at any point during the custodial element of the sentence and can be accessed by all people sentenced, regardless of the location they will be released to.  Interventions commenced in custody, but not completed prior to release, may continue in the community until the intervention is completed under the same referral. \n\nAny Sessions delivered as part of  a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices will be offered as  High complexity.\n\nDelivery methods include skills-building, support and advocacy and advice/, guidance/information.  \nInterventions will be tailored to meet the specific needs of the individual to enable them to make progress towards their agreed outcomes, as identified in their  Action Plan and will aim to secure one or more of the following outcomes:  \n\n•\tthe person referred’s financial management skills are developed and/or enhanced, including online banking skills\n•\tthe person referred can successfully navigate the benefits system\n•\tPathways are established to help the person referred to maintain and sustain an income, safely manage money and reduce debt\n•\tthe person referred has access to appropriate financial products, advice and/or services\n•\tthe person referred gains quick access to universal credit, including pre-release referrals\n•\tthe person referred is supported to complete tasks that they would not otherwise be able to do whilst being in custody e.g. support with banking or debt management",
+  "activities": [
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Financial Management",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Durham HMP Holme House HMP Northumberland HMP Deerbolt HMP Kirklevington Grange HMP Frankland"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Benefits",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Durham HMP Holme House HMP Northumberland HMP Deerbolt HMP Kirklevington Grange HMP Frankland"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Money Management",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Durham HMP Holme House HMP Northumberland HMP Deerbolt HMP Kirklevington Grange HMP Frankland"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Access to advice",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Durham HMP Holme House HMP Northumberland HMP Deerbolt HMP Kirklevington Grange HMP Frankland"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Access to benefits",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Durham HMP Holme House HMP Northumberland HMP Deerbolt HMP Kirklevington Grange HMP Frankland"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Custody Support",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Durham HMP Holme House HMP Northumberland HMP Deerbolt HMP Kirklevington Grange HMP Frankland"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7648.json
+++ b/src/main/resources/contracts/PRJ_7648.json
@@ -1,0 +1,69 @@
+{
+  "internal_contract_id": "350f014f-e556-4099-a52a-764cb6093f83",
+  "contract_reference": "PRJ_7648",
+  "contract_type_id": "FBD-NW",
+  "region": {
+    "nps_region_code": "B",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2022-12-05",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_LTD",
+    "subcontractor_codes": [
+      "THE_WISE_GROUP_LTD",
+      "RETHINK_MI_LTD",
+      "IMO_CHARITY",
+      "ROTUNDA"
+    ]
+  },
+  "internal_intervention_id": "b022c6a6-307f-4bf1-a290-91323156ef58",
+  "intervention_title": "Finance Benefit & Debt Services in the North West",
+  "short_description": "Services are available for all adult males on probation either:\n\n-\ton a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n-\tpre-release to people who are sentenced.\n-\treleased on licence and post-sentence supervision.\n\nServices are available to all adult males pre-release who are sentenced.These services can be delivered at any point during the custodial element of the sentence and can be accessed by all people sentenced, regardless of the location they will be released to.  Interventions commenced in custody, but not completed prior to release, may continue in the community until the intervention is completed under the same referral.\n\nServices can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order. Any Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.\nServices are offered as High complexity.\nA range of delivery methods need to be used including designing and delivery, support and advocacy and advice, guidance and information.\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes: \n\n•\tthe person referred’s financial management skills are developed and/or enhanced, including online banking skills\n•\tthe person referred can successfully navigate the benefits system\n•\tPathways are established to help the person referred to maintain and sustain an income, safely manage money and reduce debt\n•\tthe person referred has access to appropriate financial products, advice and/or services\n•\tthe person referred gains quick access to universal credit, including pre-release referrals\n•\tthe person referred is supported to complete tasks that they would not otherwise be able to do whilst being in custody e.g. support with banking or debt management",
+  "activities": [
+    {
+      "need_area": "Financial Management",
+      "activity": "High Complexity",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Preston HMP Altcourse HMP Liverpool HMP Risley (On site) HMP Thorncross (in reach) HMP Haverigg (on site) HMP Lancaster Farms (on site) HMP Kirkham (in-reach) HMP Garth (in reach) HMP Wymott (in reach) West Cheshire - Chester / Northwich East Cheshire - Runcorn / Crewe / Macclesfield Warrington & Halton - Warrington Knowsley & St Helens - St Helens / Huyton / Knowsley / Prescot, Sefton - Bootle Liverpool North - Bootle / Old Swan, Cumbria - Workington / Borrow / Carlise / Penrith / Kendal Wirral - Birkenhead North West Lancashire - Blackpool Blackburn - Blackburn with Darwen East Lancashire - Accrington / Burnley Central Lanashire - Chorley / Preston/ Skelmersdale"
+    },
+    {
+      "need_area": "Benefits",
+      "activity": "High Complexity",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Preston HMP Altcourse HMP Liverpool HMP Risley (On site) HMP Thorncross (in reach) HMP Haverigg (on site) HMP Lancaster Farms (on site) HMP Kirkham (in-reach) HMP Garth (in reach) HMP Wymott (in reach) West Cheshire - Chester / Northwich East Cheshire - Runcorn / Crewe / Macclesfield Warrington & Halton - Warrington Knowsley & St Helens - St Helens / Huyton / Knowsley / Prescot, Sefton - Bootle Liverpool North - Bootle / Old Swan, Cumbria - Workington / Borrow / Carlise / Penrith / Kendal Wirral - Birkenhead North West Lancashire - Blackpool Blackburn - Blackburn with Darwen East Lancashire - Accrington / Burnley Central Lanashire - Chorley / Preston/ Skelmersdale"
+    },
+    {
+      "need_area": "Money Management",
+      "activity": "High Complexity",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Preston HMP Altcourse HMP Liverpool HMP Risley (On site) HMP Thorncross (in reach) HMP Haverigg (on site) HMP Lancaster Farms (on site) HMP Kirkham (in-reach) HMP Garth (in reach) HMP Wymott (in reach) West Cheshire - Chester / Northwich East Cheshire - Runcorn / Crewe / Macclesfield Warrington & Halton - Warrington Knowsley & St Helens - St Helens / Huyton / Knowsley / Prescot, Sefton - Bootle Liverpool North - Bootle / Old Swan, Cumbria - Workington / Borrow / Carlise / Penrith / Kendal Wirral - Birkenhead North West Lancashire - Blackpool Blackburn - Blackburn with Darwen East Lancashire - Accrington / Burnley Central Lanashire - Chorley / Preston/ Skelmersdale"
+    },
+    {
+      "need_area": "Access to advice",
+      "activity": "High Complexity",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Preston HMP Altcourse HMP Liverpool HMP Risley (On site) HMP Thorncross (in reach) HMP Haverigg (on site) HMP Lancaster Farms (on site) HMP Kirkham (in-reach) HMP Garth (in reach) HMP Wymott (in reach) West Cheshire - Chester / Northwich East Cheshire - Runcorn / Crewe / Macclesfield Warrington & Halton - Warrington Knowsley & St Helens - St Helens / Huyton / Knowsley / Prescot, Sefton - Bootle Liverpool North - Bootle / Old Swan, Cumbria - Workington / Borrow / Carlise / Penrith / Kendal Wirral - Birkenhead North West Lancashire - Blackpool Blackburn - Blackburn with Darwen East Lancashire - Accrington / Burnley Central Lanashire - Chorley / Preston/ Skelmersdale"
+    },
+    {
+      "need_area": "Access to benefits",
+      "activity": "High Complexity",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Preston HMP Altcourse HMP Liverpool HMP Risley (On site) HMP Thorncross (in reach) HMP Haverigg (on site) HMP Lancaster Farms (on site) HMP Kirkham (in-reach) HMP Garth (in reach) HMP Wymott (in reach) West Cheshire - Chester / Northwich East Cheshire - Runcorn / Crewe / Macclesfield Warrington & Halton - Warrington Knowsley & St Helens - St Helens / Huyton / Knowsley / Prescot, Sefton - Bootle Liverpool North - Bootle / Old Swan, Cumbria - Workington / Borrow / Carlise / Penrith / Kendal Wirral - Birkenhead North West Lancashire - Blackpool Blackburn - Blackburn with Darwen East Lancashire - Accrington / Burnley Central Lanashire - Chorley / Preston/ Skelmersdale"
+    },
+    {
+      "need_area": "Custody Support",
+      "activity": "High Complexity",
+      "delivery_method": "1:1",
+      "delivery_location": "HMP Preston HMP Altcourse HMP Liverpool HMP Risley (On site) HMP Thorncross (in reach) HMP Haverigg (on site) HMP Lancaster Farms (on site) HMP Kirkham (in-reach) HMP Garth (in reach) HMP Wymott (in reach)"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7649.json
+++ b/src/main/resources/contracts/PRJ_7649.json
@@ -1,0 +1,84 @@
+{
+  "internal_contract_id": "71947388-6d27-4231-9da7-7b9dd1ea9402",
+  "contract_reference": "PRJ_7649",
+  "contract_type_id": "FBD-SC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "hampshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "ACCESS_2_ADVICE"
+    ]
+  },
+  "internal_intervention_id": "100a8dfc-f328-40eb-b750-d37c06c0e7f9",
+  "intervention_title": "Finance, Benefit and Debt Services in Hampshire",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order or released on licence.  Services can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order. Any Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Low, Medium or High complexity.\n\nA range of delivery methods need to be used including:  designing and delivery, support and advocacy and advice, guidance and information.  \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probation's Action Plan and aim to secure one or more of the following outcomes:  \n\nPerson(s) on probation has access to appropriate financial products, advice and/or services. \n\nPathways are established to help person(s) on probation maintain and sustain an income, safely manage money and reduce debt. \n\nPerson(s) on probation financial management skills are developed and/or enhanced. Including online banking. \n\nPerson(s) on probation can successfully navigate the benefits system \n\nPerson(s) on probation gains quick access to universal credit.",
+  "activities": [
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at Banking",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits calculators",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at budgeting",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at my budget",
+      "delivery_method": "One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at debts",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at loans and sanctions",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at financial awareness",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Quantifying debt and type of debt",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7651.json
+++ b/src/main/resources/contracts/PRJ_7651.json
@@ -1,0 +1,84 @@
+{
+  "internal_contract_id": "1ed949f4-ca38-4b2a-abf7-b347761b7bb2",
+  "contract_reference": "PRJ_7651",
+  "contract_type_id": "FBD-SC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "thames-valley"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "c706771a-9561-4022-8a67-515265742362",
+  "intervention_title": "Finance, Benefit and Debt Services in Thames Valley",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order or released on licence.  Services can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order. Any Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Low, Medium or High complexity.\n\nA range of delivery methods need to be used including:  designing and delivery, support and advocacy and advice, guidance and information.  \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:  \n\nPerson(s) on probation has access to appropriate financial products, advice and/or services. \n\nPathways are established to help person(s) on probation maintain and sustain an income, safely manage money and reduce debt. \n\nPerson(s) on probation financial management skills are developed and/or enhanced. \n\nPerson(s) on probation can successfully navigate the benefits system, including online banking skills. \n\nPerson(s) on probation gains quick access to universal credit.",
+  "activities": [
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at Banking",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits calculators",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at budgeting",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at my budget",
+      "delivery_method": "One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at debts",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at loans and sanctions",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at financial awareness",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Quantifying debt and type of debt",
+      "delivery_method": "Group/One to one",
+      "delivery_location": "Andover, Basingstoke, Farnborough/Aldershot, Gosport, Havant, Isle of Wight, Lymington/New Forest, Portsmouth, Southampton, Aylesbury, Bicester, Bracknell, High Wycombe, Milton Keynes/Bletchley, Newbury, Oxford, Reading, Slough"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7659.json
+++ b/src/main/resources/contracts/PRJ_7659.json
@@ -1,0 +1,33 @@
+{
+  "internal_contract_id": "13cf8811-446e-4a81-851d-1196a314b9bf",
+  "contract_reference": "PRJ_7659",
+  "contract_type_id": "FBD-W",
+  "region": {
+    "nps_region_code": "D",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "ST_GILES_WISE_LTD",
+    "subcontractor_codes": [
+      "ST_GILES_TRUST",
+      "ADFERIAD",
+      "THE_WISE_GROUP_LTD"
+    ]
+  },
+  "internal_intervention_id": "5ace18d1-732f-4e64-8d8c-98191248ea2f",
+  "intervention_title": "Finance, Benefit & Debt in Wales",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order or released on licence.  Services can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Low or  High complexity. \n\nA range of delivery methods need to be used including designing and delivery, support and advocacy and advice, guidance and information.  \nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:  \n\n•\tPerson(s) on probation has access to appropriate financial products, advice and/or services. \n•\tPathways are established to help person(s) on probation maintain and sustain an income, safely manage money and reduce debt. \n•\tPerson(s) on probation financial management skills are developed and/or enhanced. Including online banking. \n•\tPerson(s) on probation can successfully navigate the benefits system \n•\tPerson(s) on probation gains quick access to universal credit.",
+  "activities": [
+
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7661.json
+++ b/src/main/resources/contracts/PRJ_7661.json
@@ -1,0 +1,84 @@
+{
+  "internal_contract_id": "82d5715c-6172-4a1e-a349-27dd4476cf81",
+  "contract_reference": "PRJ_7661",
+  "contract_type_id": "FBD-WM",
+  "region": {
+    "nps_region_code": "E",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "BIRMINGHAM_SETTLEMENT"
+    ]
+  },
+  "internal_intervention_id": "101bde0f-dd4a-4a10-8f6e-0d3cee5b1a9e",
+  "intervention_title": "Finance, Benefit Services and Debt in the West Midlands",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order or released on licence.  Services can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order. Any Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Medium or High complexity. \n\nA range of delivery methods need to be used including:  designing and delivery, support and advocacy and advice, guidance and information.  \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:  \n\nPerson(s) on probation has access to appropriate financial products, advice and/or services. \n\nPathways are established to help person(s) on probation maintain and sustain an income, safely manage money and reduce debt. \n\nPerson(s) on probation financial management skills are developed and/or enhanced. Including online banking. \n\nPerson(s) on probation can successfully navigate the benefits system. \n\nPerson(s) on probation gains quick access to universal credit.",
+  "activities": [
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at Banking",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits calculators",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at benefits",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at budgeting",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at my budget",
+      "delivery_method": "One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at debts",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at loans and sanctions",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Looking at financial awareness",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    },
+    {
+      "need_area": "Finance Benefits & Debt",
+      "activity": "Quantifying debt and type of debt",
+      "delivery_method": "group/One to one",
+      "delivery_location": "Birmingham Central, Burton-Upon-Trent, Coventry, Dudley, Hereford, Kidderminster, Kitts Green, Leamington Spa, Nuneaton, Redditch, Shrewsbury, Stafford, Stoke-on-Trent, Telford, Walsall, West Bromwich, Wolverhampton, Worcester"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7662.json
+++ b/src/main/resources/contracts/PRJ_7662.json
@@ -1,0 +1,48 @@
+{
+  "internal_contract_id": "0539cfa4-74ff-4beb-805d-15b0b40129fb",
+  "contract_reference": "PRJ_7662",
+  "contract_type_id": "FBD-Y",
+  "region": {
+    "nps_region_code": "C",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_GROWTH_COMPANY_LTD",
+    "subcontractor_codes": [
+      "STEPCHANGE_DEBT_CHARITY"
+    ]
+  },
+  "internal_intervention_id": "d039c87e-94ab-4c45-9303-7f7a6426786c",
+  "intervention_title": "Finance, Benefit & Debt in Custody in Yorkshire and the Humber",
+  "short_description": "Services are available to all adult males  pre-release who are sentenced. These services can be delivered at any point during the custodial element of the sentence and can be accessed by all people sentenced, regardless of the location they will be released to.  Interventions commenced in custody, but not completed prior to release, may continue in the community until the intervention is completed under the same referral.\n\n Any Sessions delivered as part of a mandated Licence or Post Sentence Supervision appointment will be Enforceable.\n\nServices will be offered as High complexity.\n\nDelivery methods include skills-building, support and advocacy and advice/, guidance/information.\nInterventions will be tailored to meet the specific needs of the individual to enable them to make progress towards their agreed outcomes, as identified in their Action Plan and will aim to secure one or more of the following outcomes:\n\n•\tthe person referred’s financial management skills are developed and/or enhanced, including online banking skills\n•\tthe person referred can successfully navigate the benefits system\n•\tPathways are established to help the person referred to maintain and sustain an income, safely manage money and reduce debt\n•\tthe person referred has access to appropriate financial products, advice and/or services\n•\tthe person referred gains quick access to universal credit, including pre-release referrals\n•\tthe person referred is supported to complete tasks that they would not otherwise be able to do whilst being in custody e.g. support with banking or debt management",
+  "activities": [
+    {
+      "need_area": "Finance, Benefit & Debt",
+      "activity": "Benefits",
+      "delivery_method": "One-to-one",
+      "delivery_location": "Doncaster, Hull, Leeds; Optional: Hatfield, Moorland, Lindholme, Humber, Wealstun"
+    },
+    {
+      "need_area": "Finance, Benefit & Debt",
+      "activity": "ID/Bank Accounts",
+      "delivery_method": "One-to-one",
+      "delivery_location": "Doncaster, Hull, Leeds; Optional: Hatfield, Moorland, Lindholme, Humber, Wealstun"
+    },
+    {
+      "need_area": "Finance, Benefit & Debt",
+      "activity": "Budgeting",
+      "delivery_method": "One-to-one",
+      "delivery_location": "Doncaster, Hull, Leeds; Optional: Hatfield, Moorland, Lindholme, Humber, Wealstun"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7669.json
+++ b/src/main/resources/contracts/PRJ_7669.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "3778cce0-f517-41b9-b958-b48a3b309701",
+  "contract_reference": "PRJ_7669",
+  "contract_type_id": "DNR-K",
+  "region": {
+    "nps_region_code": "K",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGE_GROW_LIVE_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "3f511fa5-a85e-41b9-822d-415819d9f654",
+  "intervention_title": "Dependency and Recovery Services in Kent, Surrey & Sussex",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.  \n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.  \n\nServices are offered as either, Medium or High complexity. \n\nA range of delivery methods need to be used including: skills-building, support and advocacy and advice/, guidance/information.   \nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\nPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency. \n\nPerson on probation has continuity of care from prison into the community where there is no other available resource or commissioned service\n\nPerson on probation has a minimised risk of overdose following release from prison",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention – one-off identification and brief advice support session for low-level alcohol dependency",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Extended Brief Intervention (EBI) – six-session programme for more intensive advice/strategies and support to sustain recovery for PoP with Alcohol Abstinence Monitoring Requirement and/or borderline dependency",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Recovery (FoRecovery) – CGL’s core psychosocial, dependency & recovery suite develops PoP’s recovery capital & resilience, building on identified recovery goals",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Rehabilitation (FoRehab) – flexible modules centred on thinking skills, motivation and behaviour change with a criminal justice and desistance focus (18 sessions)",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Harm Reduction materials – a series of age/substance-specific harm reduction guides and sessions covering psychoactive substances, Chemsex, cannabis, etc.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Life in the 21st Century – a workbook and accompanying session, preparing men for life outside of prison – can be delivered to men pre-release/on recall.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Non-opiates – group sessions and 1:1 interventions that explore stimulants, cannabis, and other ‘novel psychoactive substances’",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "One you drinks tracker",
+      "delivery_method": "Digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinkaware App",
+      "delivery_method": "Digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Happify",
+      "delivery_method": "Digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Insight Timer",
+      "delivery_method": "Digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Lower my Drinking",
+      "delivery_method": "Digital",
+      "delivery_location": "Ashford; Canterbury; Folkestone; Ramsgate; Sittingbourne; Thanet/Margate; Chatham; Gravesend; Maidstone; Tunbridge Wells; Guildford; Redhill; Staines; Brighton; Eastbourne; Hastings; Crawley; Littlehampton; Worthing."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7671.json
+++ b/src/main/resources/contracts/PRJ_7671.json
@@ -1,0 +1,66 @@
+{
+  "internal_contract_id": "0487f430-7008-4383-bffc-631d0ee1c5cd",
+  "contract_reference": "PRJ_7671",
+  "contract_type_id": "DNR-L",
+  "region": {
+    "nps_region_code": "J",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+      "CATCH_22_CHARITY_LTD"
+    ]
+  },
+  "internal_intervention_id": "ddaab32b-4447-4a4a-931b-63c1643d3f9d",
+  "intervention_title": "Dependency and Recovery Services in London",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either Low, Medium or High complexity.\n\nA range of delivery methods need to be used including: skills-building, support and advocacy and advice/, guidance/information.  \nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:  \n\n·\tPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse.\n·\tPerson on probation improves their physical health and mental resilience.\n·\tPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse.\n·\tPerson on probation enhances their belief in ability to manage/ desist from addiction(s).\n·\tPerson on probation increases understanding of addictive behaviours and triggers and options to reduce dependency.\n·\tPerson on probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes\n·\tPerson on probation has continuity of care from prison into the community where there is no other available resource or commissioned service",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support and Advocacy",
+      "delivery_method": "One to one",
+      "delivery_location": "Bexleyheath,   Greenwich, Lewisham , Orpington, London SE1<; Brixton, Croydon, Richmond, Hammersmith and Fullham, Islington, Ealing, Uxbridge, Wimbledon. Wandsworth, Willesden, West Hendon, Stoke Newington, Tower Hamlets, Tothenham, Enflied, Stratford, Ilford, Leytonstone, Hornchurch."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Design and Delivery",
+      "delivery_method": "One to one",
+      "delivery_location": "Bexleyheath,   Greenwich, Lewisham , Orpington, London SE1<; Brixton, Croydon, Richmond, Hammersmith and Fullham, Islington, Ealing, Uxbridge, Wimbledon. Wandsworth, Willesden, West Hendon, Stoke Newington, Tower Hamlets, Tothenham, Enflied, Stratford, Ilford, Leytonstone, Hornchurch."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Design and Delivery",
+      "delivery_method": "group",
+      "delivery_location": "Bexleyheath,   Greenwich, Lewisham , Orpington, London SE1<; Brixton, Croydon, Richmond, Hammersmith and Fullham, Islington, Ealing, Uxbridge, Wimbledon. Wandsworth, Willesden, West Hendon, Stoke Newington, Tower Hamlets, Tothenham, Enflied, Stratford, Ilford, Leytonstone, Hornchurch."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support and Advocacy",
+      "delivery_method": "One to one",
+      "delivery_location": "Bexleyheath,   Greenwich, Lewisham , Orpington, London SE1<; Brixton, Croydon, Richmond, Hammersmith and Fullham, Islington, Ealing, Uxbridge, Wimbledon. Wandsworth, Willesden, West Hendon, Stoke Newington, Tower Hamlets, Tothenham, Enflied, Stratford, Ilford, Leytonstone, Hornchurch."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Design and Delivery",
+      "delivery_method": "One to one and group",
+      "delivery_location": "Bexleyheath,   Greenwich, Lewisham , Orpington, London SE1<; Brixton, Croydon, Richmond, Hammersmith and Fullham, Islington, Ealing, Uxbridge, Wimbledon. Wandsworth, Willesden, West Hendon, Stoke Newington, Tower Hamlets, Tothenham, Enflied, Stratford, Ilford, Leytonstone, Hornchurch."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice Guidance and information",
+      "delivery_method": "One to one",
+      "delivery_location": "Bexleyheath,   Greenwich, Lewisham , Orpington, London SE1<; Brixton, Croydon, Richmond, Hammersmith and Fullham, Islington, Ealing, Uxbridge, Wimbledon. Wandsworth, Willesden, West Hendon, Stoke Newington, Tower Hamlets, Tothenham, Enflied, Stratford, Ilford, Leytonstone, Hornchurch."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7672.json
+++ b/src/main/resources/contracts/PRJ_7672.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "27aa4c15-3951-48af-973e-b0df8954742f",
+  "contract_reference": "PRJ_7672",
+  "contract_type_id": "DNR-NEN",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "northumbria"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "HUMANKIND"
+    ]
+  },
+  "internal_intervention_id": "07a7618d-9135-42b9-b3d8-95a938dfd4fa",
+  "intervention_title": "Dependency and Recovery Services in Northumbria",
+  "short_description": "Services are available for all adult males on probation either on a Community Sentence or Suspended Sentence Order.\nServices can be delivered as part of a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated by the Probation Service for those subject to a Community Sentence or Suspended Sentence Order.\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.\n\nServices are offered as  High complexity.\n\nA range of delivery methods need to be used including:  designing and delivery, support and advocacy and advice, guidance and information.\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:\n\nPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse.\nPerson on probation improves their physical health and mental resilience.\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse.\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s).\nPerson on probation increases understanding of addictive behaviours and triggers and options to reduce dependency.\nPerson on probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Arts Activities",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Sports Activities",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Hope in Recovery",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Guided Recovery Journaling",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Out-of-hours service for crisis-management",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Map of Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Plotting the Course",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Breaking Free Online",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Trigger Rehearsal",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Mutual aid",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Inclusion",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Ingeus Academy",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Health Trainer/Health Champion support",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Understanding cravings",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Managing-Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Me and My Emotions",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Engage with other Probation service providers",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinking and Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drink Coach",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "ABEI",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Pathways to Change",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Diversion",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Geese Theatre: “USED”",
+      "delivery_method": "Group",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "My Choices",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Keeping Me Safe",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Addressing harmful/negative relationships",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Departure Lounges (where available)",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Satnav",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-Engage",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Co-ordinate",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Make Time Count",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Inside Out",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Getting To Know You",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Link-it",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Navigate from the Gate",
+      "delivery_method": "1:1",
+      "delivery_location": "Ashington, Berwick, Gateshead and South Shields, Hexham, Newcastle, North Shields, Sunderland, Wallsend"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7674.json
+++ b/src/main/resources/contracts/PRJ_7674.json
@@ -1,0 +1,78 @@
+{
+  "internal_contract_id": "3274e913-23ca-4379-9ade-ab190c704b08",
+  "contract_reference": "PRJ_7674",
+  "contract_type_id": "DNR-SC",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "hampshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGE_GROW_LIVE_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "21168261-cd36-4629-b6e9-3a618872d4ae",
+  "intervention_title": "Dependency and Recovery Services in Hampshire",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.  \n  \nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.  \n\nServices are offered as either Low, Medium or High complexity. \n\nA range of delivery methods need to be used including: skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\nPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention – one-off identification and brief advice support session for low-level alcohol dependency",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Extended Brief Intervention (EBI) – six-session programme for more intensive advice/strategies and support to sustain recovery for PoP with Alcohol Abstinence Monitoring Requirement and/or borderline dependency",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Recovery (FoRecovery) – CGL’s core psycho social, dependency & recovery suite develops PoP’s recovery capital & resilience, building on identified recovery goals",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Rehabilitation (FoRehab) – flexible modules centred on thinking skills, motivation and behaviour change with a criminal justice and resistance focus",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Harm Reduction materials – a series of age/substance-specific harm reduction guides and sessions covering psychoactive substances, Chemsex, cannabis, etc.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Life in the 21st Century – a workbook and accompanying session, preparing men for life outside of prison – can be delivered to men pre-release/on recall.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Non-opiates – group sessions and 1:1 interventions that explore stimulants, cannabis, and other ‘novel psychoactive substances’",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital suite – recovery-focused apps (e.g. Drinkaware, Happify).",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Portsmouth, Gosport, Havant, Basingstoke, Farnborough/Aldershot, Andover, Southampton, Lymington and New Forest, Isle of Wight"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7680.json
+++ b/src/main/resources/contracts/PRJ_7680.json
@@ -1,0 +1,108 @@
+{
+  "internal_contract_id": "8a91f241-a6e0-4f56-b65b-d6d792a64328",
+  "contract_reference": "PRJ_7680",
+  "contract_type_id": "DNR-WM",
+  "region": {
+    "nps_region_code": "E",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGE_GROW_LIVE_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "49a7ee3f-cab1-4d17-8eed-b35b2aa38bd7",
+  "intervention_title": "Dependency and Recovery Services in West Midlands",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.  \n\nServices are offered as either Low, Medium or High complexity.\n\nA range of delivery methods need to be used including:skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probation's Action Plan and aim to secure one or more of the following outcomes:   \n\nPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Extended Brief Intervention (EBI)",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Recovery (FoRecovery)",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Rehabilitation (FoRehab)",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Harm Reduction Materials",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Life in the 21st Century",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Non Opiates Interventions",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Suite, - Breaking Free Online",
+      "delivery_method": "digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Suite - One You - Drinks Tracker",
+      "delivery_method": "digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Suite - Drinkaware",
+      "delivery_method": "digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Suite- Happify",
+      "delivery_method": "digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Suite - Insight Timer",
+      "delivery_method": "digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Suite - Lower My Drinking",
+      "delivery_method": "digital",
+      "delivery_location": "Birmingham; Dudley; West Bromwich; Wolverhampton; Walsall; Coventry; Leamington Spa; Nuneaton; Stoke on Trent; Burton upon Trent; Stafford; Worcester; Kidderminster; Redditch; Hereford; Shrewsbury; Telford"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7681.json
+++ b/src/main/resources/contracts/PRJ_7681.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "b6525117-d604-4206-b046-6da53d12e461",
+  "contract_reference": "PRJ_7681",
+  "contract_type_id": "DNR-Y",
+  "region": {
+    "nps_region_code": "C",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "HUMANKIND"
+    ]
+  },
+  "internal_intervention_id": "87e84d75-77d9-4b71-98b4-b430297cd526",
+  "intervention_title": "Dependency and Recovery Services in North Yorkshire",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either, Medium or High complexity. \n\nA range of delivery methods need to be used including skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\n Person on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Arts Activities",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Sports Activities",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Hope in Recovery",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Guided Recovery Journaling",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Out-of-hours service for crisis-management",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Map of Me",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Plotting the Course",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Breaking Free Online",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Trigger Rehearsal",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Mutual aid",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Inclusion",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Ingeus Academy",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Health Trainer/Health Champion support",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Understanding cravings",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Managing-Me",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Me and My Emotions",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Engage with other Probation service providers",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinking and Me",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drink Coach",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "ABEI",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Pathways to Change",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Diversion",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Geese Theatre: “USED”",
+      "delivery_method": "Group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "My Choices",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Keeping Me Safe",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Addressing harmful/negative relationships",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Departure Lounges (where available)",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Satnav",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-Engage",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Co-ordinate",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Make Time Count",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Inside Out",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Getting To Know You",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Link-it",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Navigate from the Gate",
+      "delivery_method": "1:1",
+      "delivery_location": "NORTH YORKSHIRE - Harrogate, Northallerton, Scarborough, Skipton, York"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7682.json
+++ b/src/main/resources/contracts/PRJ_7682.json
@@ -1,0 +1,102 @@
+{
+  "internal_contract_id": "cd6a3bf4-d67c-4e4e-b05c-a98f6eadee27",
+  "contract_reference": "PRJ_7682",
+  "contract_type_id": "DNR-SY",
+  "region": {
+    "nps_region_code": null,
+    "pcc_region_code": "south-yorkshire"
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "CHANGE_GROW_LIVE_LTD",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "9f137480-85bf-4152-9a9b-43cd812a3f7b",
+  "intervention_title": "Dependence and Recovery services in South Yorkshire",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.  \n\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.  \n\nServices are offered as either, Medium or High complexity. \n\n A range of delivery methods need to be used including skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\n Person on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention – one-off identification and brief advice support session for low-level alcohol dependency",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Extended Brief Intervention (EBI) – six-session programme for more intensive advice/strategies and support to sustain recovery for PoP with Alcohol Abstinence Monitoring Requirement and/or borderline dependency",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Recovery (FoRecovery) – CGL’s core psychosocial, dependency & recovery suite develops PoP’s recovery capital & resilience, building on identified recovery goals",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Foundations of Rehabilitation (FoRehab) – flexible modules centred on thinking skills, motivation and behaviour change with a criminal justice and desistance focus (18 sessions)",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Harm Reduction materials – a series of age/substance-specific harm reduction guides and sessions covering psychoactive substances, Chemsex, cannabis, etc.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Life in the 21st Century – a workbook and accompanying session, preparing men for life outside of prison – can be delivered to men pre-release/on recall.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Breaking Free Online: an online 24/7 service delivering evidence-based psychosocial intervention strategies (compliant with NICE guidance 115/51) available through mobile Apps (Staying Free) and desktops.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "One You - Drinks Tracker",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinkaware",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Happify is a self-improvement program offered in both website and app form. It measures a user’s emotional well-being - measures it for them, and provides little tasks and games to help you increase it.Happify lets you train yourself for happiness and resilience through life’s challenges",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Insight Timer",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Lower My Drinking is a digital platform that facilitates a preventative approach to alcohol harm on a population-wide scale.",
+      "delivery_method": "1:1/group/digital",
+      "delivery_location": "Barnsley; Rotherham; Sheffield; Doncaster."
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7683.json
+++ b/src/main/resources/contracts/PRJ_7683.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "b8749ab4-af69-41ee-9fb2-1daf91266765",
+  "contract_reference": "PRJ_7683",
+  "contract_type_id": "DNR-Y",
+  "region": {
+    "nps_region_code": "C",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "HUMANKIND"
+    ]
+  },
+  "internal_intervention_id": "393083f3-8810-4a20-ae8a-04a7ff865405",
+  "intervention_title": "Dependency and Recovery Services in West Yorkshire",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as either, Medium or High complexity. \n\nA range of delivery methods need to be used including skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\nPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Arts Activities",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Sports Activities",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Hope in Recovery",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Guided Recovery Journaling",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Out-of-hours service for crisis-management",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Map of Me",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Plotting the Course",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Breaking Free Online",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Trigger Rehearsal",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Mutual aid",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Inclusion",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Ingeus Academy",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Health Trainer/Health Champion support",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Understanding cravings",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Managing-Me",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Me and My Emotions",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Engage with other Probation service providers",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinking and Me",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drink Coach",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "ABEI",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Pathways to Change",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Diversion",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Geese Theatre: “USED”",
+      "delivery_method": "Group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "My Choices",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Keeping Me Safe",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Addressing harmful/negative relationships",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Departure Lounges (where available)",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Satnav",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-Engage",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Co-ordinate",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Make Time Count",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Inside Out",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Getting To Know You",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Link-it",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Navigate from the Gate",
+      "delivery_method": "1:1",
+      "delivery_location": "Wakefield and Halifax"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7709.json
+++ b/src/main/resources/contracts/PRJ_7709.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "af813600-bed0-42ac-91b5-94434fcb58b0",
+  "contract_reference": "PRJ_7709",
+  "contract_type_id": "DNR-NE",
+  "region": {
+    "nps_region_code": "A",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "HUMANKIND"
+    ]
+  },
+  "internal_intervention_id": "74f609f6-5ae0-45f8-8439-42edbd32e108",
+  "intervention_title": "Dependency and Recovery Services in Cleveland",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.  \n\nServices are offered as High complexity.\n\nA range of delivery methods need to be used including: skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\n•\tService User achieves abstinence or controlled/non-dependent or non-problematic substance misuse.\n•\tService User increases their understanding of addictive behaviours and triggers and options to reduce dependency.\n•\tService User on Probation improves their physical health and mental resilience\n•\tService User on Probation enhances their skills to manage risky situations which may pose a trigger or relapse.\n•\tService User on Probation enhances their belief in their ability to manage/ desist from addiction(s).\n•\tService User on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Arts Activities",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Sports Activities",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Hope in Recovery",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Guided Recovery Journaling",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Out-of-hours service for crisis-management",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Map of Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Plotting the Course",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Breaking Free Online",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Trigger Rehearsal",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Mutual aid",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Inclusion",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Ingeus Academy",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Health Trainer/Health Champion support",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Understanding cravings",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Managing-Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Me and My Emotions",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Engage with other Probation service providers",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinking and Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drink Coach",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "ABEI",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Pathways to Change",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Diversion",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Geese Theatre: “USED”",
+      "delivery_method": "Group",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "My Choices",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Keeping Me Safe",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Addressing harmful/negative relationships",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Departure Lounges (where available)",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Satnav",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-Engage",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Co-ordinate",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Make Time Count",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Inside Out",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Getting To Know You",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Link-it",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Navigate from the Gate",
+      "delivery_method": "1:1",
+      "delivery_location": "Hartlepool, Hemlington, Middlesborough, Redcar, Saltburn, Southbank, Stockton"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7710.json
+++ b/src/main/resources/contracts/PRJ_7710.json
@@ -1,0 +1,246 @@
+{
+  "internal_contract_id": "2c15b134-ad58-4887-ad93-22ac58816222",
+  "contract_reference": "PRJ_7710",
+  "contract_type_id": "DNR-NE",
+  "region": {
+    "nps_region_code": "A",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "INGEUS_UK_LIMITED",
+    "subcontractor_codes": [
+      "HUMANKIND"
+    ]
+  },
+  "internal_intervention_id": "65301f01-2e52-474a-a8ec-df94c7e6fced",
+  "intervention_title": "Dependency and Recovery Services in Durham",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable. \n\nServices are offered as High complexity.\n\nA range of delivery methods need to be used including: skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards  their agreed outcomes, as identified in the Person(s) on Probations Action Plan and aim to secure one or more of the following outcomes:   \n\n•\tService User achieves abstinence or controlled/non-dependent or non-problematic substance misuse.\n•\tService User increases their understanding of addictive behaviours and triggers and options to reduce dependency.\n•\tService User on Probation improves their physical health and mental resilience\n•\tService User on Probation enhances their skills to manage risky situations which may pose a trigger or relapse.\n•\tService User on Probation enhances their belief in their ability to manage/ desist from addiction(s).\n•\tService User on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Arts Activities",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Sports Activities",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Hope in Recovery",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Guided Recovery Journaling",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Out-of-hours service for crisis-management",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Map of Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Plotting the Course",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Breaking Free Online",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Trigger Rehearsal",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Mutual aid",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Digital Inclusion",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Ingeus Academy",
+      "delivery_method": "1:1 or group",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Health Trainer/Health Champion support",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Understanding cravings",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Managing-Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Me and My Emotions",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Engage with other Probation service providers",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Alcohol Brief Intervention",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drinking and Me",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Drink Coach",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "ABEI",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Pathways to Change",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Diversion",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Geese Theatre: “USED”",
+      "delivery_method": "Group",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "My Choices",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Keeping Me Safe",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Addressing harmful/negative relationships",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Departure Lounges (where available)",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Satnav",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Re-Engage",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Co-ordinate",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Make Time Count",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Inside Out",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Getting To Know You",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Link-it",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Navigate from the Gate",
+      "delivery_method": "1:1",
+      "delivery_location": "Consett, Darlington, Dawdon, Durham City, Newton Aycliffe, Peterlee, Stanley"
+    }
+  ]
+}

--- a/src/main/resources/contracts/PRJ_7907.json
+++ b/src/main/resources/contracts/PRJ_7907.json
@@ -1,0 +1,150 @@
+{
+  "internal_contract_id": "e1763a0f-9f8a-40ad-9ec9-0e20d048c4a3",
+  "contract_reference": "PRJ_7907",
+  "contract_type_id": "DNR-Y",
+  "region": {
+    "nps_region_code": "C",
+    "pcc_region_code": null
+  },
+  "eligibility": {
+    "allows_female": false,
+    "allows_male": true,
+    "minimum_age": 18,
+    "maximum_age": null
+  },
+  "scheduling": {
+    "hide_before": "2021-01-01",
+    "hide_after": null
+  },
+  "providers": {
+    "prime_provider_code": "THE_FORWARD_TRUST",
+    "subcontractor_codes": [
+
+    ]
+  },
+  "internal_intervention_id": "30a6af4d-bb24-4148-9c55-d4c18298a375",
+  "intervention_title": "Dependency and Recovery Services in Humberside",
+  "short_description": "Services are available for all adult males on probation either:\n\n- on a Community Sentence or Suspended Sentence Order and subject to a Rehabilitation Activity Requirement (RAR) whereby a specified number of RAR Activity Days will be allocated.\n\n- pre-release to people who are convicted.  For most cases a pre-release referral will be beneficial to support the person prior to release, by building and maintaining relationships to maximise engagement once released, develop close working relationships with treatment providers and support post release appointments with local substance misuse teams.\n\n- released on licence and post-sentence supervision.\n\nAny Sessions delivered as part of a RAR Activity Day or as a mandated Licence or Post Sentence Supervision appointment will be Enforceable.  \n\nServices are offered as either, Medium or High complexity. \n\nA range of delivery methods need to be used including skills-building, support and advocacy and advice/, guidance/information.   \n\nInterventions must be tailored to meet the specific needs of each Person(s) on Probation to enable them to make progress towards their agreed outcomes, as identified in the Person(s) on Probation's Action Plan and aim to secure one or more of the following outcomes:   \n\nPerson on probation achieves abstinence or controlled/ non-dependent or non-problematic substance misuse. \n\nPerson on probation enhances their skills to manage risky situations which may pose a trigger or relapse. \n\nPerson on probation enhances their belief in ability to manage/ desist from addiction(s). \n\nPerson on probation improves their physical health and mental resilience. \n\nPerson(s) on Probation establishes Dependency Pathways to manage a range of addictive behaviours, including supporting access into other treatment providers and detox programmes. \n\nPerson(s) on Probation increases their understanding of addictive behaviours and triggers and options to reduce dependency.",
+  "activities": [
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Recovery Connections",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Me Plus",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Lived Experience Network (LEN) activities run by PS/volunteers",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Design and Delivery ; Recovery Skills for Relapse Prevention skills-based programme (five sessions)",
+      "delivery_method": "Delivery method -• 1:1/group • Accompanying workbooks (paper/electronic)",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Design and Delivery ; Stay Strong, Stay Positive skills-based programme (four sessions)",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Care pathway co-ordination:",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice/Guidance & Information; Staying Safe + Well (6 sessions)",
+      "delivery_method": "Delivery method -121 and work book",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Design and Delivery ; Motivational Enhancement Therapy (MET) skills-based sessions (motivational psychology, grounded in research (Prochaska and DiClemente,1994)",
+      "delivery_method": "Delivery method -121 and group work",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice/Guidance & Information;Recovery Tools – selection of sessions",
+      "delivery_method": "Delivery method -121 and group work",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Alternative behavioural therapies",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Pre-release",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Post-release engagement with mutual aid",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; On-release engagement and ongoing support",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice/Guidance & Information; Psycho-education sessions on specific substances (e.g., Cocaine, Cannabis), health and wellbeing risks, relationships, wider community, offending.",
+      "delivery_method": "Delivery method -121 , group",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice/Guidance & Information;Safeguarding against Gangs and County Lines",
+      "delivery_method": "Delivery method -121 , group",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; Support to identify underlying causes (e.g. Adverse Childhood Experiences, ACEs) using compassionate enquiry and referral to intensive ongoing support",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy Signposting to relevant support services for PoP and significant others and facilitating referrals (e.g. Adfam, Mind, IAPT).",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice/Guidance &amp; Information; Brief interventions",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Advice/Guidance &amp; Information; Extended brief interventions",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    },
+    {
+      "need_area": "Dependency & Recovery",
+      "activity": "Support/Advocacy; \"• Signposting to ongoing support (e.g. AA/mutual aid) • Access to One Year No Beer app (motivational app for controlled reduction) • Access to Interventions Hub (Alcohol Awareness e-workbooks) \"",
+      "delivery_method": "Delivery method -121",
+      "delivery_location": "Grimsby , Scunthorpe Hull , Bridlington ,  Goole , Beverley  HMP Hull HMP Humber"
+    }
+  ]
+}

--- a/src/main/resources/desiredoutcomes/contractDetails.json
+++ b/src/main/resources/desiredoutcomes/contractDetails.json
@@ -1,0 +1,31 @@
+[
+  {
+    "contract_type": "Accommodation",
+    "contract_code": "ACC",
+    "service_category": "Accommodation",
+    "desired_outcomes": [
+      "All barriers as identified in the Service user action plan, for example financial, behavioural, physical, mental or offence-type related), to obtaining or sustaining accommodation, are successfully removed.",
+      "Service user makes progress in obtaining accommodation.",
+      "Service user is helped to secure social or supported housing.",
+      "Service user is helped to secure a tenancy in the private rented sector (PRS).",
+      "Service user is helped to sustain existing accommodation.",
+      "Service user is prevented from becoming homeless.",
+      "Service user at risk of losing their tenancy are successfully helped to retain it.",
+      "Intervention ends before the Service user has sustained accommodation for three months, but s/he has a strong prospect of sustaining it for at least three months (including for those serving custodial sentences of less than 6 months)."
+    ],
+    "complexity_levels": [
+      {
+        "severity": "LOW",
+        "description": "Service user has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so."
+      },
+      {
+        "severity": "MEDIUM",
+        "description": "Service user is at risk of homelessness/is homeless, or will be on release from prison. Service user has had some success in maintaining a tenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently."
+      },
+      {
+        "severity":"HIGH",
+        "description": "Service user is homeless or in temporary/unstable accommodation, or will be on release from prison. Service user has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy."
+      }
+    ]
+  }
+]

--- a/src/main/resources/providers/providers.json
+++ b/src/main/resources/providers/providers.json
@@ -1,0 +1,482 @@
+[
+  {
+    "code": "A_WAY_OUT",
+    "name": "A Way Out"
+  },
+  {
+    "code": "ACCESS_2_ADVICE",
+    "name": "Access 2 Advice"
+  },
+  {
+    "code": "ACCORD_HOUSING_ASSOC",
+    "name": "Accord Housing Association"
+  },
+  {
+    "code": "ACHIEVE_NW",
+    "name": "Achieve NW (Career Connect)"
+  },
+  {
+    "code": "ACORN",
+    "name": "Acorn"
+  },
+  {
+    "code": "ADFERIAD",
+    "name": "Adferiad Recovery Limited"
+  },
+  {
+    "code": "ADVANCE_CHARITY",
+    "name": "Advance Charity"
+  },
+  {
+    "code": "AIR_SPORTS_NETWORK_LTD",
+    "name": "AIR Sports Network Ltd"
+  },
+  {
+    "code": "ALLIANCE_SPORT",
+    "name": "Alliance of Sport"
+  },
+  {
+    "code": "ANAWIM",
+    "name": "Anawim"
+  },
+  {
+    "code": "ANGLIA_CARE_TRUST",
+    "name": "Anglia Care Trust (ACT)"
+  },
+  {
+    "code": "AURORA_NEW_DAWN",
+    "name": "Aurora New Dawn"
+  },
+  {
+    "code": "BEDFORD_WOMENS_CENTRE",
+    "name": "Bedford Women's Centre"
+  },
+  {
+    "code": "BIRMINGHAM_SETTLEMENT",
+    "name": "Birmingham Settlement"
+  },
+  {
+    "code": "BIRTH_COMPANIONS",
+    "name": "Birth Companions"
+  },
+  {
+    "code": "BLACK_COUNTRY_WA",
+    "name": "Black Country Women's Aid"
+  },
+  {
+    "code": "BWC",
+    "name": "BWC (Brighton Women's Centre)"
+  },
+  {
+    "code": "C2C",
+    "name": "C2C"
+  },
+  {
+    "code": "CAIS_LTD",
+    "name": "CAIS Ltd"
+  },
+  {
+    "code": "CAMBS_WMNS_RESOURCE_CTR",
+    "name": "Cambridge Women's Resource Centre"
+  },
+  {
+    "code": "CATCH_22_CHARITY_LTD",
+    "name": "Catch22 Charity Limited"
+  },
+  {
+    "code": "CHANGE_GROW_LIVE_LTD",
+    "name": "Change Grow Live (CGL) Services Ltd"
+  },
+  {
+    "code": "CHANGING_LIVES",
+    "name": "Changing Lives"
+  },
+  {
+    "code": "CHOICES",
+    "name": "Choices"
+  },
+  {
+    "code": "CIRCLES_UK",
+    "name": "Circles UK"
+  },
+  {
+    "code": "CLEAN_BREAK",
+    "name": "Clean Break"
+  },
+  {
+    "code": "COMMUNITY_LED_INIT",
+    "name": "Community Led Initiatives"
+  },
+  {
+    "code": "DVIP_RICHMOND",
+    "name": "DVIP (Richmond Fellowship)"
+  },
+  {
+    "code": "EVOLVE_EAST_ANGLIA",
+    "name": "Evolve East Anglia"
+  },
+  {
+    "code": "FOUNDATION",
+    "name": "Foundation"
+  },
+  {
+    "code": "GANGSLINE",
+    "name": "Gangsline"
+  },
+  {
+    "code": "GATEWAY_4_WOMEN",
+    "name": "Gateway 4 Women"
+  },
+  {
+    "code": "GM_MH_NHS_FT",
+    "name": "Greater Manchester Mental Health NHS Foundation Trust - Achieve Recovery Services"
+  },
+  {
+    "code": "GM_WOM_SUP_AL",
+    "name": "Greater Manchester Women's Support Alliance"
+  },
+  {
+    "code": "GROUNDWORK_EAST",
+    "name": "Groundwork East"
+  },
+  {
+    "code": "GROW",
+    "name": "Grow"
+  },
+  {
+    "code": "HIBISCUS_INIT",
+    "name": "Hibiscus Initiatives"
+  },
+  {
+    "code": "HOUSING_4_WOMEN",
+    "name": "Housing 4 Women"
+  },
+  {
+    "code": "HUMANKIND",
+    "name": "HumanKind"
+  },
+  {
+    "code": "IMO_CHARITY",
+    "name": "IMO Charity"
+  },
+  {
+    "code": "INCLUSION",
+    "name": "Inclusion"
+  },
+  {
+    "code": "IDAS",
+    "name": "Independent Domestic Abuse Service (IDAS)"
+  },
+  {
+    "code": "INGEUS_UK_LIMITED",
+    "name": "Ingeus UK Limited"
+  },
+  {
+    "code": "INSPIRE_CUMBRIA_LTD",
+    "name": "Inspira Cumbria Ltd"
+  },
+  {
+    "code": "INSPIRIT_T_D",
+    "name": "Inspirit Training and Development Ltd"
+  },
+  {
+    "code": "JIGSAW_SUPPORT",
+    "name": "Jigsaw Support"
+  },
+  {
+    "code": "JUDAH_ARMANI",
+    "name": "Judah Armani Public Service Design Practice"
+  },
+  {
+    "code": "KALEIDOSCOPE",
+    "name": "Kaleidoscope"
+  },
+  {
+    "code": "KAREN_MACKEY",
+    "name": "Karen Mackey Consultants"
+  },
+  {
+    "code": "KSS_CRC",
+    "name": "Kent, Surrey and Sussex CRC"
+  },
+  {
+    "code": "KHIDMAT_CENTRE",
+    "name": "Khidmat Centre"
+  },
+  {
+    "code": "LANCASHIRE_WOMEN",
+    "name": "Lancashire Women"
+  },
+  {
+    "code": "LEONARD_CHESHIRE",
+    "name": "Leonard Cheshire Disability"
+  },
+  {
+    "code": "LINCS_ACTION_TRUST",
+    "name": "Lincolnshire Action Trust"
+  },
+  {
+    "code": "MAGISTRA",
+    "name": "Magistra"
+  },
+  {
+    "code": "MANCHESTER_ATHENA",
+    "name": "Manchester Athena"
+  },
+  {
+    "code": "MAXIMUS_UK",
+    "name": "MAXIMUS UK Services Limited"
+  },
+  {
+    "code": "NACRO",
+    "name": "Nacro"
+  },
+  {
+    "code": "NEPACS",
+    "name": "Nepacs"
+  },
+  {
+    "code": "NEWDAWN_NEWDAY",
+    "name": "New Dawn New Day"
+  },
+  {
+    "code": "NOTT_WOMENS_CENTRE",
+    "name": "Nottingham Women's Centre"
+  },
+  {
+    "code": "OFFPLOY",
+    "name": "Offploy CIC"
+  },
+  {
+    "code": "ONE_SMALL_THING",
+    "name": "One Small Thing"
+  },
+  {
+    "code": "ORMISTON_FAMILIES",
+    "name": "Ormiston Families"
+  },
+  {
+    "code": "PACT",
+    "name": "PACT"
+  },
+  {
+    "code": "PACT_FUTURES_CIC",
+    "name": "PACT Futures Community Interest Company"
+  },
+  {
+    "code": "POPS",
+    "name": "Partners of Prisoners and Families Support Group (POPS)"
+  },
+  {
+    "code": "PECAN",
+    "name": "Pecan"
+  },
+  {
+    "code": "PENNINE_CARE_NHS_FT",
+    "name": "Pennine Care NHS Foundation Trust - Pathfinder Stockport"
+  },
+  {
+    "code": "PETRUS_COMMUNITY",
+    "name": "Petrus Community"
+  },
+  {
+    "code": "PRISON_ADVICE_CARE_TRST",
+    "name": "Prison Advice and Care Trust (Pact)"
+  },
+  {
+    "code": "PSS_UK",
+    "name": "PSS UK"
+  },
+  {
+    "code": "REFORM_RESTORE_RESPECT",
+    "name": "Reform,Restore,Respect"
+  },
+  {
+    "code": "RESTORATIVE_WALES",
+    "name": "Restorative Wales"
+  },
+  {
+    "code": "RETHINK_MI_LTD",
+    "name": "Rethink Mental Illness Ltd"
+  },
+  {
+    "code": "RFEA",
+    "name": "RFEA"
+  },
+  {
+    "code": "RISE_MUTUAL_CIC",
+    "name": "RISE Mutual CIC"
+  },
+  {
+    "code": "RISING_SUN_DVA",
+    "name": "Rising Sun Domestic Violence and Abuse Service"
+  },
+  {
+    "code": "ROAR_TURNING_POINT",
+    "name": "ROAR Turning Point"
+  },
+  {
+    "code": "ROTUNDA",
+    "name": "Rotunda"
+  },
+  {
+    "code": "SAFE_GROUND",
+    "name": "Safe Ground"
+  },
+  {
+    "code": "SAFER_PLACES",
+    "name": "Safer Places"
+  },
+  {
+    "code": "SALFORD_FOUNDATION",
+    "name": "Salford Foundation Limited"
+  },
+  {
+    "code": "SEETEC_BUS_TECH_CTR_LTD",
+    "name": "Seetec Business Technology Centre Limited"
+  },
+  {
+    "code": "SHELTER",
+    "name": "Shelter"
+  },
+  {
+    "code": "SHP",
+    "name": "SHP"
+  },
+  {
+    "code": "SPARK_INSIDE",
+    "name": "Spark Inside"
+  },
+  {
+    "code": "ST_GILES_TRUST",
+    "name": "St Giles Trust"
+  },
+  {
+    "code": "ST_GILES_WISE_GRP",
+    "name": "St Giles Wise Group Partnership"
+  },
+  {
+    "code": "ST_GILES_WISE_LTD",
+    "name": "St Giles Wise Ltd"
+  },
+  {
+    "code": "ST_MUNGOS",
+    "name": "St Mungos"
+  },
+  {
+    "code": "STEPCHANGE_DEBT_CHARITY",
+    "name": "StepChange Debt Charity"
+  },
+  {
+    "code": "STEPPINGSTONES_LUTON",
+    "name": "Stepping Stones (Luton)"
+  },
+  {
+    "code": "STOCKPORT_WOMENS_CENTRE",
+    "name": "Stockport Women's Centre"
+  },
+  {
+    "code": "SUSSEX_PATHWAYS",
+    "name": "Sussex Pathways"
+  },
+  {
+    "code": "THAMES_VALLEY_PART",
+    "name": "Thames Valley Partnership"
+  },
+  {
+    "code": "THE_BRIDGE_EM",
+    "name": "The Bridge (East Midlands)"
+  },
+  {
+    "code": "THE_FORWARD_TRUST",
+    "name": "The Forward Trust"
+  },
+  {
+    "code": "THE_GROWTH_COMPANY_LTD",
+    "name": "The Growth Company Ltd"
+  },
+  {
+    "code": "THE_NELSON_TRUST",
+    "name": "The Nelson Trust"
+  },
+  {
+    "code": "PLUSS_ORG_CIC",
+    "name": "The Pluss Organisation CIC"
+  },
+  {
+    "code": "THE_WISE_GROUP_LTD",
+    "name": "The Wise Group Limited"
+  },
+  {
+    "code": "WOMENS_CTR_CORNWALL",
+    "name": "The Women’s Centre Cornwall (TWCC)"
+  },
+  {
+    "code": "THIRTEEN_HOUSING_GROUP",
+    "name": "Thirteen Housing Group"
+  },
+  {
+    "code": "TOGETHER_WOMEN_PROJECT",
+    "name": "Together Women Project"
+  },
+  {
+    "code": "TOMORROWS_WOMEN_WIRRAL",
+    "name": "Tomorrow's Women Wirral"
+  },
+  {
+    "code": "TOUCHSTONE_LEEDS",
+    "name": "Touchstone - Leeds"
+  },
+  {
+    "code": "UP_BEAT_LIFE",
+    "name": "Up Beat Life"
+  },
+  {
+    "code": "URBAN_OUTREACH",
+    "name": "Urban Outreach Bolton"
+  },
+  {
+    "code": "WILLOWDENE",
+    "name": "Willowdene Rehabilitation and Training"
+  },
+  {
+    "code": "WITH_YOU_WIGAN_LEIGH",
+    "name": "With You - Wigan and Leigh"
+  },
+  {
+    "code": "WOMEN_FOR_WELL_WOMEN",
+    "name": "Women for Well Women"
+  },
+  {
+    "code": "WOMEN_IN_PRISON",
+    "name": "Women in Prison"
+  },
+  {
+    "code": "WOMEN_OF_WORTH",
+    "name": "Women of Worth"
+  },
+  {
+    "code": "WOMEN_OUT_WEST",
+    "name": "Women Out West"
+  },
+  {
+    "code": "WOMENS_COMM_MATTERS",
+    "name": "Women's Community Matters"
+  },
+  {
+    "code": "WOMENSSUPPORTCTR_SURREY",
+    "name": "Women's Support Centre Surrey"
+  },
+  {
+    "code": "WOMENS_WORK_DERBS_LTD",
+    "name": "Women's Work (Derbyshire) Ltd"
+  },
+  {
+    "code": "WORKING_CHANCE_LTD",
+    "name": "Working Chance Ltd"
+  },
+  {
+    "code": "YSS",
+    "name": "YSS"
+  }
+]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -518,7 +518,7 @@ class SetupAssistant(
     val primeProvider = serviceProviderRepository.save(serviceProviderFactory.create(id = primeProviderId, name = primeProviderId))
     val serviceProviders = subContractorServiceProviderIds.map {
       serviceProviderRepository.save(serviceProviderFactory.create(id = it, name = it))
-    }.toSet()
+    }.toMutableSet()
 
     val contract = dynamicFrameworkContractFactory.create(
       id = id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DynamicFrameworkContractRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DynamicFrameworkContractRepositoryTest.kt
@@ -45,7 +45,7 @@ class DynamicFrameworkContractRepositoryTest @Autowired constructor(
   @Test
   fun `can store and retrieve a contract with a subcontractor`() {
     val serviceProvider = serviceProviderFactory.create()
-    val contract = dynamicFrameworkContractFactory.create(subcontractorProviders = setOf(serviceProvider))
+    val contract = dynamicFrameworkContractFactory.create(subcontractorProviders = mutableSetOf(serviceProvider))
 
     val savedContract = dynamicFrameworkContractRepository.findById(contract.id).get()
     assertThat(savedContract.id).isEqualTo(contract.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepositoryTest.kt
@@ -399,7 +399,7 @@ class ReferralRepositoryTest @Autowired constructor(
         contractReference = random(10),
       )
       else -> dynamicFrameworkContractFactory.create(
-        subcontractorProviders = setOf(serviceProvider),
+        subcontractorProviders = mutableSetOf(serviceProvider),
         contractReference = random(10),
       )
     }
@@ -461,7 +461,7 @@ class ReferralRepositoryTest @Autowired constructor(
     val serviceProvider = serviceProviderFactory.create(random(13), random(14))
     val contract = when {
       asPrime -> dynamicFrameworkContractFactory.create(primeProvider = serviceProvider, contractReference = random(10))
-      else -> dynamicFrameworkContractFactory.create(subcontractorProviders = setOf(serviceProvider), contractReference = random(10))
+      else -> dynamicFrameworkContractFactory.create(subcontractorProviders = mutableSetOf(serviceProvider), contractReference = random(10))
     }
     val intervention = interventionFactory.create(contract = contract)
     val referral = referralFactory.createDraft(intervention = intervention)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -381,9 +381,9 @@ class ReferralServiceTest @Autowired constructor(
     fun `user with multiple providers can see referrals where the providers are subcontractors`() {
       val userProviders = listOf("test_org_1", "test_org_2", "test_org_3", "test_org_4", "test_org_5").map { id -> serviceProviderFactory.create(id = id, name = id) }
       val contractWithUserProviderAsPrime = contractFactory.create(primeProvider = userProviders[0])
-      val contractWithUserProviderAsSub1 = contractFactory.create(subcontractorProviders = setOf(userProviders[1]))
-      val contractWithUserProviderAsSub2 = contractFactory.create(subcontractorProviders = setOf(userProviders[2]))
-      val contractWithUserProviderAsBothPrimeAndSub = contractFactory.create(primeProvider = userProviders[3], subcontractorProviders = setOf(userProviders[4]))
+      val contractWithUserProviderAsSub1 = contractFactory.create(subcontractorProviders = mutableSetOf(userProviders[1]))
+      val contractWithUserProviderAsSub2 = contractFactory.create(subcontractorProviders = mutableSetOf(userProviders[2]))
+      val contractWithUserProviderAsBothPrimeAndSub = contractFactory.create(primeProvider = userProviders[3], subcontractorProviders = mutableSetOf(userProviders[4]))
       val contractWithNoUserProviders = contractFactory.create()
 
       val primeRef = referralFactory.createSent(intervention = interventionFactory.create(contract = contractWithUserProviderAsPrime))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/DynamicFrameworkContractFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/DynamicFrameworkContractFactory.kt
@@ -28,7 +28,7 @@ class DynamicFrameworkContractFactory(em: TestEntityManager? = null) : EntityFac
     npsRegion: NPSRegion? = null,
     pccRegion: PCCRegion? = null,
     contractReference: String = RandomStringUtils.randomAlphanumeric(8),
-    subcontractorProviders: Set<ServiceProvider> = setOf(),
+    subcontractorProviders: MutableSet<ServiceProvider> = mutableSetOf(),
     referralStartDate: LocalDate = LocalDate.of(2021, 6, 1),
     referralEndAt: OffsetDateTime? = null,
   ): DynamicFrameworkContract {


### PR DESCRIPTION
## What does this pull request do?

- creates a job to onboard the new contract
- The job reads the jsons present in folders `resources/contracts, resources/desiredoutcomes, resources/providers`
- feeds those jsons to the `upsertContractsJob` 

## What is the intent behind these changes?

- This was done to adapt the existing onboarding solution to kotlin. 
- The intent was to avoid the onboarding in two different places with two different solutions. 
