### PR TITLE
change the renovate config to use the base config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,8 +5,7 @@
     {
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "all gradle dependencies",
-      "schedule": ["before 7am on Monday"],
+      "groupName": "all gradle dependencies"
     },
     {
       // upgrading these is a team decision


### PR DESCRIPTION
## What does this pull request do?

- removes the schedule config to inherit the base schedule config

## What is the intent behind these changes?

- The existing schedule config was not working correctly
