### PR TITLE
removing unused access key and secret key

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/S3Configuration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/S3Configuration.kt
@@ -14,8 +14,6 @@ data class S3Bucket(val enabled: Boolean, val bucketName: String, val client: S3
 data class S3BucketConfiguration(
   val enabled: Boolean,
   val region: String,
-  val accessKeyId: String,
-  val secretAccessKey: String,
   val endpoint: Endpoint?,
   val bucket: Bucket,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/SNSConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/SNSConfiguration.kt
@@ -11,8 +11,6 @@ import java.net.URI
 class SNSConfiguration(
   @Value("\${aws.sns.provider}") private val provider: String,
   @Value("\${aws.sns.region}") private val region: String,
-  @Value("\${aws.sns.access-key-id}") private val accessKeyId: String,
-  @Value("\${aws.sns.secret-access-key}") private val secretAccessKey: String,
   @Value("\${aws.sns.endpoint.uri:}") private val uri: String,
 
 ) {


### PR DESCRIPTION
## What does this pull request do?

- removing unused access key and secret key

## What is the intent behind these changes?

- access key and secret key is not required anymore for aws config
