### PR TITLE
Add a guard condition / logging to cope with exceptional appointment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentCleaner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentCleaner.kt
@@ -53,6 +53,12 @@ class AppointmentCleaner(
       val targetDeliverySession = targetDeliverySessionList.get(0)
       val sortedAppointmentFromDeliverySession = targetDeliverySession.appointments.sortedBy { it.createdAt }
       val nextAppointmentIndex = sortedAppointmentFromDeliverySession.indexOf(currentAppointment) + 1
+
+      if (nextAppointmentIndex > sortedAppointmentFromDeliverySession.lastIndex) {
+        logger.info("superseded delivery appointment ${currentAppointment.id} has no appointments created after it, skipping")
+        return null
+      }
+
       return sortedAppointmentFromDeliverySession.get(nextAppointmentIndex)
     } else {
       // supplier assessment appointments
@@ -62,6 +68,12 @@ class AppointmentCleaner(
       if (supplierAssessment != null) {
         val sortedAppointmentFromSupplierAssessment = supplierAssessment.appointments.sortedBy { it.createdAt }
         val nextAppointmentIndex = sortedAppointmentFromSupplierAssessment.indexOf(currentAppointment) + 1
+
+        if (nextAppointmentIndex > sortedAppointmentFromSupplierAssessment.lastIndex) {
+          logger.info("superseded supplier assessement appointment ${currentAppointment.id} has no appointments created after it, skipping")
+          return null
+        }
+
         return sortedAppointmentFromSupplierAssessment.get(nextAppointmentIndex)
       } else {
         logger.info("unable to find delivery session or supplier assessment for superseded appointment ${currentAppointment.id}")


### PR DESCRIPTION
Add a guard condition / logging to cope with exceptional appointment records

## What does this pull request do?

Adds a guard condition to linkSupersededAppointments job

Specifically where superseded appointment has created timestamp after the appointment that supersedes it...

## What is the intent behind these changes?

Cope with / flag data that requires more detailed analysis and rectification, prevent failures in link superseded job runs.
