### PR TITLE
Set parallelism to 1 for batch jobs to avoid locking issues

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/job-link-superseded-appointments.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-link-superseded-appointments.yaml
@@ -9,6 +9,7 @@ spec:
       template:
         spec:
           restartPolicy: "Never"
+          parallelism: 1
           containers:
             - name: link-superseded-appointments
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm_deploy/hmpps-interventions-service/templates/job-mark-stale-appointments.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-mark-stale-appointments.yaml
@@ -9,6 +9,7 @@ spec:
       template:
         spec:
           restartPolicy: "Never"
+          parallelism: 1
           containers:
             - name: mark-stale-appointments
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## What does this pull request do?

Sets parallelism to 1 for both cleanup jobs

## What is the intent behind these changes?

Prevent multiple clients from attempting to update the same record.
