### PR TITLE
save the probation practitioner details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -149,9 +149,7 @@ class SupplierAssessmentController(
 
   private fun getSupplierAssessmentAppointment(referralId: UUID, user: AuthUser): Appointment {
     val referral = referralService.getSentReferralForUser(referralId, user)
-    if (referral == null) {
-      throw ResponseStatusException(HttpStatus.NOT_FOUND, "referral not found [id=$referralId]")
-    }
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "referral not found [id=$referralId]")
     if (referral.supplierAssessment == null) {
       throw ResponseStatusException(HttpStatus.NOT_FOUND, "supplier assessment not found for referral [id=$referralId]")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -53,13 +53,13 @@ data class DraftReferralDTO(
   val hasExpectedReleaseDate: Boolean? = null,
   val expectedReleaseDate: LocalDate? = null,
   val expectedReleaseDateMissingReason: String? = null,
-  val nDeliusPPName: String? = null,
-  val nDeliusPPEmailAddress: String? = null,
-  val nDeliusPDU: String? = null,
+  val ndeliusPPName: String? = null,
+  val ndeliusPPEmailAddress: String? = null,
+  val ndeliusPDU: String? = null,
   val ppName: String? = null,
   val ppEmailAddress: String? = null,
-  val pdu: String? = null,
-  val probationOffice: String? = null,
+  val ppPdu: String? = null,
+  val ppProbationOffice: String? = null,
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {
@@ -101,13 +101,13 @@ data class DraftReferralDTO(
         personCustodyPrisonId = referral.personCustodyPrisonId,
         expectedReleaseDate = referral.expectedReleaseDate,
         expectedReleaseDateMissingReason = referral.expectedReleaseDateMissingReason,
-        nDeliusPPName = referral.nDeliusPPName,
-        nDeliusPPEmailAddress = referral.nDeliusPPEmailAddress,
-        nDeliusPDU = referral.nDeliusPPPDU,
+        ndeliusPPName = referral.nDeliusPPName,
+        ndeliusPPEmailAddress = referral.nDeliusPPEmailAddress,
+        ndeliusPDU = referral.nDeliusPPPDU,
         ppName = referral.name,
         ppEmailAddress = referral.emailAddress,
-        pdu = referral.pdu,
-        probationOffice = referral.probationOffice,
+        ppPdu = referral.pdu,
+        ppProbationOffice = referral.probationOffice,
       )
     }
 
@@ -151,13 +151,13 @@ data class DraftReferralDTO(
         personCustodyPrisonId = referral.referralLocation?.prisonId,
         expectedReleaseDate = referral.referralLocation?.expectedReleaseDate,
         expectedReleaseDateMissingReason = referral.referralLocation?.expectedReleaseDateMissingReason,
-        nDeliusPPName = referral.probationPractitionerDetails?.nDeliusName,
-        nDeliusPPEmailAddress = referral.probationPractitionerDetails?.nDeliusEmailAddress,
-        nDeliusPDU = referral.probationPractitionerDetails?.nDeliusPDU,
+        ndeliusPPName = referral.probationPractitionerDetails?.nDeliusName,
+        ndeliusPPEmailAddress = referral.probationPractitionerDetails?.nDeliusEmailAddress,
+        ndeliusPDU = referral.probationPractitionerDetails?.nDeliusPDU,
         ppName = referral.probationPractitionerDetails?.name,
         ppEmailAddress = referral.probationPractitionerDetails?.emailAddress,
-        pdu = referral.probationPractitionerDetails?.pdu,
-        probationOffice = referral.probationPractitionerDetails?.probationOffice!!,
+        ppPdu = referral.probationPractitionerDetails?.pdu,
+        ppProbationOffice = referral.probationPractitionerDetails?.probationOffice!!,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -109,6 +109,7 @@ data class DraftReferralDTO(
         ppEmailAddress = referral.emailAddress,
         ppPdu = referral.pdu,
         ppProbationOffice = referral.probationOffice,
+        hasValidDeliusPPDetails = referral.hasValidDeliusPPDetails,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -60,6 +60,7 @@ data class DraftReferralDTO(
   val ppEmailAddress: String? = null,
   val ppPdu: String? = null,
   val ppProbationOffice: String? = null,
+  val hasValidDeliusPPDetails: Boolean? = null,
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -53,6 +53,13 @@ data class DraftReferralDTO(
   val hasExpectedReleaseDate: Boolean? = null,
   val expectedReleaseDate: LocalDate? = null,
   val expectedReleaseDateMissingReason: String? = null,
+  val nDeliusPPName: String? = null,
+  val nDeliusPPEmailAddress: String? = null,
+  val nDeliusPDU: String? = null,
+  val ppName: String? = null,
+  val ppEmailAddress: String? = null,
+  val pdu: String? = null,
+  val probationOffice: String? = null,
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {
@@ -94,6 +101,13 @@ data class DraftReferralDTO(
         personCustodyPrisonId = referral.personCustodyPrisonId,
         expectedReleaseDate = referral.expectedReleaseDate,
         expectedReleaseDateMissingReason = referral.expectedReleaseDateMissingReason,
+        nDeliusPPName = referral.nDeliusPPName,
+        nDeliusPPEmailAddress = referral.nDeliusPPEmailAddress,
+        nDeliusPDU = referral.nDeliusPPPDU,
+        ppName = referral.name,
+        ppEmailAddress = referral.emailAddress,
+        pdu = referral.pdu,
+        probationOffice = referral.probationOffice,
       )
     }
 
@@ -137,6 +151,13 @@ data class DraftReferralDTO(
         personCustodyPrisonId = referral.referralLocation?.prisonId,
         expectedReleaseDate = referral.referralLocation?.expectedReleaseDate,
         expectedReleaseDateMissingReason = referral.referralLocation?.expectedReleaseDateMissingReason,
+        nDeliusPPName = referral.probationPractitionerDetails?.nDeliusName,
+        nDeliusPPEmailAddress = referral.probationPractitionerDetails?.nDeliusEmailAddress,
+        nDeliusPDU = referral.probationPractitionerDetails?.nDeliusPDU,
+        ppName = referral.probationPractitionerDetails?.name,
+        ppEmailAddress = referral.probationPractitionerDetails?.emailAddress,
+        pdu = referral.probationPractitionerDetails?.pdu,
+        probationOffice = referral.probationPractitionerDetails?.probationOffice!!,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -105,10 +105,10 @@ data class DraftReferralDTO(
         ndeliusPPName = referral.nDeliusPPName,
         ndeliusPPEmailAddress = referral.nDeliusPPEmailAddress,
         ndeliusPDU = referral.nDeliusPPPDU,
-        ppName = referral.name,
-        ppEmailAddress = referral.emailAddress,
-        ppPdu = referral.pdu,
-        ppProbationOffice = referral.probationOffice,
+        ppName = referral.ppName,
+        ppEmailAddress = referral.ppEmailAddress,
+        ppPdu = referral.ppPdu,
+        ppProbationOffice = referral.ppProbationOffice,
         hasValidDeliusPPDetails = referral.hasValidDeliusPPDetails,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -157,7 +157,7 @@ data class DraftReferralDTO(
         ppName = referral.probationPractitionerDetails?.name,
         ppEmailAddress = referral.probationPractitionerDetails?.emailAddress,
         ppPdu = referral.probationPractitionerDetails?.pdu,
-        ppProbationOffice = referral.probationPractitionerDetails?.probationOffice!!,
+        ppProbationOffice = referral.probationPractitionerDetails?.probationOffice,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
@@ -88,6 +88,14 @@ class DraftReferral(
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "referral_id")
   val referralDetailsHistory: Set<ReferralDetails>? = null,
+
+  @Column(name = "ndelius_pp_name") var nDeliusPPName: String? = null,
+  @Column(name = "ndelius_pp_email_address") var nDeliusPPEmailAddress: String? = null,
+  @Column(name = "ndelius_pp_pdu") var nDeliusPPPDU: String? = null,
+  @Column(name = "pp_name") var name: String? = null,
+  @Column(name = "pp_email_address") var emailAddress: String? = null,
+  @Column(name = "pp_pdu") var pdu: String? = null,
+  @Column(name = "pp_probation_office") var probationOffice: String? = null,
 ) {
   val referralDetails: ReferralDetails? get() {
     return referralDetailsHistory?.firstOrNull { it.supersededById == null }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
@@ -96,6 +96,7 @@ class DraftReferral(
   @Column(name = "pp_email_address") var emailAddress: String? = null,
   @Column(name = "pp_pdu") var pdu: String? = null,
   @Column(name = "pp_probation_office") var probationOffice: String? = null,
+  @Column(name = "valid_delius_pp_details") var hasValidDeliusPPDetails: Boolean? = null,
 ) {
   val referralDetails: ReferralDetails? get() {
     return referralDetailsHistory?.firstOrNull { it.supersededById == null }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
@@ -92,10 +92,10 @@ class DraftReferral(
   @Column(name = "ndelius_pp_name") var nDeliusPPName: String? = null,
   @Column(name = "ndelius_pp_email_address") var nDeliusPPEmailAddress: String? = null,
   @Column(name = "ndelius_pp_pdu") var nDeliusPPPDU: String? = null,
-  @Column(name = "pp_name") var name: String? = null,
-  @Column(name = "pp_email_address") var emailAddress: String? = null,
-  @Column(name = "pp_pdu") var pdu: String? = null,
-  @Column(name = "pp_probation_office") var probationOffice: String? = null,
+  @Column(name = "pp_name") var ppName: String? = null,
+  @Column(name = "pp_email_address") var ppEmailAddress: String? = null,
+  @Column(name = "pp_pdu") var ppPdu: String? = null,
+  @Column(name = "pp_probation_office") var ppProbationOffice: String? = null,
   @Column(name = "valid_delius_pp_details") var hasValidDeliusPPDetails: Boolean? = null,
 ) {
   val referralDetails: ReferralDetails? get() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ProbationPractitionerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ProbationPractitionerDetails.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity
+
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.Id
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "probation_practitioner_details")
+data class ProbationPractitionerDetails(
+  @Id val id: UUID,
+  @OneToOne(fetch = FetchType.LAZY) val referral: Referral,
+  @Column(name = "ndelius_name") var nDeliusName: String?,
+  @Column(name = "ndelius_email_address") var nDeliusEmailAddress: String?,
+  @Column(name = "ndelius_pdu") var nDeliusPDU: String?,
+  @Column(name = "name") var name: String?,
+  @Column(name = "email_address") var emailAddress: String?,
+  @Column(name = "pdu") var pdu: String?,
+  @Column(name = "probation_office") var probationOffice: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ProbationPractitionerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ProbationPractitionerDetails.kt
@@ -19,5 +19,5 @@ data class ProbationPractitionerDetails(
   @Column(name = "name") var name: String?,
   @Column(name = "email_address") var emailAddress: String?,
   @Column(name = "pdu") var pdu: String?,
-  @Column(name = "probation_office") var probationOffice: String,
+  @Column(name = "probation_office") var probationOffice: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -114,6 +114,10 @@ class Referral(
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "referral_id")
   private val referralDetailsHistory: Set<ReferralDetails>? = null,
+
+  @OneToOne(mappedBy = "referral")
+  @Fetch(JOIN)
+  var probationPractitionerDetails: ProbationPractitionerDetails? = null,
 ) {
   val urn: String
     get() = "urn:hmpps:interventions-referral:$id"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ProbationPractitionerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ProbationPractitionerDetailsRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ProbationPractitionerDetails
+import java.util.UUID
+
+interface ProbationPractitionerDetailsRepository : JpaRepository<ProbationPractitionerDetails, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -170,13 +170,15 @@ class DraftReferralService(
   }
 
   private fun updateProbationPractitionerDetails(referral: DraftReferral, update: DraftReferralDTO) {
-    referral.nDeliusPPName = update.ndeliusPPName
-    referral.nDeliusPPEmailAddress = update.ndeliusPPEmailAddress
-    referral.nDeliusPPPDU = update.ndeliusPDU
-    referral.name = update.ppName
-    referral.emailAddress = update.ppEmailAddress
-    referral.pdu = update.ppPdu
-    referral.probationOffice = update.ppProbationOffice
+    if (update.ndeliusPPName != null || update.ppName != null) {
+      referral.nDeliusPPName = update.ndeliusPPName
+      referral.nDeliusPPEmailAddress = update.ndeliusPPEmailAddress
+      referral.nDeliusPPPDU = update.ndeliusPDU
+      referral.name = update.ppName
+      referral.emailAddress = update.ppEmailAddress
+      referral.pdu = update.ppPdu
+      referral.probationOffice = update.ppProbationOffice
+    }
   }
 
   fun updateDraftReferralDetails(referral: DraftReferral, update: UpdateReferralDetailsDTO, actor: AuthUser): ReferralDetails? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -170,7 +170,7 @@ class DraftReferralService(
   }
 
   private fun updateProbationPractitionerDetails(referral: DraftReferral, update: DraftReferralDTO) {
-    if (update.ndeliusPPName != null || update.ppName != null) {
+    if (update.hasValidDeliusPPDetails != null) {
       referral.nDeliusPPName = update.ndeliusPPName
       referral.nDeliusPPEmailAddress = update.ndeliusPPEmailAddress
       referral.nDeliusPPPDU = update.ndeliusPDU

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -170,13 +170,13 @@ class DraftReferralService(
   }
 
   private fun updateProbationPractitionerDetails(referral: DraftReferral, update: DraftReferralDTO) {
-    referral.nDeliusPPName = update.nDeliusPPName
-    referral.nDeliusPPEmailAddress = update.nDeliusPPEmailAddress
-    referral.nDeliusPPPDU = update.nDeliusPDU
+    referral.nDeliusPPName = update.ndeliusPPName
+    referral.nDeliusPPEmailAddress = update.ndeliusPPEmailAddress
+    referral.nDeliusPPPDU = update.ndeliusPDU
     referral.name = update.ppName
     referral.emailAddress = update.ppEmailAddress
-    referral.pdu = update.pdu
-    referral.probationOffice = update.probationOffice
+    referral.pdu = update.ppPdu
+    referral.probationOffice = update.ppProbationOffice
   }
 
   fun updateDraftReferralDetails(referral: DraftReferral, update: UpdateReferralDetailsDTO, actor: AuthUser): ReferralDetails? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -178,6 +178,7 @@ class DraftReferralService(
       referral.emailAddress = update.ppEmailAddress
       referral.pdu = update.ppPdu
       referral.probationOffice = update.ppProbationOffice
+      referral.hasValidDeliusPPDetails = update.hasValidDeliusPPDetails
     }
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -213,6 +213,8 @@ overrides:
 feature-flags:
   current-location:
     enabled: true
+  save-probation-practitioner-details:
+    enabled: true
 
 appointment:
   ids: 82e2fbbe-1bb4-4967-8ee6-81aa072fd44b

--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -169,4 +169,8 @@ COMMENT ON TABLE referral_location IS 'details about the service user''s current
 
 COMMENT ON TABLE complexity_level IS 'details about the complexity levels of the service category';
 
+COMMENT ON TABLE draft_referral IS 'adding probation practitioner details';
+
+COMMENT ON TABLE probation_practitioner_details IS 'storing the probation practitioner details for a particular referral';
+
 -- some definitions are in V1_34__document_contract_table.sql; needs lifting

--- a/src/main/resources/db/migration/V1_135__create_probation_practitioner_details.sql
+++ b/src/main/resources/db/migration/V1_135__create_probation_practitioner_details.sql
@@ -1,0 +1,23 @@
+CREATE TABLE probation_practitioner_details (
+    id uuid not null,
+    referral_id uuid not null,
+    ndelius_name text,
+    ndelius_email_address text,
+    ndelius_pdu text,
+    name text,
+    email_address text,
+    pdu text,
+    probation_office text,
+    primary key (id),
+    constraint fk_probation_practitioner_details_referral_id foreign key (referral_id) references referral
+);
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','id',FALSE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','referral_id',FALSE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','ndelius_name',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','ndelius_email_address',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','ndelius_pdu',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','name',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','email_address',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','pdu',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','probation_office',TRUE, TRUE);

--- a/src/main/resources/db/migration/V1_136__add_probation_practitioner_details.sql
+++ b/src/main/resources/db/migration/V1_136__add_probation_practitioner_details.sql
@@ -5,7 +5,8 @@ alter table draft_referral
     add column pp_name text,
     add column pp_email_address text,
     add column pp_pdu text,
-    add column pp_probation_office text;
+    add column pp_probation_office text,
+    add column valid_delius_pp_details boolean;
 
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','ndelius_pp_name',TRUE, TRUE);
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','ndelius_pp_email_address',TRUE, TRUE);
@@ -14,3 +15,4 @@ INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_email_address',TRUE, TRUE);
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_pdu',TRUE, TRUE);
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_probation_office',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','valid_delius_pp_details',TRUE, TRUE);

--- a/src/main/resources/db/migration/V1_136__add_probation_practitioner_details.sql
+++ b/src/main/resources/db/migration/V1_136__add_probation_practitioner_details.sql
@@ -1,0 +1,16 @@
+alter table draft_referral
+    add column ndelius_pp_name text,
+    add column ndelius_pp_email_address text,
+    add column ndelius_pp_pdu text,
+    add column pp_name text,
+    add column pp_email_address text,
+    add column pp_pdu text,
+    add column pp_probation_office text;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','ndelius_pp_name',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','ndelius_pp_email_address',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','ndelius_pp_pdu',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_name',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_email_address',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_pdu',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_probation_office',TRUE, TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/IntegrationTestBase.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Dyn
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.NPSRegionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ProbationPractitionerDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralLocationRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
@@ -83,6 +84,9 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var changeLogRepository: ChangelogRepository
 
   @Autowired protected lateinit var referralLocationRepository: ReferralLocationRepository
+
+  @Autowired protected lateinit var probationPractitionerDetailsRepository: ProbationPractitionerDetailsRepository
+
   protected lateinit var setupAssistant: SetupAssistant
 
   @BeforeEach
@@ -110,6 +114,7 @@ abstract class IntegrationTestBase {
       referralDetailsRepository,
       changeLogRepository,
       referralLocationRepository,
+      probationPractitionerDetailsRepository,
     )
     setupAssistant.cleanAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfSe
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.NPSRegion
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ProbationPractitionerDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
@@ -49,6 +50,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Dyn
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.EndOfServiceReportRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.NPSRegionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ProbationPractitionerDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralLocationRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
@@ -64,6 +66,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DynamicFramew
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.EndOfServiceReportOutcomeFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.InterventionFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ProbationPractitionerDetailsFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceProviderFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ServiceUserFactory
@@ -101,6 +104,7 @@ class SetupAssistant(
   private val referralDetailsRepository: ReferralDetailsRepository,
   private val changeLogRepository: ChangelogRepository,
   private val referralLocationRepository: ReferralLocationRepository,
+  private val probationPractitionerDetailsRepository: ProbationPractitionerDetailsRepository,
 ) {
   private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
   private val interventionFactory = InterventionFactory()
@@ -115,6 +119,7 @@ class SetupAssistant(
   private val caseNoteFactory = CaseNoteFactory()
   private val changelogFactory = ChangeLogFactory()
   private val endOfServiceReportOutcomeFactory = EndOfServiceReportOutcomeFactory()
+  private val probationPractitionerDetailsFactory = ProbationPractitionerDetailsFactory()
 
   val serviceCategories = serviceCategoryRepository.findAll().associateBy { it.name }
   val npsRegions = npsRegionRepository.findAll().associateBy { it.id }
@@ -135,6 +140,7 @@ class SetupAssistant(
     appointmentRepository.deleteAll()
     changeLogRepository.deleteAll()
     deleteAllReferralDetails()
+    probationPractitionerDetailsRepository.deleteAll()
     referralRepository.deleteAll()
     draftReferralRepository.deleteAll()
     interventionRepository.deleteAll()
@@ -258,6 +264,7 @@ class SetupAssistant(
     personCurrentLocationType: PersonCurrentLocationType? = null,
     personCustodyPrisonId: String? = null,
     expectedReleaseDate: LocalDate? = null,
+    probationOffice: String? = "probation-office",
   ): DraftReferral {
     return draftReferralRepository.save(
       referralFactory.createDraft(
@@ -271,6 +278,7 @@ class SetupAssistant(
         personCurrentLocationType = personCurrentLocationType,
         personCustodyPrisonId = personCustodyPrisonId,
         expectedReleaseDate = expectedReleaseDate,
+        probationOffice = probationOffice,
       ),
     )
   }
@@ -333,6 +341,7 @@ class SetupAssistant(
     personCurrentLocationType: PersonCurrentLocationType = PersonCurrentLocationType.CUSTODY,
     personCustodyPrisonId: String? = null,
     expectedReleaseDate: LocalDate? = null,
+    probationPractitionerDetails: ProbationPractitionerDetails? = null,
   ): Referral {
     createDraftReferral(
       id = id,
@@ -352,23 +361,15 @@ class SetupAssistant(
         completionDeadline = completionDeadline,
         needsInterpreter = needsInterpreter,
         interpreterLanguage = interpreterLanguage,
+        probationPractitionerDetails = probationPractitionerDetails,
       ),
     )
+    val probationPractitionerDetails = probationPractitionerDetailsFactory.create(referral = referral)
+    probationPractitionerDetailsRepository.save(probationPractitionerDetails)
+    referral.probationPractitionerDetails = probationPractitionerDetails
     referral.supplierAssessment = createSupplierAssessment(referral = referral)
+    referralRepository.save(referral)
     return referral
-  }
-
-  private fun createReferralLocation(referral: Referral, type: PersonCurrentLocationType = PersonCurrentLocationType.CUSTODY, prisonId: String? = "aaa"): ReferralLocation {
-    return referralLocationRepository.save(
-      ReferralLocation(
-        UUID.randomUUID(),
-        referral = referral,
-        type = type,
-        prisonId = prisonId,
-        expectedReleaseDate = null,
-        expectedReleaseDateMissingReason = null,
-      ),
-    )
   }
 
   fun addSupplierAssessmentAppointment(
@@ -466,7 +467,7 @@ class SetupAssistant(
       intervention = intervention,
       createdBy = ppUser,
     )
-    return referralRepository.save(
+    val referral = referralRepository.save(
       referralFactory.createSent(
         id = id,
         intervention = intervention,
@@ -477,6 +478,11 @@ class SetupAssistant(
         completionDeadline = LocalDate.now(),
       ),
     )
+    val probationPractitionerDetails = probationPractitionerDetailsFactory.create(referral = referral)
+    probationPractitionerDetailsRepository.save(probationPractitionerDetails)
+    referral.probationPractitionerDetails = probationPractitionerDetails
+
+    return referralRepository.saveAndFlush(referral)
   }
 
   fun createAssignedReferral(
@@ -520,6 +526,9 @@ class SetupAssistant(
         referenceNumber = referenceNumber,
       ),
     )
+    val probationPractitionerDetails = probationPractitionerDetailsFactory.create(referral = referral)
+    probationPractitionerDetailsRepository.save(probationPractitionerDetails)
+    referral.probationPractitionerDetails = probationPractitionerDetails
     val serviceUser = serviceUserFactory.create(firstName = serviceUserFirstName, lastName = serviceUserLastName, referral = draftReferral)
     draftReferral.serviceUserData = serviceUser
     referral.serviceUserData = serviceUser
@@ -652,6 +661,17 @@ class SetupAssistant(
       expectedReleaseDate = LocalDate.now().plusDays(1),
       expectedReleaseDateMissingReason = null,
     ),
+    probationPractitionerDetails: ProbationPractitionerDetails = ProbationPractitionerDetails(
+      id = UUID.randomUUID(),
+      referral = referral,
+      nDeliusName = "ndelius name",
+      nDeliusEmailAddress = "a.b@xyz.com",
+      nDeliusPDU = "ndeliusPDU",
+      name = "name",
+      emailAddress = "emailAddress",
+      pdu = "pdu",
+      probationOffice = "probation-office",
+    ),
   ): Referral {
     referral.selectedServiceCategories = selectedServiceCategories.toMutableSet()
     // required to satisfy foreign key constrains on desired outcomes and complexity levels
@@ -661,6 +681,7 @@ class SetupAssistant(
     draftReferral.personCurrentLocationType = referralLocation.type
     draftReferral.personCustodyPrisonId = referralLocation.prisonId
     draftReferral.expectedReleaseDate = referralLocation.expectedReleaseDate
+    draftReferral.probationOffice = probationPractitionerDetails.probationOffice
     draftReferralRepository.save(draftReferral)
     referralRepository.saveAndFlush(referral)
 
@@ -676,6 +697,7 @@ class SetupAssistant(
     referral.relevantSentenceId = relevantSentenceId
     referral.whenUnavailable = whenUnavailable
     referral.referralLocation = referralLocation
+    referral.probationPractitionerDetails = probationPractitionerDetails
     return referralRepository.save(referral).also {
       referralLocationRepository.save(referralLocation)
       val details = referralDetailsRepository.save(
@@ -731,6 +753,7 @@ class SetupAssistant(
     personCurrentLocationType: PersonCurrentLocationType? = PersonCurrentLocationType.CUSTODY,
     personCustodyPrisonId: String? = "test",
     expectedReleaseDate: LocalDate? = LocalDate.of(2050, 11, 1),
+    probationOffice: String? = "probation-office",
   ): DraftReferral {
     referral.selectedServiceCategories = selectedServiceCategories.toMutableSet()
     // required to satisfy foreign key constrains on desired outcomes and complexity levels
@@ -751,6 +774,7 @@ class SetupAssistant(
     referral.personCurrentLocationType = personCurrentLocationType
     referral.personCustodyPrisonId = personCustodyPrisonId
     referral.expectedReleaseDate = expectedReleaseDate
+    referral.probationOffice = probationOffice
 
     return draftReferralRepository.save(referral).also {
       val details = referralDetailsRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -681,7 +681,7 @@ class SetupAssistant(
     draftReferral.personCurrentLocationType = referralLocation.type
     draftReferral.personCustodyPrisonId = referralLocation.prisonId
     draftReferral.expectedReleaseDate = referralLocation.expectedReleaseDate
-    draftReferral.probationOffice = probationPractitionerDetails.probationOffice
+    draftReferral.ppProbationOffice = probationPractitionerDetails.probationOffice
     draftReferralRepository.save(draftReferral)
     referralRepository.saveAndFlush(referral)
 
@@ -774,7 +774,7 @@ class SetupAssistant(
     referral.personCurrentLocationType = personCurrentLocationType
     referral.personCustodyPrisonId = personCustodyPrisonId
     referral.expectedReleaseDate = expectedReleaseDate
-    referral.probationOffice = probationOffice
+    referral.ppProbationOffice = probationOffice
 
     return draftReferralRepository.save(referral).also {
       val details = referralDetailsRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -73,7 +73,7 @@ class SampleData {
       supplementaryRiskId: UUID? = null,
       serviceUserData: ServiceUserData = ServiceUserData(),
     ): Referral {
-      return Referral(
+      val referral = Referral(
         serviceUserCRN = crn,
         id = id,
         createdAt = createdAt,
@@ -90,6 +90,21 @@ class SampleData {
         supplementaryRiskId = supplementaryRiskId,
         serviceUserData = serviceUserData,
       )
+
+      val probationPractitionerDetails = ProbationPractitionerDetails(
+        id = UUID.randomUUID(),
+        referral = referral,
+        nDeliusName = "ndelius name",
+        nDeliusEmailAddress = "a.b@xyz.com",
+        nDeliusPDU = "ndeliusPDU",
+        name = "name",
+        emailAddress = "emailAddress",
+        pdu = "pdu",
+        probationOffice = "probation-office",
+      )
+
+      referral.probationPractitionerDetails = probationPractitionerDetails
+      return referral
     }
 
     fun sampleDraftReferral(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -331,6 +331,7 @@ class DraftReferralServiceTest @Autowired constructor(
         ppName = "chris pratt",
         ppEmailAddress = "rr@abc.com",
         ppPdu = "pdu2",
+        hasValidDeliusPPDetails = false,
       )
       draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
       val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
@@ -352,6 +353,7 @@ class DraftReferralServiceTest @Autowired constructor(
         ppName = "chris pratt",
         ppEmailAddress = "rr@abc.com",
         ppPdu = "pdu2",
+        hasValidDeliusPPDetails = true,
       )
       draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
       val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
@@ -373,6 +375,32 @@ class DraftReferralServiceTest @Autowired constructor(
         ndeliusPPName = "chris patt",
         ndeliusPPEmailAddress = "pp@abc.com",
         ndeliusPDU = "pdu1",
+        hasValidDeliusPPDetails = false,
+      )
+      draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
+      val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
+      assertThat(savedDraftReferral).isNotNull
+      assertThat(savedDraftReferral?.id).isEqualTo(sampleDraftReferral.id)
+      assertThat(savedDraftReferral?.nDeliusPPName).isEqualTo("chris patt")
+      assertThat(savedDraftReferral?.nDeliusPPEmailAddress).isEqualTo("pp@abc.com")
+      assertThat(savedDraftReferral?.nDeliusPPPDU).isEqualTo("pdu1")
+      assertThat(savedDraftReferral?.name).isNull()
+      assertThat(savedDraftReferral?.emailAddress).isNull()
+      assertThat(savedDraftReferral?.pdu).isNull()
+    }
+
+    @Test
+    fun `does not updates probation practitioner details in the draft referral when valid Delius PP Details is not set`() {
+      sampleDraftReferral.nDeliusPPName = "chris patt"
+      sampleDraftReferral.nDeliusPPEmailAddress = "pp@abc.com"
+      sampleDraftReferral.nDeliusPPPDU = "pdu1"
+      entityManager.persistAndFlush(sampleDraftReferral)
+
+      val draftReferral = DraftReferralDTO(
+        ndeliusPPName = null,
+        ndeliusPPEmailAddress = null,
+        ndeliusPDU = null,
+        hasValidDeliusPPDetails = null,
       )
       draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
       val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -325,12 +325,12 @@ class DraftReferralServiceTest @Autowired constructor(
       entityManager.persistAndFlush(sampleDraftReferral)
 
       val draftReferral = DraftReferralDTO(
-        nDeliusPPName = "chris patt",
-        nDeliusPPEmailAddress = "pp@abc.com",
-        nDeliusPDU = "pdu1",
+        ndeliusPPName = "chris patt",
+        ndeliusPPEmailAddress = "pp@abc.com",
+        ndeliusPDU = "pdu1",
         ppName = "chris pratt",
         ppEmailAddress = "rr@abc.com",
-        pdu = "pdu2",
+        ppPdu = "pdu2",
       )
       draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
       val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
@@ -351,7 +351,7 @@ class DraftReferralServiceTest @Autowired constructor(
       val draftReferral = DraftReferralDTO(
         ppName = "chris pratt",
         ppEmailAddress = "rr@abc.com",
-        pdu = "pdu2",
+        ppPdu = "pdu2",
       )
       draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
       val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())
@@ -370,9 +370,9 @@ class DraftReferralServiceTest @Autowired constructor(
       entityManager.persistAndFlush(sampleDraftReferral)
 
       val draftReferral = DraftReferralDTO(
-        nDeliusPPName = "chris patt",
-        nDeliusPPEmailAddress = "pp@abc.com",
-        nDeliusPDU = "pdu1",
+        ndeliusPPName = "chris patt",
+        ndeliusPPEmailAddress = "pp@abc.com",
+        ndeliusPDU = "pdu1",
       )
       draftReferralService.updateDraftReferral(sampleDraftReferral, draftReferral)
       val savedDraftReferral = draftReferralService.getDraftReferralForUser(sampleDraftReferral.id, userFactory.create())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceTest.kt
@@ -343,6 +343,7 @@ class DraftReferralServiceTest @Autowired constructor(
       assertThat(savedDraftReferral?.name).isEqualTo("chris pratt")
       assertThat(savedDraftReferral?.emailAddress).isEqualTo("rr@abc.com")
       assertThat(savedDraftReferral?.pdu).isEqualTo("pdu2")
+      assertThat(savedDraftReferral?.hasValidDeliusPPDetails).isFalse
     }
 
     @Test
@@ -365,6 +366,7 @@ class DraftReferralServiceTest @Autowired constructor(
       assertThat(savedDraftReferral?.name).isEqualTo("chris pratt")
       assertThat(savedDraftReferral?.emailAddress).isEqualTo("rr@abc.com")
       assertThat(savedDraftReferral?.pdu).isEqualTo("pdu2")
+      assertThat(savedDraftReferral?.hasValidDeliusPPDetails).isTrue
     }
 
     @Test
@@ -387,6 +389,7 @@ class DraftReferralServiceTest @Autowired constructor(
       assertThat(savedDraftReferral?.name).isNull()
       assertThat(savedDraftReferral?.emailAddress).isNull()
       assertThat(savedDraftReferral?.pdu).isNull()
+      assertThat(savedDraftReferral?.hasValidDeliusPPDetails).isFalse
     }
 
     @Test
@@ -412,6 +415,7 @@ class DraftReferralServiceTest @Autowired constructor(
       assertThat(savedDraftReferral?.name).isNull()
       assertThat(savedDraftReferral?.emailAddress).isNull()
       assertThat(savedDraftReferral?.pdu).isNull()
+      assertThat(savedDraftReferral?.hasValidDeliusPPDetails).isNull()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
+import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -77,6 +78,7 @@ class DraftReferralServiceUnitTest {
   private val referralDetailsRepository: ReferralDetailsRepository = mock()
   private val referralLocationRepository: ReferralLocationRepository = mock()
   private val probationPractitionerDetailsRepository: ProbationPractitionerDetailsRepository = mock()
+  private val telemetryClient: TelemetryClient = mock()
 
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
@@ -109,6 +111,7 @@ class DraftReferralServiceUnitTest {
     draftOasysRiskInformationService,
     referralLocationRepository,
     probationPractitionerDetailsRepository,
+    telemetryClient,
     currentLocationEnabled,
     saveProbationPractitionerDetails,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralServiceUnitTest.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.Aut
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DeliverySessionRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.InterventionRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ProbationPractitionerDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralLocationRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
@@ -75,6 +76,7 @@ class DraftReferralServiceUnitTest {
   private val draftOasysRiskInformationService: DraftOasysRiskInformationService = mock()
   private val referralDetailsRepository: ReferralDetailsRepository = mock()
   private val referralLocationRepository: ReferralLocationRepository = mock()
+  private val probationPractitionerDetailsRepository: ProbationPractitionerDetailsRepository = mock()
 
   private val referralFactory = ReferralFactory()
   private val authUserFactory = AuthUserFactory()
@@ -84,6 +86,7 @@ class DraftReferralServiceUnitTest {
   private val dynamicFrameworkContractFactory = DynamicFrameworkContractFactory()
   private val draftOasysRiskInformationFactory = DraftOasysRiskInformationFactory()
   private var currentLocationEnabled: Boolean = true
+  private var saveProbationPractitionerDetails: Boolean = true
 
   private val draftReferralService = DraftReferralService(
     referralRepository,
@@ -105,7 +108,9 @@ class DraftReferralServiceUnitTest {
     referralDetailsRepository,
     draftOasysRiskInformationService,
     referralLocationRepository,
+    probationPractitionerDetailsRepository,
     currentLocationEnabled,
+    saveProbationPractitionerDetails,
   )
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
@@ -154,7 +154,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
       complexityLevelIds = complexityLevelIds,
       additionalRiskInformation = additionalRiskInformation,
       additionalRiskInformationUpdatedAt = additionalRiskInformationUpdatedAt,
-      probationOffice = probationOffice,
+      ppProbationOffice = probationOffice,
       referralDetailsHistory = if (referralDetails != null) {
         setOf(
           referralDetails.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftRe
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ProbationPractitionerDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
@@ -57,6 +58,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
     interpreterLanguage: String? = null,
     completionDeadline: LocalDate? = null,
     maximumEnforceableDays: Int? = null,
+    probationPractitionerDetails: ProbationPractitionerDetails? = null,
   ): Referral {
     val referral = save(
       Referral(
@@ -90,6 +92,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
         additionalNeedsInformation = additionalNeedsInformation,
         needsInterpreter = needsInterpreter,
         interpreterLanguage = interpreterLanguage,
+        probationPractitionerDetails = probationPractitionerDetails,
         referralDetailsHistory = if (referralDetails != null) {
           setOf(
             referralDetails.let {
@@ -134,6 +137,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
     personCurrentLocationType: PersonCurrentLocationType? = null,
     personCustodyPrisonId: String? = null,
     expectedReleaseDate: LocalDate? = null,
+    probationOffice: String? = null,
   ): DraftReferral {
     val draftReferral = DraftReferral(
       id = id,
@@ -150,6 +154,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
       complexityLevelIds = complexityLevelIds,
       additionalRiskInformation = additionalRiskInformation,
       additionalRiskInformationUpdatedAt = additionalRiskInformationUpdatedAt,
+      probationOffice = probationOffice,
       referralDetailsHistory = if (referralDetails != null) {
         setOf(
           referralDetails.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ProbationPractitionerDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ProbationPractitionerDetailsFactory.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ProbationPractitionerDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
+import java.util.UUID
+
+class ProbationPractitionerDetailsFactory(em: TestEntityManager? = null) : EntityFactory(em) {
+
+  fun create(
+    id: UUID? = UUID.randomUUID(),
+    referral: Referral,
+    nDeliusName: String = "delius name",
+    nDeliusEmailAddress: String = "a.b@xyz.com",
+    nDeliusPdu: String = "pdu1",
+    name: String = "user name",
+    emailAddress: String = "c.d@xyz.com",
+    pdu: String = "pdu2",
+    probationOffice: String = "probation-office",
+  ): ProbationPractitionerDetails {
+    return save(
+      ProbationPractitionerDetails(
+        id = id ?: UUID.randomUUID(),
+        referral = referral,
+        nDeliusName = nDeliusName,
+        nDeliusEmailAddress = nDeliusEmailAddress,
+        nDeliusPDU = nDeliusPdu,
+        name = name,
+        emailAddress = emailAddress,
+        pdu = pdu,
+        probationOffice = probationOffice,
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DraftRe
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ProbationPractitionerDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
@@ -24,6 +25,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
   private val interventionFactory = InterventionFactory(em)
   private val cancellationReasonFactory = CancellationReasonFactory(em)
   private val referalDetailsFactory = ReferralDetailsFactory(em)
+  private val probationPractitionerDetailsFactory = ProbationPractitionerDetailsFactory(em)
 
   fun createDraft(
     id: UUID = UUID.randomUUID(),
@@ -43,6 +45,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     personCurrentLocationType: PersonCurrentLocationType? = null,
     personCustodyPrisonId: String? = null,
     expectedReleaseDate: LocalDate? = null,
+    probationOffice: String? = "probation-office1",
   ): DraftReferral {
     return createDraftReferral(
       id = id,
@@ -60,6 +63,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       personCurrentLocationType = personCurrentLocationType,
       personCustodyPrisonId = personCustodyPrisonId,
       expectedReleaseDate = expectedReleaseDate,
+      probationOffice = probationOffice,
     )
   }
 
@@ -92,7 +96,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     referralDetail: ReferralDetails? = null,
     needsInterpreter: Boolean? = null,
     interpreterLanguage: String? = null,
-
+    probationPractitionerDetails: ProbationPractitionerDetails? = null,
   ): Referral {
     if (createDraft) {
       createDraft(
@@ -103,7 +107,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
         intervention = intervention,
       )
     }
-    return createReferral(
+    val referral = createReferral(
       id = id,
       createdAt = createdAt,
       createdBy = createdBy,
@@ -131,7 +135,13 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       additionalNeedsInformation = additionalNeedsInformation,
       needsInterpreter = needsInterpreter,
       interpreterLanguage = interpreterLanguage,
+      probationPractitionerDetails = probationPractitionerDetails,
     )
+    val probationPractitionerDetails = probationPractitionerDetailsFactory.create(referral = referral)
+
+    referral.probationPractitionerDetails = probationPractitionerDetails
+    save(referral)
+    return referral
   }
 
   fun createAssigned(
@@ -165,7 +175,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       intervention = intervention,
       selectedServiceCategories = selectedServiceCategories,
     )
-    return createReferral(
+    val referral = createReferral(
       id = id,
       createdAt = createdAt,
       createdBy = createdBy,
@@ -185,6 +195,10 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       supplierAssessment = supplierAssessment,
       serviceUserData = serviceUserData,
     )
+    val probationPractitionerDetails = probationPractitionerDetailsFactory.create(referral = referral)
+    referral.probationPractitionerDetails = probationPractitionerDetails
+    save(referral)
+    return referral
   }
 
   fun createEnded(
@@ -222,7 +236,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       intervention = intervention,
       selectedServiceCategories = selectedServiceCategories,
     )
-    return createReferral(
+    val referral = createReferral(
       id = id,
       createdAt = createdAt,
       createdBy = createdBy,
@@ -250,5 +264,9 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
 
       endOfServiceReport = endOfServiceReport,
     )
+    val probationPractitionerDetails = probationPractitionerDetailsFactory.create(referral = referral)
+    referral.probationPractitionerDetails = probationPractitionerDetails
+    save(referral)
+    return referral
   }
 }


### PR DESCRIPTION
## What does this pull request do?

- captures the probation practitioner details during the draft stage
- saves the probation practitioner details when the referral is changed from draft to live referral

## What is the intent behind these changes?

- For making a referral for a community with COM, we need save the probation practitioner details
