### PR TITLE
pass correct appointment id through to email

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -72,6 +72,7 @@ data class DeliverySessionDTO(
   val appointmentDeliveryAddress: AddressDTO?,
   val sessionFeedback: SessionFeedbackDTO,
   val deliusAppointmentId: Long?,
+  val appointmentId: UUID?,
 ) {
   companion object {
     fun from(session: DeliverySession): DeliverySessionDTO {
@@ -106,6 +107,7 @@ data class DeliverySessionDTO(
         npsOfficeCode = session.currentAppointment?.appointmentDelivery?.npsOfficeCode,
         sessionFeedback = SessionFeedbackDTO.from(session.currentAppointment),
         deliusAppointmentId = session.currentAppointment?.deliusAppointmentId,
+        appointmentId = session.currentAppointment?.id,
       )
     }
     fun from(sessions: List<DeliverySession>): List<DeliverySessionDTO> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
@@ -135,7 +135,7 @@ class NotifyActionPlanAppointmentService(
         ppSessionFeedbackLocation,
         event.referral.id,
         event.deliverySession.sessionNumber,
-        event.deliverySession.deliusAppointmentId!!,
+        event.deliverySession.appointmentId!!,
       )
 
       when (event.type) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyActionPlanAppointmentServiceTest.kt
@@ -85,12 +85,15 @@ class NotifyActionPlanAppointmentServiceTest {
   fun `appointment attendance recorded event calls email client when attended is NO`() {
     whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
-    notifyService().onApplicationEvent(generateAppointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, false, Attended.NO))
+    val actionPlanAppointmentEvent = generateAppointmentEvent(ActionPlanAppointmentEventType.ATTENDANCE_RECORDED, false, Attended.NO)
+    val appointmentId = actionPlanAppointmentEvent.deliverySession.appointmentId
+
+    notifyService().onApplicationEvent(actionPlanAppointmentEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
     Assertions.assertThat(personalisationCaptor.firstValue["popfullname"]).isEqualTo("Bob Green")
-    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1/appointment/12345/feedback")
+    Assertions.assertThat(personalisationCaptor.firstValue["attendanceUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1/appointment/$appointmentId/feedback")
   }
 
   @Test
@@ -112,11 +115,14 @@ class NotifyActionPlanAppointmentServiceTest {
   fun `appointment behaviour recorded event calls email client`() {
     whenever(referralService.getResponsibleProbationPractitioner(any(), any(), any())).thenReturn(ResponsibleProbationPractitioner("abc", "abc@abc.com", null, null, "def"))
 
-    notifyService().onApplicationEvent(generateAppointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true))
+    val actionPlanAppointmentEvent = generateAppointmentEvent(ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED, true)
+    val appointmentId = actionPlanAppointmentEvent.deliverySession.appointmentId
+
+    notifyService().onApplicationEvent(actionPlanAppointmentEvent)
     val personalisationCaptor = argumentCaptor<Map<String, String>>()
     verify(emailSender).sendEmail(eq("template"), eq("abc@abc.com"), personalisationCaptor.capture())
     Assertions.assertThat(personalisationCaptor.firstValue["ppFirstName"]).isEqualTo("abc")
     Assertions.assertThat(personalisationCaptor.firstValue["referenceNumber"]).isEqualTo("HAS71263")
-    Assertions.assertThat(personalisationCaptor.firstValue["sessionUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1/appointment/12345/feedback")
+    Assertions.assertThat(personalisationCaptor.firstValue["sessionUrl"]).isEqualTo("http://example.com/pp/referrals/68df9f6c-3fcb-4ec6-8fcf-96551cd9b080/session/1/appointment/$appointmentId/feedback")
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Passes the correct id through to the email to view post session feedback.

## What is the intent behind these changes?

Fix the broken email link to view the post session feedback. Previously it was using the delius Id, rather than the R&M id.