### PR TITLE
Log invalid assumptions instead of throwing InvalidAssumptionErrors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/ErrorConfiguration.kt
@@ -43,8 +43,6 @@ class ValidationError(override val message: String, val errors: List<FieldError>
 
 class AccessError(val user: AuthUser, override val message: String, val errors: List<String>) : RuntimeException(message)
 
-class InvalidAssumptionError(assumption: String) : RuntimeException("assumption proved invalid: $assumption")
-
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
   val status: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/TelemetryService.kt
@@ -1,13 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 
 import com.microsoft.applicationinsights.TelemetryClient
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.InvalidAssumptionError
 
 @Service
 class TelemetryService(
   private val telemetryClient: TelemetryClient,
 ) {
+  companion object {
+    private val logger = KotlinLogging.logger {}
+  }
   fun reportInvalidAssumption(assumption: String, information: Map<String, String> = emptyMap(), recoverable: Boolean = true) {
     telemetryClient.trackEvent(
       "InterventionsInvalidAssumption",
@@ -16,7 +19,7 @@ class TelemetryService(
     )
 
     if (!recoverable) {
-      throw InvalidAssumptionError(assumption)
+      logger.warn("assumption proved invalid: $assumption")
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Logs invalid assumptions instead of throwing InvalidAssumptionErrors

## What is the intent behind these changes?

To prevent Sentry alerts for invalid assumptions which can lead to alert fatigue
