### PR TITLE
Ipb 426/fixing empty data exception for username

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/AuthUserRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/AuthUserRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.repository.CrudRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 
 interface AuthUserRepository : CrudRepository<AuthUser, String> {
-  fun findByUserName(userName: String): AuthUser
+  fun findByUserName(userName: String?): AuthUser?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RamDeliusAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/RamDeliusAPIOffenderService.kt
@@ -15,7 +15,7 @@ data class OfficerDetails(
 data class CommunityManager(
   val code: String,
   val name: Name,
-  val username: String,
+  val username: String?,
   val email: String?,
   val responsibleOfficer: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -276,7 +276,7 @@ class ReferralService(
           responsibleOfficer.communityManager.name.forename,
           responsibleOfficer.communityManager.email,
           responsibleOfficer.communityManager.code,
-          authUserRepository.findByUserName(responsibleOfficer.communityManager.username),
+          if (responsibleOfficer.communityManager.username != null) authUserRepository.findByUserName(responsibleOfficer.communityManager.username) else null,
           responsibleOfficer.communityManager.name.surname,
         )
       }


### PR DESCRIPTION
## What does this pull request do?

Making the username nullable element from the responsible office end point

## What is the intent behind these changes?

The username from responsible office end point seems to be null
