### PR TITLE
fixing NPE exception when emailing for concluded events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralConcludedListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/listeners/ReferralConcludedListener.kt
@@ -46,15 +46,17 @@ class ReferralConcludedNotificationListener(
   override fun onApplicationEvent(event: ReferralConcludedEvent) {
     when (event.type) {
       ReferralConcludedState.CANCELLED -> {
-        val userDetails = hmppsAuthService.getUserDetail(event.referral.currentAssignee!!)
-        emailSender.sendEmail(
-          cancelledReferralTemplateID,
-          userDetails.email,
-          mapOf(
-            "sp_first_name" to userDetails.firstName,
-            "referral_number" to event.referral.referenceNumber!!,
-          ),
-        )
+        event.referral.currentAssignee?.let {
+          val userDetails = hmppsAuthService.getUserDetail(event.referral.currentAssignee!!)
+          emailSender.sendEmail(
+            cancelledReferralTemplateID,
+            userDetails.email,
+            mapOf(
+              "sp_first_name" to userDetails.firstName,
+              "referral_number" to event.referral.referenceNumber!!,
+            ),
+          )
+        }
       }
       ReferralConcludedState.PREMATURELY_ENDED,
       ReferralConcludedState.COMPLETED,


### PR DESCRIPTION
## What does this pull request do?

- checks if the current assignee is present before sending an email to them

## What is the intent behind these changes?

- conclude events can be called when the user is not assigned as well.
- so the check needs to be done if the user is assigned before the email is sent
- There are around 21K errors due to this issue (https://ministryofjustice.sentry.io/issues/4172206305/events/0fab206c85804c3ca335b846a7df53a2/events/?project=5807819)
