### PR TITLE
PI-1135

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SNSService.kt
@@ -206,15 +206,15 @@ class SNSAppointmentService(
           "Session feedback submitted for an initial assessment appointment",
           event.detailUrl,
           appointment.appointmentFeedbackSubmittedAt!!,
-          mapOf(
+          listOfNotNull(
             "serviceUserCRN" to referral.serviceUserCRN,
             "referralId" to referral.id,
             "referralReference" to referral.referenceNumber!!,
             "contractTypeName" to contractTypeName,
             "primeProviderName" to primeProviderName,
-            "deliusAppointmentId" to appointment.deliusAppointmentId.toString(),
+            appointment.deliusAppointmentId?.let { "deliusAppointmentId" to it.toString() },
             "referralProbationUserURL" to url,
-          ),
+          ).toMap(),
           PersonReference.crn(referral.serviceUserCRN),
         )
 


### PR DESCRIPTION
## What does this pull request do?

only sends delius id when non null - allows event to be raised with records that don't have one

## What is the intent behind these changes?

allows us to process some existing appointments without a delius id and allows easier transition when no longer required
