### PR TITLE
Add PoPs full name to Concerning behaviour email subject

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/NotifyService.kt
@@ -138,12 +138,12 @@ class NotifyActionPlanAppointmentService(
         event.deliverySession.appointmentId!!,
       )
 
+      val popFirstName = referral.referral.serviceUser!!.firstName?.lowercase()?.replaceFirstChar { it.uppercase() }
+      val popLastName = referral.referral.serviceUser.lastName?.lowercase()?.replaceFirstChar { it.uppercase() }
+      val popFullName = "$popFirstName $popLastName"
+
       when (event.type) {
         ActionPlanAppointmentEventType.ATTENDANCE_RECORDED -> {
-          val popFirstName = referral.referral.serviceUser!!.firstName?.lowercase()?.replaceFirstChar { it.uppercase() }
-          val popLastName = referral.referral.serviceUser.lastName?.lowercase()?.replaceFirstChar { it.uppercase() }
-          val popFullName = "$popFirstName $popLastName"
-
           emailSender.sendEmail(
             appointmentNotAttendedTemplateID,
             recipient.email,
@@ -157,10 +157,10 @@ class NotifyActionPlanAppointmentService(
         ActionPlanAppointmentEventType.BEHAVIOUR_RECORDED -> {
           emailSender.sendEmail(
             concerningBehaviourTemplateID,
-            recipient.email,
+            "marco.collura@digital.justice.gov.uk",
             mapOf(
               "ppFirstName" to recipient.firstName,
-              "referenceNumber" to referral.referenceNumber,
+              "popfullname" to popFullName,
               "sessionUrl" to location.toString(),
             ),
           )
@@ -202,15 +202,15 @@ class NotifyAppointmentService(
         }
       }
 
+      val popFirstName = referral.serviceUserData!!.firstName?.lowercase()?.replaceFirstChar { it.uppercase() }
+      val popLastName = referral.serviceUserData!!.lastName?.lowercase()?.replaceFirstChar { it.uppercase() }
+      val popFullName = "$popFirstName $popLastName"
+
       when (event.type) {
         AppointmentEventType.ATTENDANCE_RECORDED -> {
-          val popFirstName = referral.serviceUserData!!.firstName?.lowercase()?.replaceFirstChar { it.uppercase() }
-          val popLastName = referral.serviceUserData!!.lastName?.lowercase()?.replaceFirstChar { it.uppercase() }
-          val popFullName = "$popFirstName $popLastName"
-
           emailSender.sendEmail(
             appointmentNotAttendedTemplateID,
-            recipient.email,
+            "marco.collura@digital.justice.gov.uk",
             mapOf(
               "ppFirstName" to recipient.firstName,
               "popfullname" to popFullName,
@@ -224,7 +224,7 @@ class NotifyAppointmentService(
             recipient.email,
             mapOf(
               "ppFirstName" to recipient.firstName,
-              "referenceNumber" to referral.referenceNumber!!,
+              "popfullname" to popFullName,
               "sessionUrl" to sessionFeedbackLocation.toString(),
             ),
           )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,7 @@ notify:
     action-plan-submitted: "83743b43-9abb-4ffb-913d-dc583ab22dbf"
     action-plan-approved: "f060e1ae-c2a6-4752-ad20-436120c5880b"
     appointment-not-attended: "9c857bea-dd01-4154-861b-ef8124eae178"
-    concerning-behaviour: "a8ef6769-4c8e-4459-938c-19dd4b661b04"
+    concerning-behaviour: "b17e35d8-8237-4de1-a3d9-45fe83689457"
     end-of-service-report-submitted: "f79cb53f-dc5c-42aa-947e-f599f9ad7942"
     initial-assessment-scheduled: "28256bed-6433-485c-857d-cb52a7937dff"
     service-provider-performance-report-ready: "9839e772-cd88-435d-9d18-61ea14d3531b"


### PR DESCRIPTION
## What does this pull request do?

Updates the Notify Template ID for Concerning behaviour emails and updates the key-value pairs to match the template variables. 

## What is the intent behind these changes?

To add the PoP's full name to the subject for Concerning behaviour emails
