### PR TITLE
Use a simple jobLauncher instead of more general interface and

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
 import com.github.marschall.spring.batch.inmemory.NullJobRepository
-import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.beans.factory.annotation.Value
@@ -15,7 +14,7 @@ class BatchConfiguration(
   @Value("\${spring.batch.concurrency.queue-size}") private val queueSize: Int,
 ) {
   @Bean
-  fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
+  fun asyncJobLauncher(jobRepository: JobRepository): SimpleJobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
     taskExecutor.corePoolSize = poolSize
     taskExecutor.queueCapacity = queueSize

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
@@ -1,10 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff
 
+import com.github.marschall.spring.batch.inmemory.NullJobRepository
 import mu.KLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.converter.DefaultJobParametersConverter
-import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.launch.support.SimpleJvmExitCodeMapper
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
@@ -14,7 +15,7 @@ import kotlin.system.exitProcess
 
 @Component
 class OnStartupJobLauncherFactory(
-  private val jobLauncher: JobLauncher,
+  private val jobLauncher: SimpleJobLauncher,
 ) {
   companion object : KLogging()
 
@@ -40,6 +41,7 @@ class OnStartupJobLauncherFactory(
         it.getNext(rawParams)
       } ?: rawParams
 
+      jobLauncher.setJobRepository(NullJobRepository())
       val execution = jobLauncher.run(job, nextParams)
       return exitCodeMapper.intValue(execution.exitStatus.exitCode)
     }


### PR DESCRIPTION
Use a simple jobLauncher instead of more general interface and introduce NullJobRepository to onStartupJobLauncherFactory

## What does this pull request do?

Passes the nullJobRepository to onStartupJobLauncher, used more generally by reports

## What is the intent behind these changes?

Allow report to run against readonly datasource
