### PR TITLE
Retrieving end of service report if it exists before or else create it

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/EndOfServiceReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/EndOfServiceReportRepository.kt
@@ -4,4 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import java.util.UUID
 
-interface EndOfServiceReportRepository : JpaRepository<EndOfServiceReport, UUID>
+interface EndOfServiceReportRepository : JpaRepository<EndOfServiceReport, UUID> {
+
+  fun findByReferralId(referralId: UUID): EndOfServiceReport?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -35,7 +35,7 @@ class EndOfServiceReportService(
       createdAt = OffsetDateTime.now(),
     )
     return endOfServiceReportRepository.findByReferralId(referralId)
-      ?: return endOfServiceReportRepository.save(endOfServiceReport)
+      ?: endOfServiceReportRepository.save(endOfServiceReport)
   }
 
   fun getEndOfServiceReport(endOfServiceReportId: UUID): EndOfServiceReport {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -34,8 +34,8 @@ class EndOfServiceReportService(
       createdBy = authUserRepository.save(createdByUser),
       createdAt = OffsetDateTime.now(),
     )
-
-    return endOfServiceReportRepository.save(endOfServiceReport)
+    return endOfServiceReportRepository.findByReferralId(referralId)
+      ?: return endOfServiceReportRepository.save(endOfServiceReport)
   }
 
   fun getEndOfServiceReport(endOfServiceReportId: UUID): EndOfServiceReport {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportServiceTest.kt
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.firstValue
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.EndOfServiceReportEventPublisher
@@ -50,10 +51,28 @@ class EndOfServiceReportServiceTest {
     whenever(authUserRepository.save(authUser)).thenReturn(authUser)
     whenever(referralRepository.getReferenceById(referral.id)).thenReturn(referral)
     whenever(endOfServiceReportRepository.save(any())).thenReturn(endOfServiceReport)
+    whenever(endOfServiceReportRepository.findByReferralId(referralId = referral.id)).thenReturn(null)
     whenever(referralRepository.save(any())).thenReturn(referral)
 
     val savedEndOfServiceReport = endOfServiceReportService.createEndOfServiceReport(referral.id, authUser)
 
+    assertThat(savedEndOfServiceReport).isNotNull
+  }
+
+  @Test
+  fun `return existing end of service report`() {
+    val authUser = AuthUser("CRN123", "auth", "user")
+    val referral = SampleData.sampleReferral(crn = "CRN123", serviceProviderName = "Service Provider")
+    val endOfServiceReport = SampleData.sampleEndOfServiceReport(outcomes = mutableSetOf(), referral = referral)
+
+    whenever(authUserRepository.save(authUser)).thenReturn(authUser)
+    whenever(referralRepository.getReferenceById(referral.id)).thenReturn(referral)
+    whenever(endOfServiceReportRepository.findByReferralId(referralId = referral.id)).thenReturn(endOfServiceReport)
+    whenever(referralRepository.save(any())).thenReturn(referral)
+
+    val savedEndOfServiceReport = endOfServiceReportService.createEndOfServiceReport(referral.id, authUser)
+
+    verify(endOfServiceReportRepository, never()).save(any())
     assertThat(savedEndOfServiceReport).isNotNull
   }
 


### PR DESCRIPTION
## What does this pull request do?

retrieves the end of service report if it already exists or else 

## What is the intent behind these changes?

Due to the issues in end of service report, users trying to create end of service report again and facing DataIntegrityViolation exception
