### PR TITLE
Updated generic-data-analytics-extractor chart version to 1.0.1 and c…

### DIFF
--- a/helm_deploy/hmpps-interventions-service/Chart.yaml
+++ b/helm_deploy/hmpps-interventions-service/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 
 dependencies:
   - name: generic-data-analytics-extractor
-    version: 0.1.4
+    version: 1.0.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-interventions-service/values.yaml
+++ b/helm_deploy/hmpps-interventions-service/values.yaml
@@ -1,7 +1,8 @@
 generic-data-analytics-extractor:
   enabled: true
   databaseSecretName: postgres14
-  analyticalPlatformSecretName: analytical-platform-reporting-s3-bucket
+  destinationS3SecretName: analytical-platform-reporting-s3-bucket
+  serviceAccountName: hmpps-interventions-to-ap-s3
 
 serviceAccountName: "hmpps-interventions"
 serviceAccountNameForNdmisReporting: "hmpps-interventions-to-ndmis-s3"


### PR DESCRIPTION
…hanged analyticalPlatformSecretName to destinationS3SecretName

## What does this pull request do?

Updated generic-data-analytics-extractor chart version to 1.0.1 and changed analyticalPlatformSecretName to destinationS3SecretName

## What is the intent behind these changes?

To allow transfer of analytical extracts to analytical platform reporting s3 bucket
