### PR TITLE
Use alternative method to get supplierAssessment object

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SupplierAssessmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SupplierAssessmentRepository.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import java.util.UUID
 
-interface SupplierAssessmentRepository : JpaRepository<SupplierAssessment, UUID>
+interface SupplierAssessmentRepository : JpaRepository<SupplierAssessment, UUID> {
+  fun findByReferral(referral: Referral): SupplierAssessment
+}
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SupplierAssessmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/SupplierAssessmentRepository.kt
@@ -8,4 +8,3 @@ import java.util.UUID
 interface SupplierAssessmentRepository : JpaRepository<SupplierAssessment, UUID> {
   fun findByReferral(referral: Referral): SupplierAssessment
 }
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentCleaner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentCleaner.kt
@@ -63,7 +63,7 @@ class AppointmentCleaner(
     } else {
       // supplier assessment appointments
       val referraL = currentAppointment.referral
-      val supplierAssessment = referraL.supplierAssessment
+      val supplierAssessment = supplierAssessmentRepository.findByReferral(referraL)
 
       if (supplierAssessment != null) {
         val sortedAppointmentFromSupplierAssessment = supplierAssessment.appointments.sortedBy { it.createdAt }


### PR DESCRIPTION
in the cleaner due to nulls from previous call

## What does this pull request do?

Changes method of getting supplier assessment from a referral id in the cleaner job

## What is the intent behind these changes?

Mark records with a superseded record which were previously null
