### PR TITLE
PI-1013 update to use new endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RamDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RamDeliusClient.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentResponseDTO
 
 @Component
 class RamDeliusClient(private val ramDeliusApiClient: RestClient) {
 
-  fun makeSyncPutRequest(uri: String, requestBody: Any) {
-    ramDeliusApiClient.put(uri, requestBody).retrieve().toBodilessEntity().block()
-  }
+  fun makeSyncPutRequest(uri: String, requestBody: Any): AppointmentResponseDTO? =
+    ramDeliusApiClient.put(uri, requestBody).retrieve().bodyToMono(AppointmentResponseDTO::class.java).block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RamDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/RamDeliusClient.kt
@@ -6,6 +6,9 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.Appointmen
 @Component
 class RamDeliusClient(private val ramDeliusApiClient: RestClient) {
 
-  fun makeSyncPutRequest(uri: String, requestBody: Any): AppointmentResponseDTO? =
+  fun makeSyncPutRequest(uri: String, requestBody: Any) =
+    ramDeliusApiClient.put(uri, requestBody).retrieve().toBodilessEntity().block()
+
+  fun makePutAppointmentRequest(uri: String, requestBody: Any): AppointmentResponseDTO? =
     ramDeliusApiClient.put(uri, requestBody).retrieve().bodyToMono(AppointmentResponseDTO::class.java).block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -77,7 +77,7 @@ class AppointmentService(
       }
       // the current appointment needs to be updated
       appointment.attended == null -> {
-        val (deliusAppointmentId, _) =
+        val (deliusAppointmentId, appointmentId) =
           communityAPIBookingService.book(referral, appointment, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode)
         updateAppointment(
           durationInMinutes,
@@ -95,6 +95,7 @@ class AppointmentService(
           notifyProbationPractitioner,
           behaviourDescription,
           appointmentType,
+          appointmentId,
         )
       }
       // the appointment has already been attended
@@ -283,6 +284,7 @@ class AppointmentService(
     notifyProbationPractitioner: Boolean?,
     behaviourDescription: String?,
     appointmentType: AppointmentType,
+    uuid: UUID?,
   ): Appointment {
     val appointment = createAppointment(
       durationInMinutes,
@@ -299,6 +301,7 @@ class AppointmentService(
       notifyProbationPractitioner,
       behaviourDescription,
       appointmentType,
+      uuid,
     )
     oldAppointment.superseded = true
     appointmentRepository.save(oldAppointment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -72,7 +72,7 @@ class AppointmentService(
           notifyProbationPractitioner,
           behaviourDescription,
           appointmentType,
-          appointmentId
+          appointmentId,
         )
       }
       // the current appointment needs to be updated
@@ -250,7 +250,7 @@ class AppointmentService(
     notifyProbationPractitioner: Boolean?,
     behaviourDescription: String?,
     appointmentType: AppointmentType,
-    uuid: UUID? = null
+    uuid: UUID? = null,
   ): Appointment {
     val appointment = Appointment(
       id = uuid ?: UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -53,9 +53,9 @@ class AppointmentService(
     behaviourDescription: String? = null,
   ): Appointment {
     val appointment = when {
-      // an initial appointment is required
-      appointment == null -> {
-        val deliusAppointmentId =
+      // an initial appointment is required or an additional appointment is required
+      appointment == null || appointment.attended == Attended.NO -> {
+        val (deliusAppointmentId, appointmentId) =
           communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode, attended, notifyProbationPractitioner)
         createAppointment(
           durationInMinutes,
@@ -72,11 +72,12 @@ class AppointmentService(
           notifyProbationPractitioner,
           behaviourDescription,
           appointmentType,
+          appointmentId
         )
       }
       // the current appointment needs to be updated
       appointment.attended == null -> {
-        val deliusAppointmentId =
+        val (deliusAppointmentId, _) =
           communityAPIBookingService.book(referral, appointment, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode)
         updateAppointment(
           durationInMinutes,
@@ -90,27 +91,6 @@ class AppointmentService(
           npsOfficeCode,
           attended,
           referral,
-          additionalAttendanceInformation,
-          notifyProbationPractitioner,
-          behaviourDescription,
-          appointmentType,
-        )
-      }
-      // an additional appointment is required
-      appointment.attended == Attended.NO -> {
-        val deliusAppointmentId =
-          communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode, attended, notifyProbationPractitioner)
-        createAppointment(
-          durationInMinutes,
-          appointmentTime,
-          deliusAppointmentId,
-          createdByUser,
-          appointmentDeliveryType,
-          appointmentSessionType,
-          appointmentDeliveryAddress,
-          referral,
-          npsOfficeCode,
-          attended,
           additionalAttendanceInformation,
           notifyProbationPractitioner,
           behaviourDescription,
@@ -270,9 +250,10 @@ class AppointmentService(
     notifyProbationPractitioner: Boolean?,
     behaviourDescription: String?,
     appointmentType: AppointmentType,
+    uuid: UUID? = null
   ): Appointment {
     val appointment = Appointment(
-      id = UUID.randomUUID(),
+      id = uuid ?: UUID.randomUUID(),
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
@@ -362,10 +343,10 @@ class AppointmentService(
     val sentReferral = referralRepository.findByIdAndSentAtIsNotNull(sentReferralId) ?: throw EntityNotFoundException(
       "Sent Referral not found [referralId=$sentReferralId]",
     )
-    val deliusAppointmentId =
+    val (deliusAppointmentId, appointmentId) =
       communityAPIBookingService.book(sentReferral, null, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode)
     val appointment = Appointment(
-      id = UUID.randomUUID(),
+      id = appointmentId ?: UUID.randomUUID(),
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
@@ -392,7 +373,7 @@ class AppointmentService(
   ): Appointment {
     val appointment = this.appointmentRepository.findById(appointmentId).orElseThrow { EntityNotFoundException("Appointment not found [appointmentId=$appointmentId]") }
     appointment.appointmentFeedbackSubmittedAt ?.let { throw EntityExistsException("Appointment has already been delivered [appointmentId=$appointmentId]") }
-    val deliusAppointmentId =
+    val (deliusAppointmentId, _) =
       communityAPIBookingService.book(appointment.referral, appointment, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode)
     appointment.durationInMinutes = durationInMinutes
     appointment.appointmentTime = appointmentTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -60,11 +60,11 @@ class CommunityAPIBookingService(
     npsOfficeCode: String?,
     attended: Attended?,
     notifyPPOfAttendanceBehaviour: Boolean?,
-  ): Pair<Long?, UUID> {
+  ): Pair<Long?, UUID?> {
     return existingAppointment?.let {
       if (isDifferentTimings(existingAppointment, appointmentTime, durationInMinutes)) {
         val appointmentRequestDTO = buildAppointmentRescheduleRequestDTO(appointmentTime, durationInMinutes, npsOfficeCode ?: defaultOfficeLocation)
-        makeBooking(referral.serviceUserCRN, it.deliusAppointmentId!!, appointmentRequestDTO, communityApiRescheduleAppointmentLocation) to existingAppointment.id
+        makeBooking(referral.serviceUserCRN, it.deliusAppointmentId!!, appointmentRequestDTO, communityApiRescheduleAppointmentLocation) to null
       } else if (isDifferentLocation(existingAppointment, npsOfficeCode)) {
         val appointmentMerge = existingAppointment.forMerge(
           appointmentType,
@@ -91,7 +91,7 @@ class CommunityAPIBookingService(
         ),
         npsOfficeCode ?: defaultOfficeLocation,
         get(appointmentType, countsTowardsRarDays),
-        attended?.let { AppointmentMerge.Outcome(it, (attended == NO || notifyPPOfAttendanceBehaviour == true)) }
+        attended?.let { AppointmentMerge.Outcome(it, (attended == NO || notifyPPOfAttendanceBehaviour == true)) },
       )
       mergeAppointment(mergeAppointment) to mergeAppointment.id
     }
@@ -122,7 +122,7 @@ class CommunityAPIBookingService(
     val path = UriComponentsBuilder.fromPath(appointmentMergeLocation)
       .buildAndExpand(appointmentMerge.serviceUserCrn, appointmentMerge.referralId)
       .toString()
-    return ramDeliusClient.makeSyncPutRequest(path, appointmentMerge)?.appointmentId
+    return ramDeliusClient.makePutAppointmentRequest(path, appointmentMerge)?.appointmentId
   }
 
   private fun makeBooking(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -87,6 +87,8 @@ class CommunityAPIBookingService(
         npsOfficeCode ?: defaultOfficeLocation,
         get(appointmentType, countsTowardsRarDays),
         attended?.let { AppointmentMerge.Outcome(it, (attended == NO || notifyPPOfAttendanceBehaviour == true)) },
+        null,
+        null,
       )
       mergeAppointment(mergeAppointment)
     }
@@ -111,6 +113,8 @@ class CommunityAPIBookingService(
     npsOfficeCode,
     get(appointmentType, countsTowardsRarDays),
     attended?.let { AppointmentMerge.Outcome(it, attended == NO || notifyOfAttendanceBehaviour) },
+    id,
+    deliusAppointmentId,
   )
 
   private fun mergeAppointment(appointmentMerge: AppointmentMerge): Pair<Long?, UUID> {
@@ -160,6 +164,8 @@ data class AppointmentMerge(
   val officeLocationCode: String?,
   val countsTowardsRar: Boolean,
   val outcome: Outcome?,
+  val previousId: UUID?,
+  val deliusId: Long?,
 ) {
   data class Outcome(
     val attended: Attended,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderService.kt
@@ -40,7 +40,6 @@ class CommunityAPIOffenderService(
   @Value("\${community-api.locations.offender-access}") private val offenderAccessLocation: String,
   @Value("\${community-api.locations.managed-offenders}") private val managedOffendersLocation: String,
   @Value("\${community-api.locations.staff-details}") private val staffDetailsLocation: String,
-  @Value("\${community-api.locations.offender-managers}") private val offenderManagersLocation: String,
   @Value("\${community-api.locations.offender-identifiers}") private val offenderIdentifiersLocation: String,
   private val communityApiClient: RestClient,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -157,6 +157,9 @@ class DeliverySessionService(
     notifyProbationPractitioner: Boolean? = null,
     behaviourDescription: String? = null,
   ): DeliverySession {
+    if (appointmentTime.isBefore(OffsetDateTime.now()) && attended == null) {
+      throw IllegalArgumentException("Appointment feedback must be provided for appointments in the past.")
+    }
     val (deliusAppointmentId, _) = communityAPIBookingService.book(
       deliverySession.referral,
       latestAppointment,
@@ -165,9 +168,6 @@ class DeliverySessionService(
       SERVICE_DELIVERY,
       npsOfficeCode,
     )
-    if (appointmentTime.isBefore(OffsetDateTime.now()) && attended == null) {
-      throw IllegalArgumentException("Appointment feedback must be provided for appointments in the past.")
-    }
     appointmentToSchedule.appointmentTime = appointmentTime
     appointmentToSchedule.durationInMinutes = durationInMinutes
     appointmentToSchedule.deliusAppointmentId = deliusAppointmentId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -157,7 +157,7 @@ class DeliverySessionService(
     notifyProbationPractitioner: Boolean? = null,
     behaviourDescription: String? = null,
   ): DeliverySession {
-    val deliusAppointmentId = communityAPIBookingService.book(
+    val (deliusAppointmentId, _) = communityAPIBookingService.book(
       deliverySession.referral,
       latestAppointment,
       appointmentTime,
@@ -200,7 +200,7 @@ class DeliverySessionService(
     val existingAppointment = session.currentAppointment
 
     // TODO: Some code duplication here with AppointmentService.kt
-    val deliusAppointmentId = communityAPIBookingService.book(
+    val (deliusAppointmentId, appointmentId) = communityAPIBookingService.book(
       session.referral,
       if (existingAppointment?.attended != Attended.NO) existingAppointment else null,
       appointmentTime,
@@ -213,7 +213,7 @@ class DeliverySessionService(
 
     // creating a new appointment from the existing appointment or else create a new appointment
     val appointment = Appointment(
-      id = UUID.randomUUID(),
+      id = appointmentId ?: UUID.randomUUID(),
       durationInMinutes = durationInMinutes,
       appointmentTime = appointmentTime,
       deliusAppointmentId = deliusAppointmentId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SupplierAssessmentService.kt
@@ -146,6 +146,9 @@ class SupplierAssessmentService(
       appointmentDeliveryAddress,
       npsOfficeCode,
     )
+    if (appointment.id != appointmentId) {
+      supplierAssessment.currentAppointment?.superseded = true
+    }
     supplierAssessment.appointments.add(appointment)
     supplierAssessmentRepository.save(supplierAssessment)
     return appointment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,16 +144,12 @@ refer-and-monitor-and-delius:
 
 community-api:
   locations:
-    ended-referral: "/secure/offenders/crn/{crn}/referral/end/context/{contextName}"
-    book-appointment: "/secure/offenders/crn/{crn}/sentence/{sentenceId}/appointments/context/{contextName}"
     reschedule-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/reschedule/context/{contextName}"
-    relocate-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/relocate"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
     notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
     offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"
     managed-offenders: "/secure/staff/staffIdentifier/{staffIdentifier}/managedOffenders"
     staff-details: "/secure/staff/username/{username}"
-    offender-managers: "/secure/offenders/crn/{crn}/allOffenderManagers"
     offender-identifiers: "/secure/offenders/crn/{crn}/identifiers"
   appointments:
     bookings:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,7 +144,6 @@ refer-and-monitor-and-delius:
 
 community-api:
   locations:
-    reschedule-appointment: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/reschedule/context/{contextName}"
     appointment-outcome-request: "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
     notification-request: "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
     offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,6 +139,7 @@ interventions-ui:
 refer-and-monitor-and-delius:
   locations:
     referral-start: "/probation-case/{crn}/referrals"
+    appointment-merge: "/probation-case/{crn}/referrals/{referralId}/appointments"
     responsible-officer: "/probation-case/{crn}/responsible-officer"
 
 community-api:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/CommunityAPIClientTest.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.CommunityApiCallError
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentCreateRequestDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.AppointmentResponseDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.LoggingMemoryAppender
 import java.time.OffsetDateTime
@@ -246,5 +245,18 @@ class CommunityAPIClientTest {
     countsTowardsRarDays = true,
     attended = null,
     notifyPPOfAttendanceBehaviour = null,
+  )
+
+  data class AppointmentCreateRequestDTO(
+    val contractType: String,
+    val referralStart: OffsetDateTime,
+    val referralId: UUID,
+    val appointmentStart: OffsetDateTime,
+    val appointmentEnd: OffsetDateTime,
+    val officeLocationCode: String,
+    val notes: String,
+    val countsTowardsRarDays: Boolean,
+    val attended: String?,
+    val notifyPPOfAttendanceBehaviour: Boolean?,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceRepositoryTest.kt
@@ -5,7 +5,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.isNotNull
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.AppointmentEventPublisher
@@ -67,6 +72,10 @@ class AppointmentServiceRepositoryTest @Autowired constructor(
     @Test
     fun `can schedule new appointment`() {
       val referral = referralFactory.createSent()
+
+      whenever(communityAPIBookingService.book(any(), isNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
+        .thenReturn(Pair(563729L, UUID.randomUUID()))
+
       val appointment = appointmentService.scheduleNewAppointment(
         referral.id,
         AppointmentType.SUPPLIER_ASSESSMENT,
@@ -103,7 +112,10 @@ class AppointmentServiceRepositoryTest @Autowired constructor(
 
     @Test
     fun `can reschedule existing appointment`() {
-      val appointment = appointmentFactory.create(appointmentTime = OffsetDateTime.now(), durationInMinutes = 60)
+      val appointment = appointmentFactory.create(appointmentTime = OffsetDateTime.now().plusMinutes(60), durationInMinutes = 60)
+
+      whenever(communityAPIBookingService.book(any(), anyOrNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
+        .thenReturn(Pair(56478388921L, null))
 
       val rescheduledAppointment = appointmentService.rescheduleExistingAppointment(
         appointment.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceRepositoryTest.kt
@@ -114,8 +114,8 @@ class AppointmentServiceRepositoryTest @Autowired constructor(
     fun `can reschedule existing appointment`() {
       val appointment = appointmentFactory.create(appointmentTime = OffsetDateTime.now().plusMinutes(60), durationInMinutes = 60)
 
-      whenever(communityAPIBookingService.book(any(), anyOrNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(56478388921L, null))
+      whenever(communityAPIBookingService.book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
+        .thenReturn(Pair(56473882L, UUID.randomUUID()))
 
       val rescheduledAppointment = appointmentService.rescheduleExistingAppointment(
         appointment.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -68,15 +68,10 @@ class AppointmentServiceTest {
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
     val npsOfficeCode = "CRSEXT"
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = deliusAppointmentId,
-    )
 
     whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, npsOfficeCode))
-      .thenReturn(Pair(deliusAppointmentId, savedAppointment.id))
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(deliusAppointmentId, UUID.randomUUID()))
+    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = npsOfficeCode)
@@ -102,15 +97,10 @@ class AppointmentServiceTest {
     val appointmentTime = OffsetDateTime.parse("2022-12-04T10:42:43+00:00")
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = deliusAppointmentId,
-    )
 
     whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(Pair(deliusAppointmentId, savedAppointment.id))
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(deliusAppointmentId, UUID.randomUUID()))
+    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -145,15 +135,10 @@ class AppointmentServiceTest {
     val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = deliusAppointmentId,
-    )
 
     whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, YES, false))
-      .thenReturn(Pair(deliusAppointmentId, savedAppointment.id))
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(deliusAppointmentId, UUID.randomUUID()))
+    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(
@@ -209,13 +194,9 @@ class AppointmentServiceTest {
     val rescheduledDeliusAppointmentId = 99L
 
     whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(Pair(rescheduledDeliusAppointmentId, null))
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = rescheduledDeliusAppointmentId,
-    )
-    whenever(appointmentRepository.saveAndFlush(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(rescheduledDeliusAppointmentId, UUID.randomUUID()))
+
+    whenever(appointmentRepository.saveAndFlush(any())).thenAnswer { it.arguments[0] }
 
     // When
     val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -255,15 +236,10 @@ class AppointmentServiceTest {
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = NO)
     val referral = referralFactory.createSent()
     val additionalDeliusAppointmentId = 99L
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = additionalDeliusAppointmentId,
-    )
 
     whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(Pair(additionalDeliusAppointmentId, savedAppointment.id))
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(additionalDeliusAppointmentId, UUID.randomUUID()))
+    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
@@ -299,19 +275,10 @@ class AppointmentServiceTest {
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = null)
     val referral = referralFactory.createSent()
     val rescheduledDeliusAppointmentId = 99L
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = rescheduledDeliusAppointmentId,
-      attended = NO,
-      additionalAttendanceInformation = "non attended",
-      attendanceBehaviour = null,
-      notifyPPOfAttendanceBehaviour = null,
-    )
 
     whenever(communityAPIBookingService.book(referral, existingAppointment, pastAppointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(Pair(rescheduledDeliusAppointmentId, savedAppointment.id))
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(rescheduledDeliusAppointmentId, UUID.randomUUID()))
+    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
     // When
     val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, pastAppointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
@@ -341,19 +308,10 @@ class AppointmentServiceTest {
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = NO)
     val referral = referralFactory.createSent()
     val additionalDeliusAppointmentId = 99L
-    val savedAppointment = appointmentFactory.create(
-      appointmentTime = appointmentTime,
-      durationInMinutes = durationInMinutes,
-      deliusAppointmentId = additionalDeliusAppointmentId,
-      attended = NO,
-      additionalAttendanceInformation = "non attended",
-      attendanceBehaviour = null,
-      notifyPPOfAttendanceBehaviour = null,
-    )
 
     whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, NO, null))
-      .thenReturn(Pair(additionalDeliusAppointmentId, savedAppointment.id))
-    whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
+      .thenReturn(Pair(additionalDeliusAppointmentId, UUID.randomUUID()))
+    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
@@ -443,13 +401,14 @@ class AppointmentServiceTest {
       val oldNpsCode = "CRS0001"
       val newNpsCode = "CRS0002"
       val savedAppointment = appointmentFactory.create(
+        existingAppointment.id,
         appointmentTime = appointmentTime,
         durationInMinutes = durationInMinutes,
         deliusAppointmentId = rescheduledDeliusAppointmentId,
       )
 
       whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, newNpsCode))
-        .thenReturn(Pair(rescheduledDeliusAppointmentId, savedAppointment.id))
+        .thenReturn(Pair(rescheduledDeliusAppointmentId, existingAppointment.id))
       savedAppointment.appointmentDelivery = AppointmentDelivery(appointmentId = savedAppointment.id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = oldNpsCode)
 
       whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -68,21 +68,30 @@ class AppointmentServiceTest {
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
     val npsOfficeCode = "CRSEXT"
-
-    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, npsOfficeCode))
-      .thenReturn(deliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
     )
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, npsOfficeCode))
+      .thenReturn(Pair(deliusAppointmentId, savedAppointment.id))
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = npsOfficeCode)
 
     // Then
-    verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode)
+    verifyResponse(
+      newAppointment,
+      null,
+      deliusAppointmentId,
+      appointmentTime,
+      durationInMinutes,
+      AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE,
+      AppointmentSessionType.ONE_TO_ONE,
+      npsOfficeCode,
+    )
     verifySavedAppointment(appointmentTime, durationInMinutes, deliusAppointmentId, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode)
   }
 
@@ -93,21 +102,29 @@ class AppointmentServiceTest {
     val appointmentTime = OffsetDateTime.parse("2022-12-04T10:42:43+00:00")
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
-
-    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(deliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
     )
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
+      .thenReturn(Pair(deliusAppointmentId, savedAppointment.id))
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, null, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
     // Then
-    verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifyResponse(
+      newAppointment,
+      null,
+      deliusAppointmentId,
+      appointmentTime,
+      durationInMinutes,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+    )
     verifySavedAppointment(appointmentTime, durationInMinutes, deliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     assertThat(newAppointment.attended).isNull()
     assertThat(newAppointment.additionalAttendanceInformation).isNull()
@@ -128,14 +145,14 @@ class AppointmentServiceTest {
     val appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
     val referral = referralFactory.createSent()
     val deliusAppointmentId = 99L
-
-    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, YES, false))
-      .thenReturn(deliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = deliusAppointmentId,
     )
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, YES, false))
+      .thenReturn(Pair(deliusAppointmentId, savedAppointment.id))
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
@@ -157,7 +174,15 @@ class AppointmentServiceTest {
     )
 
     // Then
-    verifyResponse(newAppointment, null, true, deliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifyResponse(
+      newAppointment,
+      null,
+      deliusAppointmentId,
+      appointmentTime,
+      durationInMinutes,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+    )
     verifySavedAppointment(appointmentTime, durationInMinutes, deliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     verify(appointmentEventPublisher).attendanceRecordedEvent(newAppointment, false, AppointmentType.SUPPLIER_ASSESSMENT)
     verify(appointmentEventPublisher).behaviourRecordedEvent(newAppointment, false, AppointmentType.SUPPLIER_ASSESSMENT)
@@ -184,7 +209,7 @@ class AppointmentServiceTest {
     val rescheduledDeliusAppointmentId = 99L
 
     whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(rescheduledDeliusAppointmentId)
+      .thenReturn(Pair(rescheduledDeliusAppointmentId, null))
     val savedAppointment = appointmentFactory.create(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
@@ -196,7 +221,15 @@ class AppointmentServiceTest {
     val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
     // Then
-    verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifyResponse(
+      updatedAppointment,
+      existingAppointment.id,
+      rescheduledDeliusAppointmentId,
+      appointmentTime,
+      durationInMinutes,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+    )
     verifySavedAppointment(appointmentTime, durationInMinutes, rescheduledDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     val argumentCaptor = argumentCaptor<Appointment>()
     verify(appointmentRepository, atLeast(1)).save(argumentCaptor.capture())
@@ -222,20 +255,29 @@ class AppointmentServiceTest {
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = NO)
     val referral = referralFactory.createSent()
     val additionalDeliusAppointmentId = 99L
-
-    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null)).thenReturn(additionalDeliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
       deliusAppointmentId = additionalDeliusAppointmentId,
     )
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
+      .thenReturn(Pair(additionalDeliusAppointmentId, savedAppointment.id))
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
     // Then
-    verifyResponse(newAppointment, existingAppointment.id, true, additionalDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifyResponse(
+      newAppointment,
+      existingAppointment.id,
+      additionalDeliusAppointmentId,
+      appointmentTime,
+      durationInMinutes,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+    )
     verifySavedAppointment(appointmentTime, durationInMinutes, additionalDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     assertThat(newAppointment.attended).isNull()
     assertThat(newAppointment.additionalAttendanceInformation).isNull()
@@ -257,9 +299,6 @@ class AppointmentServiceTest {
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = null)
     val referral = referralFactory.createSent()
     val rescheduledDeliusAppointmentId = 99L
-
-    whenever(communityAPIBookingService.book(referral, existingAppointment, pastAppointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
-      .thenReturn(rescheduledDeliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
       durationInMinutes = durationInMinutes,
@@ -269,13 +308,24 @@ class AppointmentServiceTest {
       attendanceBehaviour = null,
       notifyPPOfAttendanceBehaviour = null,
     )
+
+    whenever(communityAPIBookingService.book(referral, existingAppointment, pastAppointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
+      .thenReturn(Pair(rescheduledDeliusAppointmentId, savedAppointment.id))
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
     val updatedAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, pastAppointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
 
     // Then
-    verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, OffsetDateTime.parse("2020-12-04T10:42:43+00:00"), durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifyResponse(
+      updatedAppointment,
+      existingAppointment.id,
+      rescheduledDeliusAppointmentId,
+      OffsetDateTime.parse("2020-12-04T10:42:43+00:00"),
+      durationInMinutes,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+    )
     verifySavedAppointment(OffsetDateTime.parse("2020-12-04T10:42:43+00:00"), durationInMinutes, rescheduledDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     assertThat(updatedAppointment.attended).isEqualTo(NO)
     assertThat(updatedAppointment.additionalAttendanceInformation).isEqualTo("non attended")
@@ -291,8 +341,6 @@ class AppointmentServiceTest {
     val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, attended = NO)
     val referral = referralFactory.createSent()
     val additionalDeliusAppointmentId = 99L
-
-    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, NO, null)).thenReturn(additionalDeliusAppointmentId)
     val savedAppointment = appointmentFactory.create(
       appointmentTime = appointmentTime,
       durationInMinutes = durationInMinutes,
@@ -302,13 +350,24 @@ class AppointmentServiceTest {
       attendanceBehaviour = null,
       notifyPPOfAttendanceBehaviour = null,
     )
+
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, NO, null))
+      .thenReturn(Pair(additionalDeliusAppointmentId, savedAppointment.id))
     whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
 
     // When
     val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, null, null, NO, "non attended", null, null)
 
     // Then
-    verifyResponse(newAppointment, existingAppointment.id, true, additionalDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
+    verifyResponse(
+      newAppointment,
+      existingAppointment.id,
+      additionalDeliusAppointmentId,
+      appointmentTime,
+      durationInMinutes,
+      AppointmentDeliveryType.PHONE_CALL,
+      AppointmentSessionType.ONE_TO_ONE,
+    )
     verifySavedAppointment(appointmentTime, durationInMinutes, additionalDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
     assertThat(newAppointment.attended).isEqualTo(NO)
     assertThat(newAppointment.additionalAttendanceInformation).isEqualTo("non attended")
@@ -336,7 +395,16 @@ class AppointmentServiceTest {
     assertThat(error.message).contains("Is it not possible to update an appointment that has already been attended")
   }
 
-  private fun verifyResponse(appointment: Appointment, originalId: UUID?, expectNewId: Boolean, deliusAppointmentId: Long, appointmentTime: OffsetDateTime?, durationInMinutes: Int, appointmentDeliveryType: AppointmentDeliveryType, appointmentSessionType: AppointmentSessionType, npsOfficeCode: String? = null) {
+  private fun verifyResponse(
+    appointment: Appointment,
+    originalId: UUID?,
+    deliusAppointmentId: Long,
+    appointmentTime: OffsetDateTime?,
+    durationInMinutes: Int,
+    appointmentDeliveryType: AppointmentDeliveryType,
+    appointmentSessionType: AppointmentSessionType,
+    npsOfficeCode: String? = null,
+  ) {
     // Verifying create or update route
     assertThat(appointment).isNotEqualTo(originalId)
 
@@ -374,14 +442,14 @@ class AppointmentServiceTest {
       val rescheduledDeliusAppointmentId = 99L
       val oldNpsCode = "CRS0001"
       val newNpsCode = "CRS0002"
-
-      whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, newNpsCode))
-        .thenReturn(rescheduledDeliusAppointmentId)
       val savedAppointment = appointmentFactory.create(
         appointmentTime = appointmentTime,
         durationInMinutes = durationInMinutes,
         deliusAppointmentId = rescheduledDeliusAppointmentId,
       )
+
+      whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, newNpsCode))
+        .thenReturn(Pair(rescheduledDeliusAppointmentId, savedAppointment.id))
       savedAppointment.appointmentDelivery = AppointmentDelivery(appointmentId = savedAppointment.id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, npsOfficeCode = oldNpsCode)
 
       whenever(appointmentRepository.save(any())).thenReturn(savedAppointment)
@@ -391,7 +459,16 @@ class AppointmentServiceTest {
 
       // Then
       assertThat(existingAppointment.superseded).isTrue
-      verifyResponse(updatedAppointment, existingAppointment.id, false, rescheduledDeliusAppointmentId, appointmentTime, durationInMinutes, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, newNpsCode)
+      verifyResponse(
+        updatedAppointment,
+        existingAppointment.id,
+        rescheduledDeliusAppointmentId,
+        appointmentTime,
+        durationInMinutes,
+        AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE,
+        AppointmentSessionType.ONE_TO_ONE,
+        newNpsCode,
+      )
       verifySavedAppointment(appointmentTime, durationInMinutes, rescheduledDeliusAppointmentId, AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, AppointmentSessionType.ONE_TO_ONE, newNpsCode)
     }
   }
@@ -485,7 +562,6 @@ class AppointmentServiceTest {
       val attended = YES
       val additionalAttendanceInformation = "information"
       val submittedBy = authUserFactory.create()
-      val feedbackSubmittedAt = OffsetDateTime.now()
       val appointment = appointmentFactory.create(id = appointmentId, appointmentTime = OffsetDateTime.now().plusMonths(2))
 
       val error = assertThrows<ResponseStatusException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingServiceTest.kt
@@ -47,9 +47,7 @@ internal class CommunityAPIBookingServiceTest {
   private val httpBaseUrl = "http://url"
   private val progressUrl = "/pp/{referralId}/progress"
   private val supplierAssessmentUrl = "/pp/{referralId}/supplier-assessment"
-  private val rescheduleApiUrl = "/appt/{CRN}/{sentenceId}/{contextName}/reschedule"
   private val crsOfficeLocation = "CRSEXTL"
-  private val crsBookingsContext = "CRS"
   private val appointmentMergeUrl = "/probation-case/{crn}/referrals/{referralId}/appointments"
 
   private val communityAPIClient: CommunityAPIClient = mock()
@@ -60,12 +58,9 @@ internal class CommunityAPIBookingServiceTest {
     httpBaseUrl,
     progressUrl,
     supplierAssessmentUrl,
-    rescheduleApiUrl,
     crsOfficeLocation,
     mapOf(SERVICE_DELIVERY to "Service Delivery"),
     mapOf(SERVICE_DELIVERY to true),
-    crsBookingsContext,
-    communityAPIClient,
     appointmentMergeUrl,
     ramDeliusAPIClient,
   )
@@ -204,16 +199,14 @@ internal class CommunityAPIBookingServiceTest {
       val deliusAppointmentId = 999L
       val appointment = makeAppointment(now, now.plusDays(1), 60, deliusAppointmentId)
 
-      val uri = "/appt/X1/999/CRS/reschedule"
-      val request = AppointmentRescheduleRequestDTO(now, now.plusMinutes(45), true, crsOfficeLocation)
+      val uri = "/probation-case/${appointment.referral.serviceUserCRN}/referrals/${appointment.referral.id}/appointments"
       val response = AppointmentResponseDTO(1234L)
 
-      whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
-        .thenReturn(response)
+      whenever(ramDeliusAPIClient.makePutAppointmentRequest(eq(uri), any())).thenReturn(response)
 
       communityAPIBookingService.book(referral, appointment, now, 45, SERVICE_DELIVERY, null, null, null)
 
-      verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+      verify(ramDeliusAPIClient).makePutAppointmentRequest(eq(uri), any())
     }
 
     @Test
@@ -228,16 +221,14 @@ internal class CommunityAPIBookingServiceTest {
       )
       existingAppointment.appointmentDelivery = appointmentDelivery
 
-      val uri = "/appt/X1/999/CRS/reschedule"
-      val request = AppointmentRescheduleRequestDTO(now, now.plusMinutes(45), true, "NEW_CODE")
+      val uri = "/probation-case/${existingAppointment.referral.serviceUserCRN}/referrals/${existingAppointment.referral.id}/appointments"
       val response = AppointmentResponseDTO(1234L)
 
-      whenever(communityAPIClient.makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java))
-        .thenReturn(response)
+      whenever(ramDeliusAPIClient.makePutAppointmentRequest(eq(uri), any())).thenReturn(response)
 
       communityAPIBookingService.book(referral, existingAppointment, now, 45, SERVICE_DELIVERY, "NEW_CODE", null, null)
 
-      verify(communityAPIClient).makeSyncPostRequest(uri, request, AppointmentResponseDTO::class.java)
+      verify(ramDeliusAPIClient).makePutAppointmentRequest(eq(uri), any())
     }
 
     @Test
@@ -372,12 +363,9 @@ internal class CommunityAPIBookingServiceTest {
       httpBaseUrl,
       progressUrl,
       supplierAssessmentUrl,
-      rescheduleApiUrl,
       crsOfficeLocation,
       mapOf(),
       mapOf(),
-      crsBookingsContext,
-      communityAPIClient,
       appointmentMergeUrl,
       ramDeliusAPIClient,
     )
@@ -398,12 +386,9 @@ internal class CommunityAPIBookingServiceTest {
       httpBaseUrl,
       progressUrl,
       supplierAssessmentUrl,
-      rescheduleApiUrl,
       crsOfficeLocation,
       mapOf(),
       mapOf(),
-      crsBookingsContext,
-      communityAPIClient,
       appointmentMergeUrl,
       ramDeliusAPIClient,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIOffenderServiceTest.kt
@@ -22,7 +22,6 @@ internal class CommunityAPIOffenderServiceTest {
   private val offenderAccessLocation = "offender-access"
   private val managedOffendersLocation = "managed-offenders"
   private val staffDetailsLocation = "staff-details"
-  private val offenderManagersLocation = "offender-managers"
   private val offenderIdentifiersLocation = "offender-identifiers"
 
   private fun createMockedRestClient(vararg responses: MockedResponse): RestClient {
@@ -47,7 +46,7 @@ internal class CommunityAPIOffenderServiceTest {
   }
 
   private fun offenderServiceFactory(restClient: RestClient): CommunityAPIOffenderService {
-    return CommunityAPIOffenderService(offenderAccessLocation, managedOffendersLocation, staffDetailsLocation, offenderManagersLocation, offenderIdentifiersLocation, restClient)
+    return CommunityAPIOffenderService(offenderAccessLocation, managedOffendersLocation, staffDetailsLocation, offenderIdentifiersLocation, restClient)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionServiceTest.kt
@@ -33,7 +33,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Aut
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFactory
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AuthUserFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DeliverySessionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -80,7 +79,6 @@ class DeliverySessionServiceTest @Autowired constructor(
   private val userFactory = AuthUserFactory(entityManager)
   private val deliverySessionFactory = DeliverySessionFactory(entityManager)
   private val actionPlanFactory = ActionPlanFactory(entityManager)
-  private val appointmentFactory = AppointmentFactory(entityManager)
 
   val defaultAppointmentTime = OffsetDateTime.now().plusDays(1)
   val defaultPastAppointmentTime = OffsetDateTime.now().minusHours(1)
@@ -108,9 +106,8 @@ class DeliverySessionServiceTest @Autowired constructor(
     fun `can schedule new appointment on empty session`() {
       val session = deliverySessionFactory.createUnscheduled()
 
-      val appt = session.currentAppointment
       whenever(communityAPIBookingService.book(any(), isNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(appt?.deliusAppointmentId, appt?.id))
+        .thenReturn(Pair(384567262L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(session.referral.id, session.sessionNumber, defaultAppointmentTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
@@ -128,7 +125,7 @@ class DeliverySessionServiceTest @Autowired constructor(
       val newTime = existingAppointment.appointmentTime.plusHours(1)
 
       whenever(communityAPIBookingService.book(any(), isNotNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(existingAppointment.deliusAppointmentId, existingAppointment.id))
+        .thenReturn(Pair(75638101746410L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(session.referral.id, session.sessionNumber, newTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
@@ -156,9 +153,8 @@ class DeliverySessionServiceTest @Autowired constructor(
         null
       }
 
-      val appt = session.currentAppointment
       whenever(communityAPIBookingService.book(eq(session.referral), isNull(), eq(pastDate), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(appt?.deliusAppointmentId, appt?.id))
+        .thenReturn(Pair(462818752L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.scheduleNewDeliverySessionAppointment(
         session.referral.id, session.sessionNumber, pastDate, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE,
@@ -270,13 +266,12 @@ class DeliverySessionServiceTest @Autowired constructor(
       val existingAppointment = session.currentAppointment!!
       val newTime = existingAppointment.appointmentTime.plusHours(1)
 
-      val appt = session.currentAppointment
       whenever(communityAPIBookingService.book(eq(session.referral), isNotNull(), eq(newTime), eq(2), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(appt?.deliusAppointmentId, appt?.id))
+        .thenReturn(Pair(32250921735125L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.rescheduleDeliverySessionAppointment(session.referral.id, session.sessionNumber, existingAppointment.id, newTime, 2, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
 
-      assertThat(updatedSession.appointments.size).isEqualTo(1)
+      assertThat(updatedSession.appointments.size).isEqualTo(2)
 
       val appointment = updatedSession.currentAppointment!!
       assertThat(appointment.appointmentTime).isEqualTo(newTime)
@@ -301,17 +296,16 @@ class DeliverySessionServiceTest @Autowired constructor(
         null
       }
 
-      val appt = session.currentAppointment
       whenever(communityAPIBookingService.book(eq(session.referral), isNotNull(), eq(pastDate), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(appt?.deliusAppointmentId, appt?.id))
+        .thenReturn(Pair(2452352906724579L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.rescheduleDeliverySessionAppointment(
         session.referral.id, session.sessionNumber, existingAppointment.id, pastDate, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE,
         attended = Attended.YES, additionalAttendanceInformation = "additionalAttendanceInformation", notifyProbationPractitioner = false, behaviourDescription = "behaviourDescription",
       )
 
-      assertThat(updatedSession.appointments.size).isEqualTo(1)
-      val appointment = updatedSession.appointments.first()
+      assertThat(updatedSession.appointments.size).isEqualTo(2)
+      val appointment = updatedSession.currentAppointment!!
       assertThat(appointment.appointmentTime).isEqualTo(pastDate)
       assertThat(appointment.durationInMinutes).isEqualTo(defaultDuration)
       assertThat(appointment.createdBy).isEqualTo(defaultUser)
@@ -605,9 +599,8 @@ class DeliverySessionServiceTest @Autowired constructor(
         null
       }
 
-      val appt = session.currentAppointment
       whenever(communityAPIBookingService.book(eq(session.referral), isNotNull(), eq(defaultPastAppointmentTime), eq(defaultDuration), eq(AppointmentType.SERVICE_DELIVERY), anyOrNull(), anyOrNull(), anyOrNull()))
-        .thenReturn(Pair(appt?.deliusAppointmentId, appt?.id))
+        .thenReturn(Pair(6571124135135L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.updateSessionAppointment(
         actionPlan.id, session.sessionNumber, defaultPastAppointmentTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE,
@@ -619,7 +612,7 @@ class DeliverySessionServiceTest @Autowired constructor(
         "behaviourDescription",
       )
 
-      // assertThat(updatedSession.appointments.size).isEqualTo(2)
+      assertThat(updatedSession.appointments.size).isEqualTo(2)
       val appointment = updatedSession.currentAppointment!!
       assertThat(appointment.appointmentTime).isEqualTo(defaultPastAppointmentTime)
       assertThat(appointment.durationInMinutes).isEqualTo(defaultDuration)
@@ -696,7 +689,7 @@ class DeliverySessionServiceTest @Autowired constructor(
         null
       }
 
-      whenever(communityAPIBookingService.book(any(), anyOrNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
+      whenever(communityAPIBookingService.book(any(), isNull(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull()))
         .thenReturn(Pair(564726L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.updateSessionAppointment(
@@ -742,11 +735,10 @@ class DeliverySessionServiceTest @Autowired constructor(
         null
       }
 
-      val appt = session.currentAppointment!!
       whenever(
         communityAPIBookingService.book(
           eq(session.referral),
-          anyOrNull(),
+          isNull(),
           eq(defaultPastAppointmentTime),
           eq(defaultDuration),
           eq(AppointmentType.SERVICE_DELIVERY),
@@ -754,7 +746,7 @@ class DeliverySessionServiceTest @Autowired constructor(
           anyOrNull(),
           anyOrNull(),
         ),
-      ).thenReturn(Pair(56381916L, null))
+      ).thenReturn(Pair(56381916L, UUID.randomUUID()))
 
       val updatedSession = deliverySessionService.updateSessionAppointment(
         actionPlan.id, session.sessionNumber, defaultPastAppointmentTime, defaultDuration, defaultUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -114,12 +114,16 @@ internal class DeliverySessionsServiceTest {
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = session.sessionNumber
     val user = createActor("scheduler")
+    val appointmentTime = OffsetDateTime.now().plusHours(1)
+    val durationInMinutes = 200
+    val appointment = session.currentAppointment
 
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
     whenever(deliverySessionRepository.save(any())).thenReturn(session)
 
-    val appointmentTime = OffsetDateTime.now().plusHours(1)
-    val durationInMinutes = 200
+    whenever(communityAPIBookingService.book(session.referral, appointment, appointmentTime, durationInMinutes, SERVICE_DELIVERY, null, null, null))
+      .thenReturn(Pair(appointment?.deliusAppointmentId, appointment?.id))
+
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
       sessionNumber,
@@ -159,6 +163,11 @@ internal class DeliverySessionsServiceTest {
 
     val appointmentTime = OffsetDateTime.now()
     val durationInMinutes = 200
+    val appointment = session.currentAppointment
+
+    whenever(communityAPIBookingService.book(session.referral, appointment, appointmentTime, durationInMinutes, SERVICE_DELIVERY, null, Attended.YES, false))
+      .thenReturn(Pair(76636819L, UUID.randomUUID()))
+
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
       sessionNumber,
@@ -206,6 +215,10 @@ internal class DeliverySessionsServiceTest {
 
     val appointmentTime = OffsetDateTime.now()
     val durationInMinutes = 200
+
+    whenever(communityAPIBookingService.book(any(), isNull(), any(), any(), eq(SERVICE_DELIVERY), isNull(), eq(Attended.NO), isNull()))
+      .thenReturn(Pair(46298523523L, UUID.randomUUID()))
+
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
       sessionNumber,
@@ -244,12 +257,16 @@ internal class DeliverySessionsServiceTest {
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = session.sessionNumber
     val user = createActor("re-scheduler")
-
-    whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    val appointment = session.currentAppointment
 
     val newTime = OffsetDateTime.now()
     val newDuration = 200
+
+    whenever(communityAPIBookingService.book(session.referral, appointment, newTime, newDuration, SERVICE_DELIVERY, null, null, null))
+      .thenReturn(Pair(4536183645L, UUID.randomUUID()))
+    whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
+    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
       sessionNumber,
@@ -296,7 +313,7 @@ internal class DeliverySessionsServiceTest {
         SERVICE_DELIVERY,
         null,
       ),
-    ).thenReturn(999L)
+    ).thenReturn(Pair(999L, appointment?.id))
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber))
       .thenReturn(session)
     whenever(deliverySessionRepository.save(any())).thenReturn(session)
@@ -348,7 +365,7 @@ internal class DeliverySessionsServiceTest {
         SERVICE_DELIVERY,
         null,
       ),
-    ).thenReturn(null)
+    ).thenReturn(Pair(null, null))
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
     whenever(deliverySessionRepository.save(any())).thenReturn(session)
 
@@ -674,7 +691,7 @@ internal class DeliverySessionsServiceTest {
         SERVICE_DELIVERY,
         npsOfficeCode,
       ),
-    ).thenReturn(999L)
+    ).thenReturn(Pair(999L, appointment?.id))
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(
       session,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionsServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.firstValue
+import org.mockito.kotlin.isNotNull
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -119,10 +120,10 @@ internal class DeliverySessionsServiceTest {
     val appointment = session.currentAppointment
 
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenReturn(session)
 
     whenever(communityAPIBookingService.book(session.referral, appointment, appointmentTime, durationInMinutes, SERVICE_DELIVERY, null, null, null))
-      .thenReturn(Pair(appointment?.deliusAppointmentId, appointment?.id))
+      .thenReturn(Pair(73457252L, UUID.randomUUID()))
 
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
@@ -159,14 +160,14 @@ internal class DeliverySessionsServiceTest {
     val user = createActor("scheduler")
 
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenReturn(session)
 
     val appointmentTime = OffsetDateTime.now()
     val durationInMinutes = 200
     val appointment = session.currentAppointment
 
     whenever(communityAPIBookingService.book(session.referral, appointment, appointmentTime, durationInMinutes, SERVICE_DELIVERY, null, Attended.YES, false))
-      .thenReturn(Pair(76636819L, UUID.randomUUID()))
+      .thenReturn(Pair(929478456763L, UUID.randomUUID()))
 
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
@@ -211,7 +212,7 @@ internal class DeliverySessionsServiceTest {
     val user = createActor("scheduler")
 
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenReturn(session)
 
     val appointmentTime = OffsetDateTime.now()
     val durationInMinutes = 200
@@ -257,15 +258,14 @@ internal class DeliverySessionsServiceTest {
     val actionPlanId = UUID.randomUUID()
     val sessionNumber = session.sessionNumber
     val user = createActor("re-scheduler")
-    val appointment = session.currentAppointment
 
     val newTime = OffsetDateTime.now()
     val newDuration = 200
 
-    whenever(communityAPIBookingService.book(session.referral, appointment, newTime, newDuration, SERVICE_DELIVERY, null, null, null))
-      .thenReturn(Pair(4536183645L, UUID.randomUUID()))
+    whenever(communityAPIBookingService.book(any(), isNotNull(), eq(newTime), eq(newDuration), eq(SERVICE_DELIVERY), isNull(), isNull(), isNull()))
+      .thenReturn(Pair(23523541087L, UUID.randomUUID()))
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenAnswer { it.arguments[0] }
 
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
@@ -316,7 +316,7 @@ internal class DeliverySessionsServiceTest {
     ).thenReturn(Pair(999L, appointment?.id))
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber))
       .thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenReturn(session)
 
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,
@@ -367,7 +367,7 @@ internal class DeliverySessionsServiceTest {
       ),
     ).thenReturn(Pair(null, null))
     whenever(deliverySessionRepository.findAllByActionPlanIdAndSessionNumber(actionPlanId, sessionNumber)).thenReturn(session)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenReturn(session)
 
     deliverySessionsService.updateSessionAppointment(
       actionPlanId,
@@ -696,7 +696,7 @@ internal class DeliverySessionsServiceTest {
       session,
     )
     whenever(authUserRepository.save(createdByUser)).thenReturn(createdByUser)
-    whenever(deliverySessionRepository.save(any())).thenReturn(session)
+    whenever(deliverySessionRepository.saveAndFlush(any())).thenReturn(session)
 
     val updatedSession = deliverySessionsService.updateSessionAppointment(
       actionPlanId,


### PR DESCRIPTION
## What does this pull request do?

Moves creation of new appointments to the new refer-and-monitor-and-delius api
Prevents duplicate appointments from being generated in delius
Allows the same endpoint to be used for location changes and rescheduling

## What is the intent behind these changes?

Improve resilience for network or other technical errors
Prevent duplicates
Allow Delius to store a reference to the appointment in the Interventions Service rather than the Interventions Service storing a delius database id
Reduce errors when rescheduling due to community API not accepting an outcome
