### PR TITLE
upgrading org.json:json version to 20231013

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,11 @@ dependencies {
 
   // notifications
   implementation("uk.gov.service.notify:notifications-java-client:4.1.0-RELEASE")
+  implementation("org.json:json") {
+    version {
+      strictly("20231013")
+    }
+  }
 
   // aws
   implementation("software.amazon.awssdk:sns:2.21.0")


### PR DESCRIPTION
## What does this pull request do?

upgrades org.json:json to 20231013

## What is the intent behind these changes?

- there was vulnerability issue in the existing version of `org.json:json` which is brought in transitively by `uk.gov.service.notify:notifications-java-client:4.1.0-RELEASE`. Not sure when this service will be upgraded. So as of now enforcing the latest version to resolve the issue
