### PR TITLE
Read resource from classpath instead of resource reader

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/markstaleappointments/MarkStaleAppointmentsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/markstaleappointments/MarkStaleAppointmentsJobConfiguration.kt
@@ -41,9 +41,9 @@ class MarkStaleAppointmentsJobConfiguration(
   fun markStaleAppointmentsJob(markStaleAppointmentsStep: Step): Job {
     if (env.isNullOrBlank()) this.env = "local"
 
-    val propsPath = "classpath:jobs/oneoff/mark-stale-appointments-$env.txt"
-    val resourceUri = resourceLoader.getResource(propsPath)
-    val lines = resourceUri.file?.bufferedReader()?.readLines()
+    val propsPath = "jobs/oneoff/mark-stale-appointments-$env.txt"
+    val resourceReader = MarkStaleAppointmentsJobConfiguration::class.java.getResourceAsStream(propsPath)
+    val lines = resourceReader?.bufferedReader()?.readLines()
 
     val validator = DefaultJobParametersValidator()
     validator.setRequiredKeys(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/markstaleappointments/MarkStaleAppointmentsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/markstaleappointments/MarkStaleAppointmentsJobConfiguration.kt
@@ -42,7 +42,7 @@ class MarkStaleAppointmentsJobConfiguration(
     if (env.isNullOrBlank()) this.env = "local"
 
     val propsPath = "jobs/oneoff/mark-stale-appointments-$env.txt"
-    val resourceReader = MarkStaleAppointmentsJobConfiguration::class.java.getResourceAsStream(propsPath)
+    val resourceReader = this::class.java.classLoader.getResourceAsStream(propsPath)
     val lines = resourceReader?.bufferedReader()?.readLines()
 
     val validator = DefaultJobParametersValidator()


### PR DESCRIPTION
Fix for deploy issue

## What does this pull request do?

Changed reader to use a classpath rather than resource loader to pull files in deployed container

## What is the intent behind these changes?

Fix for deployment issue seen in DEV
