### PR TITLE
Fix action plan validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/ActionPlanValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/ActionPlanValidator.kt
@@ -55,7 +55,7 @@ class ActionPlanValidator {
     if (
       supplierAssessmentAppointment == null ||
       supplierAssessmentAppointment.attended == Attended.NO ||
-      supplierAssessmentAppointment.sessionFeedbackSubmittedAt == null
+      supplierAssessmentAppointment.appointmentFeedbackSubmittedAt == null
     ) {
       errors.add(FieldError(field = "supplierAssessmentAppointment", error = APPOINTMENT_MUST_BE_COMPLETED))
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/ActionPlanValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/component/ActionPlanValidatorTest.kt
@@ -106,7 +106,7 @@ class ActionPlanValidatorTest {
   @Test
   fun `submit action plan fails validation - number of sessions is empty`() {
     val referral = referralFactory.createSent()
-    val appointment = appointmentFactory.create(attended = Attended.YES, sessionFeedbackSubmittedAt = OffsetDateTime.now())
+    val appointment = appointmentFactory.create(attended = Attended.YES, appointmentFeedbackSubmittedAt = OffsetDateTime.now())
     val supplierAssessment = supplierAssessmentFactory.create(appointment = appointment)
     referral.supplierAssessment = supplierAssessment
     val actionPlan = actionPlanFactory.create(referral = referral)
@@ -134,7 +134,7 @@ class ActionPlanValidatorTest {
   @Test
   fun `submit action plan passes validation if supplier assessment has been completed`() {
     val referral = referralFactory.createSent()
-    val appointment = appointmentFactory.create(attended = Attended.YES, sessionFeedbackSubmittedAt = OffsetDateTime.now())
+    val appointment = appointmentFactory.create(attended = Attended.YES, appointmentFeedbackSubmittedAt = OffsetDateTime.now())
     val supplierAssessment = supplierAssessmentFactory.create(appointment = appointment)
     referral.supplierAssessment = supplierAssessment
     val actionPlan = actionPlanFactory.create(referral = referral, numberOfSessions = 1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -453,6 +453,7 @@ class SetupAssistant(
     sessionConcerns: String? = null,
     notifyPPOfAttendanceBehaviour: Boolean? = null,
     appointmentTime: OffsetDateTime = OffsetDateTime.now().plusMonths(2),
+    appointmentFeedbackSubmittedAt: OffsetDateTime? = null,
   ) {
     val appointment: Appointment = appointmentFactory.create(createdBy = createPPUser(), referral = referral, appointmentTime = appointmentTime)
     if (attended !== null) {
@@ -469,6 +470,7 @@ class SetupAssistant(
       appointment.notifyPPOfAttendanceBehaviour = notifyPPOfAttendanceBehaviour
       appointment.sessionFeedbackSubmittedAt = OffsetDateTime.now()
       appointment.sessionFeedbackSubmittedBy = createSPUser()
+      appointment.appointmentFeedbackSubmittedAt = appointmentFeedbackSubmittedAt
     }
 
     appointmentRepository.save(appointment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
@@ -141,7 +141,7 @@ class ActionPlanContracts(private val setupAssistant: SetupAssistant) {
       attended = Attended.YES,
       sessionSummary = "test",
       sessionResponse = "test",
-      appointmentFeedbackSubmittedAt = OffsetDateTime.now()
+      appointmentFeedbackSubmittedAt = OffsetDateTime.now(),
     )
     setupAssistant.createActionPlan(
       referral = referral,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/pact/ActionPlanContracts.kt
@@ -141,6 +141,7 @@ class ActionPlanContracts(private val setupAssistant: SetupAssistant) {
       attended = Attended.YES,
       sessionSummary = "test",
       sessionResponse = "test",
+      appointmentFeedbackSubmittedAt = OffsetDateTime.now()
     )
     setupAssistant.createActionPlan(
       referral = referral,


### PR DESCRIPTION
## What does this pull request do?

Replaces the field to check is not null from sessionFeedbackSubmittedAt to appointmentFeedbackSubmittedAt when validating the supplier assessment appointment has been completed before an action plan is submitted.

## What is the intent behind these changes?

To fix issues with submitting action plans for referrals which have supplier assessment appointments created before the new sessionFeedackSubmittedAt field was introduced. 