### PR TITLE
changing the slack notification channel name for prod releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: interventions-dev-notifications
   releases-slack-channel:
     type: string
-    default: interventions
+    default: interventions-team
 
 orbs:
   hmpps: ministryofjustice/hmpps@7.3.3


### PR DESCRIPTION
## What does this pull request do?

- updates the slack channel notification name to _interventions-team_ 

## What is the intent behind these changes?

- The name of the slack channel where prod notification goes changed
