### PR TITLE
migrating to hmpps-manage-users from hmpps-auth for external users API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,56 @@ services:
     networks:
       - hmpps
     container_name: hmpps-auth
+    depends_on:
+      - auth-db
     ports:
-      - "8090:8090"
+      - '8090:8090'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8090/auth/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8090/auth/health']
     environment:
       - SERVER_PORT=8090
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev,delius,local-postgres
       - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
+      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
+
+  hmpps-manage-users:
+    image: quay.io/hmpps/hmpps-manage-users-api:latest
+    networks:
+      - hmpps
+    container_name: hmpps-manage-users
+    depends_on:
+      - hmpps-auth
+      - hmpps-external-users-api
+    ports:
+      - "8096:8096"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8096/health" ]
+    environment:
+      - SERVER_PORT=8096
+      - HMPPS_AUTH_ENDPOINT_URL=http://hmpps-auth:8090/auth
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8090/auth
+      - SPRING_PROFILES_ACTIVE=dev
+      - EXTERNAL_USERS_ENDPOINT_URL=http://hmpps-external-users-api:8098
+
+  hmpps-external-users-api:
+    image: quay.io/hmpps/hmpps-external-users-api:latest
+    networks:
+      - hmpps
+    container_name: hmpps-external-users-api
+    depends_on:
+      - auth-db
+      - hmpps-auth
+    ports:
+      - "8098:8098"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8098/health/ping"]
+    environment:
+      - SERVER_PORT=8098
+      - SPRING_PROFILES_ACTIVE=dev,local-postgres
+      - SPRING_R2DBC_URL=r2dbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
+      - SPRING_FLYWAY_URL=jdbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8090/auth
 
   assess-risks-and-needs:
     image: quay.io/hmpps/hmpps-assess-risks-and-needs:latest
@@ -36,6 +78,21 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - ./src/main/resources/db/local/init:/docker-entrypoint-initdb.d:ro
+
+  auth-db:
+    image: postgres:15
+    networks:
+      - hmpps
+    container_name: auth-db
+    restart: always
+    ports:
+      - "5434:5432"
+    environment:
+      - POSTGRES_PASSWORD=admin_password
+      - POSTGRES_USER=admin
+      - POSTGRES_DB=auth-db
+    healthcheck:
+      test: pg_isready -d auth-db
 
   wiremock:
     image: wiremock/wiremock:2.35.0

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,7 @@ env_details:
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+  MANAGEUSERS_BASEURL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   REFERANDMONITORANDDELIUS_BASEURL: "https://refer-and-monitor-and-delius-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,6 +24,7 @@ env_details:
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+  MANAGEUSERS_BASEURL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
   INTERVENTIONSUI_BASEURL: "https://hmpps-interventions-ui-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
   REFERANDMONITORANDDELIUS_BASEURL: "https://refer-and-monitor-and-delius-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,6 +22,7 @@ env_details:
 
 env:
   HMPPSAUTH_BASEURL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+  MANAGEUSERS_BASEURL: "https://manage-users-api.hmpps.service.justice.gov.uk"
   INTERVENTIONSUI_BASEURL: "https://refer-monitor-intervention.service.justice.gov.uk"
   COMMUNITYAPI_BASEURL: "https://community-api-secure.probation.service.justice.gov.uk"
   REFERANDMONITORANDDELIUS_BASEURL: "https://refer-and-monitor-and-delius.hmpps.service.justice.gov.uk"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/WebClientConfiguration.kt
@@ -24,9 +24,12 @@ class WebClientConfiguration(
   @Value("\${webclient.read-timeout-seconds}") private val defaultReadTimeoutSeconds: Int,
   @Value("\${webclient.hmpps-auth.read-timeout-seconds}") private val hmppsReadTimeoutSeconds: Int,
   @Value("\${webclient.hmpps-auth.connect-timeout-seconds}") private val hmppsAuthConnectTimeoutSeconds: Long,
+  @Value("\${webclient.manage-users.read-timeout-seconds}") private val manageUsersReadTimeoutSeconds: Int,
+  @Value("\${webclient.manage-users.connect-timeout-seconds}") private val manageUsersAuthConnectTimeoutSeconds: Long,
   @Value("\${webclient.write-timeout-seconds}") private val writeTimeoutSeconds: Int,
   @Value("\${community-api.baseurl}") private val communityApiBaseUrl: String,
   @Value("\${hmppsauth.baseurl}") private val hmppsAuthBaseUrl: String,
+  @Value("\${manage-users.baseurl}") private val manageUsersAuthBaseUrl: String,
   @Value("\${assess-risks-and-needs.baseurl}") private val assessRisksAndNeedsBaseUrl: String,
   @Value("\${prisoner-offender-search.baseurl}") private val prisonerOffenderSearchApiUrl: String,
   @Value("\${refer-and-monitor-and-delius.baseurl}") private val ramDelius: String,
@@ -47,6 +50,14 @@ class WebClientConfiguration(
   fun hmppsAuthApiClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
     return RestClient(
       createAuthorizedWebClient(authorizedClientManager, hmppsAuthBaseUrl, hmppsReadTimeoutSeconds, hmppsAuthConnectTimeoutSeconds),
+      interventionsClientRegistrationId,
+    )
+  }
+
+  @Bean
+  fun mangeUsersAuthApiClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
+    return RestClient(
+      createAuthorizedWebClient(authorizedClientManager, manageUsersAuthBaseUrl, manageUsersReadTimeoutSeconds, manageUsersAuthConnectTimeoutSeconds),
       interventionsClientRegistrationId,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
@@ -62,7 +62,7 @@ class HMPPSAuthService(
 
   fun getUserGroups(user: AuthUser): List<AuthGroupID>? {
     val url = UriComponentsBuilder.fromPath(authUserGroupsLocation)
-      .buildAndExpand(user.userName)
+      .buildAndExpand(user.id)
       .toString()
 
     return mangeUsersAuthApiClient.get(url)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/HMPPSAuthService.kt
@@ -51,12 +51,12 @@ private data class UserDetailResponse(
 @Service
 @Transactional
 class HMPPSAuthService(
-  @Value("\${hmppsauth.api.locations.auth-user-groups}") private val authUserGroupsLocation: String,
-  @Value("\${hmppsauth.api.locations.auth-user-detail}") private val authUserDetailLocation: String,
-  @Value("\${hmppsauth.api.locations.user-email}") private val userEmailLocation: String,
-  @Value("\${hmppsauth.api.locations.user-detail}") private val userDetailLocation: String,
+  @Value("\${manage-users.api.locations.auth-user-groups}") private val authUserGroupsLocation: String,
+  @Value("\${manage-users.api.locations.auth-user-detail}") private val authUserDetailLocation: String,
+  @Value("\${manage-users.api.locations.user-email}") private val userEmailLocation: String,
+  @Value("\${manage-users.api.locations.user-detail}") private val userDetailLocation: String,
   @Value("\${webclient.hmpps-auth.max-retry-attempts}") private val maxRetryAttempts: Long,
-  private val hmppsAuthApiClient: RestClient,
+  private val mangeUsersAuthApiClient: RestClient,
 ) {
   companion object : KLogging()
 
@@ -65,7 +65,7 @@ class HMPPSAuthService(
       .buildAndExpand(user.userName)
       .toString()
 
-    return hmppsAuthApiClient.get(url)
+    return mangeUsersAuthApiClient.get(url)
       .retrieve()
       .onStatus({ HttpStatus.NOT_FOUND == it }, { Mono.just(null) })
       .bodyToFlux(AuthGroupResponse::class.java)
@@ -81,7 +81,7 @@ class HMPPSAuthService(
   fun getUserDetail(user: AuthUserDTO): UserDetail {
     return if (user.authSource == "auth") {
       val url = UriComponentsBuilder.fromPath(authUserDetailLocation).buildAndExpand(user.username).toString()
-      hmppsAuthApiClient.get(url)
+      mangeUsersAuthApiClient.get(url)
         .retrieve()
         .bodyToMono(AuthUserDetailResponse::class.java)
         .withRetryPolicy()
@@ -96,12 +96,12 @@ class HMPPSAuthService(
       val detailUrl = UriComponentsBuilder.fromPath(userDetailLocation).buildAndExpand(user.username).toString()
       val emailUrl = UriComponentsBuilder.fromPath(userEmailLocation).buildAndExpand(user.username).toString()
       Mono.zip(
-        hmppsAuthApiClient.get(detailUrl)
+        mangeUsersAuthApiClient.get(detailUrl)
           .retrieve()
           .bodyToMono(UserDetailResponse::class.java)
           .withRetryPolicy()
           .map { Pair(it.name.substringBefore(' '), it.name.substringAfterLast(' ')) },
-        hmppsAuthApiClient.get(emailUrl)
+        mangeUsersAuthApiClient.get(emailUrl)
           .retrieve()
           .onStatus({ it.equals(HttpStatus.NO_CONTENT) }, { Mono.error(UnverifiedEmailException()) })
           .bodyToMono(UserEmailResponse::class.java)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,6 +50,8 @@ aws:
 
 hmppsauth:
   baseurl: http://hmpps-auth:8090/auth
+manage-users:
+  baseurl: http://manage-users:8095/auth
 
 postgres:
   uri: localhost:5432

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -51,7 +51,7 @@ aws:
 hmppsauth:
   baseurl: http://hmpps-auth:8090/auth
 manage-users:
-  baseurl: http://manage-users:8095/auth
+  baseurl: http://hmpps-manage-users:8096
 
 postgres:
   uri: localhost:5432

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,13 +165,13 @@ community-api:
       enabled: true
   integration-context: commissioned-rehabilitation-services
 
-hmppsauth:
+manage-users:
   api:
     locations:
-      auth-user-groups: "/api/authuser/{username}/groups"
-      auth-user-detail: "/api/authuser/{username}"
-      user-email: "/api/user/{username}/email"
-      user-detail: "/api/user/{username}"
+      auth-user-groups: "/externalusers/{userId}/groups"
+      auth-user-detail: "/externalusers/{username}"
+      user-email: "/users/{username}/email"
+      user-detail: "/users/{username}"
 
 assess-risks-and-needs:
   locations:
@@ -199,6 +199,10 @@ webclient:
   read-timeout-seconds: 10
   write-timeout-seconds: 10
   hmpps-auth:
+    max-retry-attempts: 2
+    connect-timeout-seconds: 20
+    read-timeout-seconds: 3
+  manage-users:
     max-retry-attempts: 2
     connect-timeout-seconds: 20
     read-timeout-seconds: 3


### PR DESCRIPTION
## What does this pull request do?

- configure hmpps-manage-users to authenticate and authorise external users

## What is the intent behind these changes?

- hmpps-auth has been rearchitected which caused their api is to be split into multiple apis.
