### PR TITLE
adding a new column to record if the referral has community allocated pp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.12.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.13.0"
   kotlin("plugin.spring") version "1.9.10"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.10"
   id("jacoco")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -66,6 +66,7 @@ data class DraftReferralDTO(
   val isReferralReleasingIn12Weeks: Boolean? = null,
   val roleOrJobTitle: String? = null,
   val ppLocationType: String? = null,
+  val allocatedCommunityPP: Boolean? = null,
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {
@@ -119,6 +120,7 @@ data class DraftReferralDTO(
         isReferralReleasingIn12Weeks = referral.isReferralReleasingIn12Weeks,
         hasMainPointOfContactDetails = referral.hasMainPointOfContactDetails,
         roleOrJobTitle = referral.roleOrJobTitle,
+        allocatedCommunityPP = referral.allocatedCommunityPP,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DraftReferral.kt
@@ -101,6 +101,7 @@ class DraftReferral(
   @Column(name = "referral_releasing_12_weeks") var isReferralReleasingIn12Weeks: Boolean? = null,
   @Column(name = "has_main_point_of_contact_details") var hasMainPointOfContactDetails: Boolean? = null,
   @Column(name = "pp_establishment") var ppEstablishment: String? = null,
+  @Column(name = "allocated_community_pp") var allocatedCommunityPP: Boolean? = null,
 ) {
   val referralDetails: ReferralDetails? get() {
     return referralDetailsHistory?.firstOrNull { it.supersededById == null }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -255,6 +255,9 @@ class DraftReferralService(
     update.personCustodyPrisonId?.let {
       draftReferral.personCustodyPrisonId = update.personCustodyPrisonId
     }
+    update.allocatedCommunityPP?.let {
+      draftReferral.allocatedCommunityPP = update.allocatedCommunityPP
+    }
   }
 
   fun updatePersonExpectedReleaseDate(draftReferral: DraftReferral, update: DraftReferralDTO) {

--- a/src/main/resources/db/migration/V1_147__allocated_community_pp_draft_referrral.sql
+++ b/src/main/resources/db/migration/V1_147__allocated_community_pp_draft_referrral.sql
@@ -1,0 +1,4 @@
+alter table draft_referral
+add column allocated_community_pp boolean;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('draft_referral','allocated_community_pp',TRUE, TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SetupAssistant.kt
@@ -276,6 +276,7 @@ class SetupAssistant(
     hasMainPointOfContactDetails: Boolean = false,
     roleOrJobTitle: String? = "Probation Practitioner",
     ppEstablishment: String? = "aaa",
+    allocatedCommunityPP: Boolean = false,
   ): DraftReferral {
     return draftReferralRepository.save(
       referralFactory.createDraft(
@@ -301,6 +302,7 @@ class SetupAssistant(
         roleOrJobTitle = roleOrJobTitle,
         isReferralReleasingIn12Weeks = isReferralReleasingIn12Weeks,
         ppEstablishment = ppEstablishment,
+        allocatedCommunityPP = allocatedCommunityPP,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
@@ -147,6 +147,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
     hasMainPointOfContactDetails: Boolean = false,
     roleOrJobTitle: String? = "Probation Practitioner",
     ppEstablishment: String? = "aaa",
+    allocatedCommunityPP: Boolean = false,
   ): DraftReferral {
     val draftReferral = DraftReferral(
       id = id,
@@ -175,6 +176,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
       hasMainPointOfContactDetails = hasMainPointOfContactDetails,
       roleOrJobTitle = roleOrJobTitle,
       ppEstablishment = ppEstablishment,
+      allocatedCommunityPP = allocatedCommunityPP,
       referralDetailsHistory = if (referralDetails != null) {
         setOf(
           referralDetails.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -57,6 +57,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     hasMainPointOfContactDetails: Boolean = false,
     roleOrJobTitle: String? = "Probation Practitioner",
     ppEstablishment: String? = "aaa",
+    allocatedCommunityPP: Boolean = false,
   ): DraftReferral {
     return createDraftReferral(
       id = id,
@@ -86,6 +87,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       hasMainPointOfContactDetails = hasMainPointOfContactDetails,
       roleOrJobTitle = roleOrJobTitle,
       ppEstablishment = ppEstablishment,
+      allocatedCommunityPP = allocatedCommunityPP,
     )
   }
 


### PR DESCRIPTION
## What does this pull request do?

- adding a new column to store if the referral has community allocated pp

## What is the intent behind these changes?

- This is to mitigate the unstable data from community api. To mitigate the issue, we are capturing the information in R&M itself.
