### PR TITLE
Remap reporting database connection secrets to readonly replica

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -38,3 +38,5 @@ CVE-2016-1000027
 # Suppression for reactor-netty-http 1.0.38 as bundled with spring boot
 #   can be suppressed as we are not using directory traversal in our application
 CVE-2023-34062
+# temporarily supressed for DEV testing, needs assessed before PROD deploy
+CVE-2023-6378

--- a/helm_deploy/hmpps-interventions-service/templates/_envs_reporting.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs_reporting.tpl
@@ -1,0 +1,91 @@
+    {{/* vim: set filetype=mustache: */}}
+{{/*
+Environment variables for reporting containers
+*/}}
+{{- define "deployment-reporting.envs" }}
+env:
+  - name: SERVER_PORT
+    value: "{{ .Values.image.ports.app }}"
+
+  {{ range $key, $value := .Values.env }}
+  - name: {{ $key }}
+    value: "{{ $value }}"
+  {{ end }}
+
+  - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+    valueFrom:
+      secretKeyRef:
+        name: application-insights
+        key: connection_string
+
+  - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSCLIENT_CLIENTID
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-auth
+        key: interventions-service-client-id.txt
+
+  - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSCLIENT_CLIENTSECRET
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-auth
+        key: interventions-service-client-secret.txt
+
+  - name: POSTGRES_URI
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: rds_instance_endpoint
+
+  - name: POSTGRES_DB
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: database_name
+
+  - name: POSTGRES_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: database_username
+
+  - name: POSTGRES_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: database_password
+
+  - name: AWS_SNS_TOPIC_ARN
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-domain-events-topic
+        key: topic_arn
+
+  - name: NOTIFY_APIKEY
+    valueFrom:
+      secretKeyRef:
+        name: notify
+        key: api_key
+
+  - name: SENTRY_DSN
+    valueFrom:
+      secretKeyRef:
+        name: sentry
+        key: service_dsn
+
+  - name: AWS_S3_STORAGE_BUCKET_NAME
+    valueFrom:
+      secretKeyRef:
+        name: storage-s3-bucket
+        key: bucket_name
+
+  - name: AWS_S3_NDMIS_BUCKET_NAME
+    valueFrom:
+      secretKeyRef:
+        name: reporting-s3-bucket
+        key: bucket_name
+
+  {{- with (index .Values.ingress.hosts 0) }}
+  - name: INTERVENTIONSAPI_BASEURL
+    value: "https://{{ .host}}"
+  {{- end -}}
+{{- end -}}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
@@ -20,7 +20,7 @@ spec:
               volumeMounts:
                 - name: heap-dumps
                   mountPath: /dumps
-  {{- include "deployment.envs" . | nindent 14 }}
+  {{- include "deployment-reporting.envs" . | nindent 14 }}
           volumes:
             - name: heap-dumps
               emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{- include "deployment.envs" . | nindent 10 }}
+  {{- include "deployment-reporting.envs" . | nindent 10 }}
       volumes:
         - name: heap-dumps
           emptyDir: {}


### PR DESCRIPTION
## What does this pull request do?

Points reporting jobs to the read replica database

## What is the intent behind these changes?

Offloads intensive reporting to a read replica to improve application performance and prevent failures under load.
