### PR TITLE
update crns for merged referrals

### DIFF
--- a/src/main/resources/db/migration/V1_141__update_merged_crns.sql
+++ b/src/main/resources/db/migration/V1_141__update_merged_crns.sql
@@ -1,0 +1,4 @@
+update referral set service_usercrn = 'E536101' where service_usercrn='E545871' and reference_number = 'HB6167ED';
+update referral set service_usercrn = 'M833264' where service_usercrn='V018774' and reference_number = 'LC2279AC';
+update draft_referral set service_usercrn = 'E536101' where id = '83260e0b-bdc8-4f50-a257-93cf51c4e971';
+update draft_referral set service_usercrn = 'M833264' where id = '804b650b-ad90-403a-92d4-8f8caaa05ca1';


### PR DESCRIPTION
## What does this pull request do?

- Runs the update script to update the crn for `E545871` and `V018774`

## What is the intent behind these changes?

- Those referrals are merged so we are required to update the crns
