### PR TITLE
Ipb 645/fix testing bugs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -65,6 +65,7 @@ data class DraftReferralDTO(
   val hasMainPointOfContactDetails: Boolean? = null,
   val isReferralReleasingIn12Weeks: Boolean? = null,
   val roleOrJobTitle: String? = null,
+  val ppLocationType: String? = null,
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import com.microsoft.applicationinsights.TelemetryClient
 import mu.KotlinLogging
 import net.logstash.logback.argument.StructuredArguments
-import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -193,11 +192,11 @@ class DraftReferralService(
       referral.roleOrJobTitle = update.roleOrJobTitle
       referral.ppEmailAddress = update.ppEmailAddress
       referral.hasMainPointOfContactDetails = update.hasMainPointOfContactDetails
-      if (StringUtils.isNotEmpty(update.ppEstablishment)) {
+      if (update.ppLocationType == "establishment") {
         referral.ppEstablishment = update.ppEstablishment
         referral.ppProbationOffice = null
       }
-      if (StringUtils.isNotEmpty(update.ppProbationOffice)) {
+      if (update.ppLocationType == "probation office") {
         referral.ppProbationOffice = update.ppProbationOffice
         referral.ppEstablishment = null
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentDeliveryAddressFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/AppointmentDeliveryAddressFactory.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appoint
 import java.util.UUID
 
 class AppointmentDeliveryAddressFactory(em: TestEntityManager? = null) : EntityFactory(em) {
-  val appointmentDeliveryFactory = AppointmentDeliveryFactory(em)
+  private val appointmentDeliveryFactory = AppointmentDeliveryFactory(em)
   fun create(
     appointmentDeliveryId: UUID? = null,
     firstAddressLine: String = "Harmony Living Office, Room 4",


### PR DESCRIPTION
## What does this pull request do?

- consumes the location type to check the option user selected
- this is to delete the other value that might have been previously set by the user 

## What is the intent behind these changes?

- The ui was not handling the switch between establishment and probation office correctly, hence we need to unset the value which was previously set when the radio button changes
