### PR TITLE
Suppress trivy issue for CVE-2023-6378

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -38,3 +38,5 @@ CVE-2016-1000027
 # Suppression for reactor-netty-http 1.0.38 as bundled with spring boot
 #   can be suppressed as we are not using directory traversal in our application
 CVE-2023-34062
+# temporarily supressed for DEV testing, remove when spring upgrade complete
+CVE-2023-6378


### PR DESCRIPTION
Will be addressed when spring is upgraded

## What does this pull request do?

Adds trivy ignore for CVE-2023-6378

## What is the intent behind these changes?

Allows dev env builds while waiting for spring upgrade
