### PR TITLE
trivy ignore for reactor-netty-http

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -35,3 +35,6 @@ CVE-2022-45868
 # Suppression for spring-web 5.3.24 as bundled with spring boot
 #   can be suppressed as we are not using java serialization and deserialization explicitly
 CVE-2016-1000027
+# Suppression for reactor-netty-http 1.0.38 as bundled with spring boot
+#   can be suppressed as we are not using directory traversal in our application
+CVE-2023-34062


### PR DESCRIPTION
## What does this pull request do?

- ignore the trivy scan for the latest reactor-netty-http CVE-2023-34062.  This can be suppressed as we are not using directory traversal in our application

## What is the intent behind these changes?

- This is done to resolve the trivy scan failure
