### PR TITLE
Replace throwing InvalidAssumptionErrors with logging

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -43,8 +43,6 @@ class ValidationError(override val message: String, val errors: List<FieldError>
 
 class AccessError(val user: AuthUser, override val message: String, val errors: List<String>) : RuntimeException(message)
 
-class InvalidAssumptionError(assumption: String) : RuntimeException("assumption proved invalid: $assumption")
-
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
   val status: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -158,9 +158,6 @@ class CommunityAPIOffenderService(
       }
     }
 
-    if (responsibleOfficers.isNullOrEmpty()) {
-      return null
-    }
-    return responsibleOfficers.first()
+    return responsibleOfficers?.firstOrNull()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -128,7 +128,7 @@ class CommunityAPIOffenderService(
       .bodyToMono(OffenderIdentifiersResponse::class.java)
   }
 
-  fun getResponsibleOfficer(crn: String): ResponsibleOfficer {
+  fun getResponsibleOfficer(crn: String): ResponsibleOfficer? {
     val offenderManagersPath = UriComponentsBuilder.fromPath(offenderManagersLocation)
       .buildAndExpand(crn)
       .toString()
@@ -158,6 +158,9 @@ class CommunityAPIOffenderService(
       }
     }
 
+    if (responsibleOfficers.isNullOrEmpty()) {
+      return null
+    }
     return responsibleOfficers.first()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -149,7 +149,6 @@ class CommunityAPIOffenderService(
         it == 0 -> telemetryService.reportInvalidAssumption(
           "service users always have a responsible officer",
           mapOf("crn" to crn),
-          recoverable = false,
         )
         it > 1 -> telemetryService.reportInvalidAssumption(
           "service users only have one responsible officer",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -271,7 +271,7 @@ class ReferralService(
   fun getResponsibleProbationPractitioner(crn: String, sentBy: AuthUser?, createdBy: AuthUser): ResponsibleProbationPractitioner {
     try {
       val responsibleOfficer = communityAPIOffenderService.getResponsibleOfficer(crn)
-      if (responsibleOfficer.email != null) {
+      if (responsibleOfficer?.email != null) {
         return ResponsibleProbationPractitioner(
           responsibleOfficer.firstName ?: "",
           responsibleOfficer.email,
@@ -283,7 +283,7 @@ class ReferralService(
 
       telemetryService.reportInvalidAssumption(
         "all responsible officers have email addresses",
-        mapOf("staffId" to responsibleOfficer.staffId.toString()),
+        mapOf("staffId" to responsibleOfficer?.staffId.toString()),
       )
 
       logger.warn("no email address for responsible officer; falling back to referring probation practitioner")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
@@ -1,13 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.microsoft.applicationinsights.TelemetryClient
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.InvalidAssumptionError
 
 @Service
 class TelemetryService(
   private val telemetryClient: TelemetryClient,
 ) {
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+  }
   fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap(), recoverable: Boolean = true) {
     telemetryClient.trackEvent(
       "InterventionsInvalidAssumption",
@@ -16,7 +20,7 @@ class TelemetryService(
     )
 
     if (!recoverable) {
-      throw InvalidAssumptionError(assumption)
+      logger.error("assumption proved invalid: $assumption")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
@@ -12,15 +12,12 @@ class TelemetryService(
   companion object {
     private val logger = KotlinLogging.logger {}
   }
-  fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap(), recoverable: Boolean = true) {
+  fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap()) {
     telemetryClient.trackEvent(
       "InterventionsInvalidAssumption",
       mapOf("assumption" to assumption).plus(information),
       null,
     )
-
-    if (!recoverable) {
-      logger.error("assumption proved invalid: $assumption")
-    }
+    logger.error("assumption proved invalid: $assumption")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -4,6 +4,7 @@ import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.ClientResponse
@@ -11,7 +12,6 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.RestClient
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.InvalidAssumptionError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 
 private data class MockedResponse(
@@ -99,11 +99,9 @@ internal class CommunityAPIOffenderServiceTest {
   }
 
   @Test
-  fun `getResponsibleOfficer fails when there are no responsible officers`() {
+  fun `getResponsibleOfficer returns null when there are no responsible officers`() {
     val offenderService = offenderServiceFactory(createMockedRestClient(MockedResponse(offenderManagersLocation, HttpStatus.OK, "[]")))
-    assertThrows<InvalidAssumptionError> {
-      offenderService.getResponsibleOfficer("X123456")
-    }
+    assertThat(offenderService.getResponsibleOfficer("X123456")).isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -153,6 +153,16 @@ class ReferralServiceUnitTest {
   }
 
   @Test
+  fun `getResponsibleProbationPractitioner uses sender if there is no responsible officer`() {
+    val sender = authUserFactory.create("sender")
+    whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(null)
+    whenever(hmppsAuthService.getUserDetail(sender)).thenReturn(UserDetail("andrew", "andrew@tom.tom", "marr"))
+    val pp = referralService.getResponsibleProbationPractitioner(referralFactory.createSent(sentBy = sender))
+    assertThat(pp.firstName).isEqualTo("andrew")
+    assertThat(pp.email).isEqualTo("andrew@tom.tom")
+  }
+
+  @Test
   fun `getResponsibleProbationPractitioner uses sender if there is no responsible officer email address`() {
     val sender = authUserFactory.create("sender")
     whenever(communityAPIOffenderService.getResponsibleOfficer(any())).thenReturn(ResponsibleOfficer("tom", null, 123, "jones"))


### PR DESCRIPTION
## What does this pull request do?

Logs the invalid assumption that service users always have a responsible officer, when requesting community-api for a responsible officer, instead of throwing an InvalidAssumptionError.

## What is the intent behind these changes?

To prevent Sentry triggering Alerts for InvalidAssumptionErrors.
