### PR TITLE
upgrading hmpps-gradle-spring-boot to 4.10.0-beta

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.9.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.10.0-beta"
   kotlin("plugin.spring") version "1.9.0"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.0"
   id("jacoco")
@@ -98,9 +98,9 @@ dependencies {
   implementation("software.amazon.awssdk:s3:2.20.116")
 
   // security
-  implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-webflux:2.7.14")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server:2.7.14")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-client:2.7.14")
   implementation("com.nimbusds:oauth2-oidc-sdk:10.12")
 
   // database


### PR DESCRIPTION
## What does this pull request do?

- Upgrading the hmpps gradle spring boot to 4.10.0-beta

## What is the intent behind these changes?

- This is done to rectify the vulnerability issue (https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/12246/workflows/3662b955-9a02-4cdd-a852-0312350f944f/jobs/52566)
