### PR TITLE
Resolve owasp dependency check failures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.5-beta-3"
   kotlin("plugin.spring") version "1.8.10"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.8.10"
   id("jacoco")
@@ -70,7 +70,7 @@ tasks {
 
 dependencyManagement {
   dependencies {
-    dependency("net.minidev:json-smart:2.4.9")
+    dependency("net.minidev:json-smart:2.4.10")
   }
 }
 


### PR DESCRIPTION
## What does this pull request do?

Updates gradle-spring-boot plugin from 4.8.4 to 4.8.5-beta-3.
Updates json-smart dependency from 2.4.9 to 2.4.10

## What is the intent behind these changes?

Resolves dependency vulnerabilities flagged by owasp dependency-check
