### PR TITLE
PI-1166 switch to RAM API for remaining read calls

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,16 +139,14 @@ interventions-ui:
 
 refer-and-monitor-and-delius:
   locations:
-    referral-start: "/probation-case/{crn}/referrals"
     appointment-merge: "/probation-case/{crn}/referrals/{referralId}/appointments"
+    case-access: "/users/{username}/access"
+    case-identifiers: "/probation-case/{crn}/identifiers"
+    managed-cases: "/users/{username}/managed-cases"
+    referral-start: "/probation-case/{crn}/referrals"
     responsible-officer: "/probation-case/{crn}/responsible-officer"
 
 community-api:
-  locations:
-    offender-access: "/secure/offenders/crn/{crn}/user/{username}/userAccess"
-    managed-offenders: "/secure/staff/staffIdentifier/{staffIdentifier}/managedOffenders"
-    staff-details: "/secure/staff/username/{username}"
-    offender-identifiers: "/secure/offenders/crn/{crn}/identifiers"
   appointments:
     bookings:
       enabled: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
@@ -22,7 +22,6 @@ internal class CaseNotesNotificationsServiceTest {
   private val referralService = mock<ReferralService>()
   private val emailSender = mock<EmailSender>()
   private val hmppsAuthService = mock<HMPPSAuthService>()
-  private val communityAPIOffenderService = mock<CommunityAPIOffenderService>()
 
   private val caseNotesNotificationsService = CaseNotesNotificationsService(
     "sent-template",
@@ -88,7 +87,6 @@ internal class CaseNotesNotificationsServiceTest {
       ResponsibleProbationPractitioner("pp", "pp@justice.gov.uk", "N01UTAA", null, "last"),
     )
     whenever(referralService.isUserTheResponsibleOfficer(any(), any())).thenReturn(true)
-    whenever(communityAPIOffenderService.getStaffIdentifier(any())).thenReturn(123L)
 
     val sender = authUserFactory.createPP(id = "pp_sender")
     val referral = referralFactory.createAssigned()


### PR DESCRIPTION
## What does this pull request do?

Switches the remaining calls to Community API to read data from the R&M&D API

## What is the intent behind these changes?

Move away from deprecated endpoints in Community API
The minimal changes have been made to reduce changes elsewhere in the codebase, ie even though the response may not match exactly that from community api - the service converts the model before returning in order to keep remaining code the same.
