### PR TITLE
Build job repo in memory for read only replica

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/_envs_reporting.tpl
+++ b/helm_deploy/hmpps-interventions-service/templates/_envs_reporting.tpl
@@ -1,0 +1,91 @@
+    {{/* vim: set filetype=mustache: */}}
+{{/*
+Environment variables for reporting containers
+*/}}
+{{- define "deployment-reporting.envs" }}
+env:
+  - name: SERVER_PORT
+    value: "{{ .Values.image.ports.app }}"
+
+  {{ range $key, $value := .Values.env }}
+  - name: {{ $key }}
+    value: "{{ $value }}"
+  {{ end }}
+
+  - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+    valueFrom:
+      secretKeyRef:
+        name: application-insights
+        key: connection_string
+
+  - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSCLIENT_CLIENTID
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-auth
+        key: interventions-service-client-id.txt
+
+  - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSCLIENT_CLIENTSECRET
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-auth
+        key: interventions-service-client-secret.txt
+
+  - name: POSTGRES_URI
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: rds_instance_endpoint
+
+  - name: POSTGRES_DB
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: database_name
+
+  - name: POSTGRES_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: database_username
+
+  - name: POSTGRES_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-interventions-postgres14-rds-replica-output
+        key: database_password
+
+  - name: AWS_SNS_TOPIC_ARN
+    valueFrom:
+      secretKeyRef:
+        name: hmpps-domain-events-topic
+        key: topic_arn
+
+  - name: NOTIFY_APIKEY
+    valueFrom:
+      secretKeyRef:
+        name: notify
+        key: api_key
+
+  - name: SENTRY_DSN
+    valueFrom:
+      secretKeyRef:
+        name: sentry
+        key: service_dsn
+
+  - name: AWS_S3_STORAGE_BUCKET_NAME
+    valueFrom:
+      secretKeyRef:
+        name: storage-s3-bucket
+        key: bucket_name
+
+  - name: AWS_S3_NDMIS_BUCKET_NAME
+    valueFrom:
+      secretKeyRef:
+        name: reporting-s3-bucket
+        key: bucket_name
+
+  {{- with (index .Values.ingress.hosts 0) }}
+  - name: INTERVENTIONSAPI_BASEURL
+    value: "https://{{ .host}}"
+  {{- end -}}
+{{- end -}}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-performance-report.yaml
@@ -20,7 +20,7 @@ spec:
               volumeMounts:
                 - name: heap-dumps
                   mountPath: /dumps
-  {{- include "deployment.envs" . | nindent 14 }}
+  {{- include "deployment-reporting.envs" . | nindent 14 }}
           volumes:
             - name: heap-dumps
               emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{- include "deployment.envs" . | nindent 10 }}
+  {{- include "deployment-reporting.envs" . | nindent 10 }}
       volumes:
         - name: heap-dumps
           emptyDir: {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -3,16 +3,30 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
 
 @Configuration
 class BatchConfiguration(
+  private val dataSource: DataSource,
+  private val transactionManager: PlatformTransactionManager,
   @Value("\${spring.batch.concurrency.pool-size}") private val poolSize: Int,
   @Value("\${spring.batch.concurrency.queue-size}") private val queueSize: Int,
 ) {
+  @Throws(Exception::class)
+  protected fun createJobRepository(): JobRepository? {
+    val factory = JobRepositoryFactoryBean()
+    factory.setDataSource(dataSource)
+    factory.setTransactionManager(transactionManager)
+    factory.setIsolationLevelForCreate("ISOLATION_REPEATABLE_READ")
+    return factory.getObject()
+  }
+
   @Bean
   fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
@@ -21,7 +35,7 @@ class BatchConfiguration(
     taskExecutor.afterPropertiesSet()
 
     val launcher = SimpleJobLauncher()
-    launcher.setJobRepository(jobRepository)
+    launcher.setJobRepository(createJobRepository())
     launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher


### PR DESCRIPTION
Build a in memory job repo

## What does this pull request do?

Builds a read only repo for job management with read only credentials

## What is the intent behind these changes?

Allow jobs to run against read only connection.