### PR TITLE
Fix for owasp check, upgrading spring parent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.7"
   kotlin("plugin.spring") version "1.8.21"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.8.21"
   id("jacoco")


### PR DESCRIPTION
## What does this pull request do?

Upgrades spring parent project to address OWASP error in build

## What is the intent behind these changes?

Prevent errors during OWASP checks and address security issue with referenced library.
