### PR TITLE
Updated generic-data-analytics-extractor chart version to 1.0.1

### DIFF
--- a/helm_deploy/hmpps-interventions-service/Chart.yaml
+++ b/helm_deploy/hmpps-interventions-service/Chart.yaml
@@ -6,5 +6,6 @@ version: 0.1.0
 
 dependencies:
   - name: generic-data-analytics-extractor
-    version: 0.2.0
+    version: 1.0.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
+

--- a/helm_deploy/hmpps-interventions-service/values.yaml
+++ b/helm_deploy/hmpps-interventions-service/values.yaml
@@ -1,7 +1,7 @@
 generic-data-analytics-extractor:
   enabled: true
   databaseSecretName: postgres14
-  analyticalPlatformSecretName: analytical-platform-reporting-s3-bucket
+  destinationS3SecretName: analytical-platform-reporting-s3-bucket
   serviceAccountName: hmpps-interventions-to-ap-s3
 
 serviceAccountName: "hmpps-interventions"


### PR DESCRIPTION
## What does this pull request do?

This PR sets the chart version for generic-data-analytics-extractor to 1.0.1

## What is the intent behind these changes?

To fix the error while running the generic-data-analytics-extractor
