### PR TITLE
Change jobRepository to readonly version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
   // batch processing
   implementation("org.springframework.boot:spring-boot-starter-batch")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3") // also needed runtime for AppInsights
+  implementation("com.github.marschall:spring-batch-inmemory:1.0.0")
 
   // monitoring and logging
   implementation("io.micrometer:micrometer-registry-prometheus")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
-import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer
+import com.github.marschall.spring.batch.inmemory.NullJobRepository
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
@@ -8,13 +8,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
-import javax.sql.DataSource
 
 @Configuration
 class BatchConfiguration(
   @Value("\${spring.batch.concurrency.pool-size}") private val poolSize: Int,
   @Value("\${spring.batch.concurrency.queue-size}") private val queueSize: Int,
-) : DefaultBatchConfigurer() {
+) {
   @Bean
   fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
@@ -23,14 +22,9 @@ class BatchConfiguration(
     taskExecutor.afterPropertiesSet()
 
     val launcher = SimpleJobLauncher()
-    launcher.setJobRepository(jobRepository)
+    launcher.setJobRepository(NullJobRepository()) // override job repo with a read only version
     launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher
-  }
-
-  override fun setDataSource(dataSource: DataSource?) {
-    // override to do not set datasource even if a datasource exist.
-    // initialize will use a Map based JobRepository (instead of database)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Introduces a read only job repository to avoid writes in the reporting jobs

## What is the intent behind these changes?

Allow reporting against a readonly datasource provided by read replica
