### PR TITLE
adopting a new field to store the PP's establishment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -60,6 +60,7 @@ data class DraftReferralDTO(
   val ppEmailAddress: String? = null,
   val ppPdu: String? = null,
   val ppProbationOffice: String? = null,
+  val ppEstablishment: String? = null,
   val hasValidDeliusPPDetails: Boolean? = null,
   val hasMainPointOfContactDetails: Boolean? = null,
   val isReferralReleasingIn12Weeks: Boolean? = null,
@@ -111,6 +112,7 @@ data class DraftReferralDTO(
         ppName = referral.ppName,
         ppEmailAddress = referral.ppEmailAddress,
         ppPdu = referral.ppPdu,
+        ppEstablishment = referral.ppEstablishment,
         ppProbationOffice = referral.ppProbationOffice,
         hasValidDeliusPPDetails = referral.hasValidDeliusPPDetails,
         isReferralReleasingIn12Weeks = referral.isReferralReleasingIn12Weeks,
@@ -166,6 +168,7 @@ data class DraftReferralDTO(
         ppName = referral.probationPractitionerDetails?.name,
         ppEmailAddress = referral.probationPractitionerDetails?.emailAddress,
         ppPdu = referral.probationPractitionerDetails?.pdu,
+        ppEstablishment = referral.probationPractitionerDetails?.establishment,
         ppProbationOffice = referral.probationPractitionerDetails?.probationOffice,
         hasValidDeliusPPDetails = referral.probationPractitionerDetails?.let {
           it.nDeliusName != null || it.nDeliusEmailAddress != null || it.nDeliusPDU != null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
@@ -100,6 +100,7 @@ class DraftReferral(
   @Column(name = "role_job_title") var roleOrJobTitle: String? = null,
   @Column(name = "referral_releasing_12_weeks") var isReferralReleasingIn12Weeks: Boolean? = null,
   @Column(name = "has_main_point_of_contact_details") var hasMainPointOfContactDetails: Boolean? = null,
+  @Column(name = "pp_establishment") var ppEstablishment: String? = null,
 ) {
   val referralDetails: ReferralDetails? get() {
     return referralDetailsHistory?.firstOrNull { it.supersededById == null }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ProbationPractitionerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ProbationPractitionerDetails.kt
@@ -20,5 +20,6 @@ data class ProbationPractitionerDetails(
   @Column(name = "email_address") var emailAddress: String? = null,
   @Column(name = "pdu") var pdu: String? = null,
   @Column(name = "probation_office") var probationOffice: String? = null,
+  @Column(name = "establishment") var establishment: String? = null,
   @Column(name = "role_job_title") var roleOrJobTitle: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -193,13 +193,13 @@ class DraftReferralService(
       referral.roleOrJobTitle = update.roleOrJobTitle
       referral.ppEmailAddress = update.ppEmailAddress
       referral.hasMainPointOfContactDetails = update.hasMainPointOfContactDetails
-      if (StringUtils.isNotEmpty(update.ppPdu)) {
-        referral.ppPdu = update.ppPdu
+      if (StringUtils.isNotEmpty(update.ppEstablishment)) {
+        referral.ppEstablishment = update.ppEstablishment
         referral.ppProbationOffice = null
       }
       if (StringUtils.isNotEmpty(update.ppProbationOffice)) {
         referral.ppProbationOffice = update.ppProbationOffice
-        referral.ppPdu = null
+        referral.ppEstablishment = null
       }
     }
   }
@@ -537,6 +537,7 @@ class DraftReferralService(
           emailAddress = draftReferral.ppEmailAddress,
           pdu = draftReferral.ppPdu,
           probationOffice = draftReferral.ppProbationOffice,
+          establishment = draftReferral.ppEstablishment,
           roleOrJobTitle = draftReferral.roleOrJobTitle,
         ),
       )

--- a/src/main/resources/db/migration/V1_143__add_ppEstablishment_draft_referral.sql
+++ b/src/main/resources/db/migration/V1_143__add_ppEstablishment_draft_referral.sql
@@ -1,0 +1,9 @@
+alter table draft_referral
+    add column pp_establishment text;
+
+alter table probation_practitioner_details
+    add column establishment text;
+
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','pp_establishment',TRUE, TRUE);
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('probation_practitioner_details','establishment',TRUE, TRUE);


### PR DESCRIPTION
## What does this pull request do?

- creates a new field ppEstablishment to store the establishment value for the probation practitioner
- creates the field both in draft referral and probation practitioner details

## What is the intent behind these changes?

- The confirm main point of contact details needs to capture PP's establishment and we need to store the captured value in the UI
