### PR TITLE
Add branching to handle SAA appointments when linking superseded

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/linksupersededappoinments/LinkSupersededAppointmentsProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/linksupersededappoinments/LinkSupersededAppointmentsProcessorTest.kt
@@ -17,6 +17,7 @@ class LinkSupersededAppointmentsProcessorTest : IntegrationTestBase() {
     appointmentCleaner = AppointmentCleaner(
       appointmentRepository,
       deliverySessionRepository,
+      supplierAssessmentRepository,
     )
     processor = LinkSupersededAppointmentsProcessor(appointmentCleaner)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/markstaleappoinments/MarkStaleAppointmentsProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/markstaleappoinments/MarkStaleAppointmentsProcessorTest.kt
@@ -17,6 +17,7 @@ class MarkStaleAppointmentsProcessorTest : IntegrationTestBase() {
     appointmentCleaner = AppointmentCleaner(
       appointmentRepository,
       deliverySessionRepository,
+      supplierAssessmentRepository,
     )
     processor = MarkStaleAppointmentsProcessor(appointmentCleaner)
   }


### PR DESCRIPTION
## What does this pull request do?

Adds logic to handle linking of SAA appointments

## What is the intent behind these changes?

Ensure all superseded appointments have a linked appointment so constraints can be applied preventing duplicates
