### PR TITLE
Ipb 682/migrate to aws irsa

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
   // aws
   implementation("software.amazon.awssdk:sns:2.20.122")
   implementation("software.amazon.awssdk:s3:2.20.122")
+  implementation("software.amazon.awssdk:sts:2.20.121")
 
   // security
   implementation("org.springframework.boot:spring-boot-starter-webflux:3.1.2")

--- a/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs.tpl
@@ -54,18 +54,6 @@ env:
         name: postgres14
         key: database_password
 
-  - name: AWS_SNS_ACCESSKEYID
-    valueFrom:
-      secretKeyRef:
-        name: hmpps-domain-events-topic
-        key: access_key_id
-
-  - name: AWS_SNS_SECRETACCESSKEY
-    valueFrom:
-      secretKeyRef:
-        name: hmpps-domain-events-topic
-        key: secret_access_key
-
   - name: AWS_SNS_TOPIC_ARN
     valueFrom:
       secretKeyRef:
@@ -84,35 +72,11 @@ env:
         name: sentry
         key: service_dsn
 
-  - name: AWS_S3_STORAGE_ACCESSKEYID
-    valueFrom:
-      secretKeyRef:
-        name: storage-s3-bucket
-        key: access_key_id
-
-  - name: AWS_S3_STORAGE_SECRETACCESSKEY
-    valueFrom:
-      secretKeyRef:
-        name: storage-s3-bucket
-        key: secret_access_key
-
   - name: AWS_S3_STORAGE_BUCKET_NAME
     valueFrom:
       secretKeyRef:
         name: storage-s3-bucket
         key: bucket_name
-
-  - name: AWS_S3_NDMIS_ACCESSKEYID
-    valueFrom:
-      secretKeyRef:
-        name: reporting-s3-bucket
-        key: access_key_id
-
-  - name: AWS_S3_NDMIS_SECRETACCESSKEY
-    valueFrom:
-      secretKeyRef:
-        name: reporting-s3-bucket
-        key: secret_access_key
 
   - name: AWS_S3_NDMIS_BUCKET_NAME
     valueFrom:

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
@@ -8,6 +8,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           restartPolicy: "Never"
           containers:
             - name: ndmis-performance-report

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-prod-to-preprod-refresh.yaml
@@ -32,6 +32,9 @@ spec:
       activeDeadlineSeconds: 1200
       template:
         spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           securityContext:
             runAsUser: 999
           containers:

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-data-dictionary.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-data-dictionary.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         {{- include "dataDictionary.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       containers:
         - name: data-dictionary
           image: "{{ .Values.image.repository }}:data-dictionary-{{ .Values.image.tag }}"

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         {{- include "performanceReportApp.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         {{- include "dashboardApp.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm_deploy/hmpps-interventions-service/templates/job-conclude-referrals.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-conclude-referrals.yaml
@@ -8,6 +8,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           restartPolicy: "Never"
           containers:
             - name: conclude-referrals

--- a/helm_deploy/hmpps-interventions-service/templates/job-transfer-womens-services-dec2022.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-transfer-womens-services-dec2022.yaml
@@ -8,6 +8,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           restartPolicy: "Never"
           containers:
             - name: transfer-dec2022-womens-referrals

--- a/helm_deploy/hmpps-interventions-service/values.yaml
+++ b/helm_deploy/hmpps-interventions-service/values.yaml
@@ -2,3 +2,6 @@ generic-data-analytics-extractor:
   enabled: true
   databaseSecretName: postgres14
   analyticalPlatformSecretName: analytical-platform-reporting-s3-bucket
+
+env:
+  serviceAccountName: "hmpps-interventions"

--- a/helm_deploy/hmpps-interventions-service/values.yaml
+++ b/helm_deploy/hmpps-interventions-service/values.yaml
@@ -3,5 +3,4 @@ generic-data-analytics-extractor:
   databaseSecretName: postgres14
   analyticalPlatformSecretName: analytical-platform-reporting-s3-bucket
 
-env:
-  serviceAccountName: "hmpps-interventions"
+serviceAccountName: "hmpps-interventions"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/S3Configuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/S3Configuration.kt
@@ -5,7 +5,6 @@ import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import java.net.URI
@@ -54,7 +53,6 @@ class S3Configuration(
   private fun bucketFactory(config: S3BucketConfiguration): S3Bucket {
     val builder = S3Client.builder()
       .region(Region.of(config.region))
-      .credentialsProvider { AwsBasicCredentials.create(config.accessKeyId, config.secretAccessKey) }
 
     val client = config.endpoint?.let {
       builder

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/SNSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/SNSConfiguration.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sns.SnsClient
 import java.net.URI
@@ -21,7 +20,6 @@ class SNSConfiguration(
   fun snsClient(): SnsClient {
     val builder = SnsClient.builder()
       .region(Region.of(region))
-      .credentialsProvider { AwsBasicCredentials.create(accessKeyId, secretAccessKey) }
 
     return when (provider) {
       "aws" -> builder.build()


### PR DESCRIPTION
## What does this pull request do?

- configure helm deployment, deployment and cron job deployment to use serviceaccount name
- remove the aws access key credentials which will not be used anymore
- Update the SNS and S3 configuration to use DefaultCredentialsProvider

## What is the intent behind these changes?

- The change is required as there is a technical direction to move from short lived credentials to long live credentials
