### PR TITLE
PI-1013 added sentence id for fuzzy matching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CommunityAPIBookingService.kt
@@ -82,6 +82,7 @@ class CommunityAPIBookingService(
         referral.id,
         referral.referenceNumber!!,
         referral.serviceUserCRN,
+        referral.relevantSentenceId,
         appointmentTime,
         appointmentTime.plusMinutes(durationInMinutes.toLong()),
         getNotes(
@@ -111,6 +112,7 @@ class CommunityAPIBookingService(
     referral.id,
     referral.referenceNumber!!,
     referral.serviceUserCRN,
+    referral.relevantSentenceId,
     appointmentTime,
     appointmentTime.plusMinutes(durationInMinutes.toLong()),
     getNotes(
@@ -174,6 +176,7 @@ data class AppointmentMerge(
   val referralId: UUID,
   val referralReference: String,
   val serviceUserCrn: String,
+  val sentenceId: Long?,
   val start: OffsetDateTime,
   val end: OffsetDateTime,
   val notes: String?,


### PR DESCRIPTION
## What does this pull request do?

sends the sentence id to delius when creating appointments

## What is the intent behind these changes?

allows delius to do a `fuzzy` search for older referrals where the external reference still isn't populated
