### PR TITLE
Revert case note email opt-out

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
@@ -41,7 +41,6 @@ class CaseNoteController(
       referralId = sentReferral.id,
       subject = createCaseNote.subject,
       body = createCaseNote.body,
-      sendEmail = createCaseNote.sendEmail,
       sentByUser = user,
     )
     return CaseNoteDTO.from(caseNote)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/CaseNoteDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/CaseNoteDTO.kt
@@ -23,5 +23,4 @@ data class CreateCaseNoteDTO(
   val referralId: UUID,
   val subject: String,
   val body: String,
-  val sendEmail: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
@@ -15,7 +15,6 @@ class CreateCaseNoteEvent(
   val sentBy: AuthUser,
   val detailUrl: String,
   val referralId: UUID,
-  val sendEmail: Boolean?,
 ) : ApplicationEvent(source) {
   override fun toString(): String = "CreateCaseNoteEvent(caseNoteId=$caseNoteId, referralId=$referralId)"
 }
@@ -25,7 +24,7 @@ class CaseNoteEventPublisher(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val locationMapper: LocationMapper,
 ) {
-  fun caseNoteSentEvent(caseNote: CaseNote, sendEmail: Boolean?) {
+  fun caseNoteSentEvent(caseNote: CaseNote) {
     applicationEventPublisher.publishEvent(
       CreateCaseNoteEvent(
         this,
@@ -33,7 +32,6 @@ class CaseNoteEventPublisher(
         caseNote.sentBy,
         caseNoteUrl(caseNote),
         caseNote.referral.id,
-        sendEmail,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
@@ -24,7 +24,7 @@ class CaseNoteService(
   val caseNoteEventPublisher: CaseNoteEventPublisher,
 ) {
 
-  fun createCaseNote(referralId: UUID, subject: String, body: String, sendEmail: Boolean?, sentByUser: AuthUser): CaseNote {
+  fun createCaseNote(referralId: UUID, subject: String, body: String, sentByUser: AuthUser): CaseNote {
     val caseNote = CaseNote(
       id = UUID.randomUUID(),
       referral = referralRepository.getById(referralId),
@@ -34,7 +34,7 @@ class CaseNoteService(
       sentAt = OffsetDateTime.now(),
     )
     return caseNoteRepository.save(caseNote).also {
-      caseNoteEventPublisher.caseNoteSentEvent(it, sendEmail)
+      caseNoteEventPublisher.caseNoteSentEvent(it)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
@@ -33,9 +33,7 @@ class CaseNotesNotificationsService(
   override fun onApplicationEvent(event: CreateCaseNoteEvent) {
     referralService.getSentReferralForUser(event.referralId, event.sentBy)?.let { referral ->
       emailAssignedCaseWorker(referral, event.sentBy, event.caseNoteId)
-      if (event.sendEmail == null || event.sendEmail) {
-        emailResponsibleProbationPractitioner(referral, event.sentBy, event.caseNoteId)
-      }
+      emailResponsibleProbationPractitioner(referral, event.sentBy, event.caseNoteId)
     } ?: run {
       throw RuntimeException("Unable to retrieve referral for id ${event.referralId}")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
@@ -45,11 +45,11 @@ class CaseNoteControllerTest {
       val userToken = tokenFactory.create(user)
       val caseNote = caseNoteFactory.create(subject = "subject", body = "body")
       val referralId = caseNote.referral.id
-      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body", sendEmail = true)
+      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body")
 
       whenever(authUserRepository.save(any())).thenReturn(user)
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(referralFactory.createSent(id = referralId))
-      whenever(caseNoteService.createCaseNote(referralId = referralId, subject = "subject", body = "body", sendEmail = true, sentByUser = user)).thenReturn(caseNote)
+      whenever(caseNoteService.createCaseNote(referralId = referralId, subject = "subject", body = "body", sentByUser = user)).thenReturn(caseNote)
 
       val caseNoteDTO = caseNoteController.createCaseNote(createCaseNoteDTO, userToken)
       assertThat(caseNoteDTO).isEqualTo(CaseNoteDTO.from(caseNote))
@@ -61,7 +61,7 @@ class CaseNoteControllerTest {
       val userToken = tokenFactory.create(user)
       val caseNote = caseNoteFactory.create(subject = "subject", body = "body")
       val referralId = caseNote.referral.id
-      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body", sendEmail = true)
+      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body")
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(null)
       whenever(authUserRepository.save(any())).thenReturn(user)
       val e = assertThrows<ResponseStatusException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisherTest.kt
@@ -25,7 +25,7 @@ internal class CaseNoteEventPublisherTest {
     whenever(locationMapper.getPathFromControllerMethod(CaseNoteController::getCaseNote)).thenReturn("/case-note/{id}")
     val publisher = CaseNoteEventPublisher(eventPublisher, locationMapper)
 
-    publisher.caseNoteSentEvent(caseNote, true)
+    publisher.caseNoteSentEvent(caseNote)
 
     val eventCaptor = argumentCaptor<CreateCaseNoteEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
@@ -36,6 +36,5 @@ internal class CaseNoteEventPublisherTest {
     assertThat(event.sentBy).isSameAs(caseNote.sentBy)
     assertThat(event.detailUrl).isEqualTo(uri.toString())
     assertThat(event.referralId).isSameAs(caseNote.referral.id)
-    assertThat(event.sendEmail).isEqualTo(true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
@@ -50,7 +50,7 @@ class RequestFactory(private val webTestClient: WebTestClient, private val setup
       Request.GetServiceProviderReferralsSummary -> webTestClient.get().uri("/sent-referrals/summary/service-provider")
 
       Request.CreateCaseNote -> webTestClient.post().uri("/case-note").bodyValue(
-        if (body != null) body as CreateCaseNoteDTO else CreateCaseNoteDTO(urlParams[0] as UUID, "subject", "body", false),
+        if (body != null) body as CreateCaseNoteDTO else CreateCaseNoteDTO(urlParams[0] as UUID, "subject", "body"),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteServiceTest.kt
@@ -50,8 +50,7 @@ class CaseNoteServiceTest @Autowired constructor(
     fun `can create case note`() {
       val referral = referralFactory.createSent()
       val user = userFactory.create()
-      val sendEmail = false
-      val caseNote = caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sendEmail = sendEmail, user)
+      val caseNote = caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", user)
       val savedCaseNote = caseNoteRepository.findById(caseNote.id).get()
       assertThat(caseNote).isEqualTo(savedCaseNote)
       assertThat(caseNote.referral.id).isEqualTo(referral.id)
@@ -60,7 +59,7 @@ class CaseNoteServiceTest @Autowired constructor(
       assertThat(caseNote.sentAt).isNotNull()
       assertThat(caseNote.sentBy).isEqualTo(user)
 
-      verify(caseNoteEventPublisher).caseNoteSentEvent(caseNote, sendEmail)
+      verify(caseNoteEventPublisher).caseNoteSentEvent(caseNote)
     }
   }
 
@@ -160,7 +159,7 @@ class CaseNoteServiceTest @Autowired constructor(
     fun `can get case note by id`() {
       val referral = referralFactory.createSent()
       val caseNote =
-        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sendEmail = false, sentByUser = referral.sentBy!!)
+        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sentByUser = referral.sentBy!!)
 
       val retrievedCaseNote = caseNoteService.getCaseNoteForUser(caseNote.id, referral.sentBy!!)
       assertThat(retrievedCaseNote).isEqualTo(caseNote)
@@ -170,7 +169,7 @@ class CaseNoteServiceTest @Autowired constructor(
     fun `user can't get case note without access to referral`() {
       val referral = referralFactory.createSent()
       val caseNote =
-        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sendEmail = false, sentByUser = referral.sentBy!!)
+        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sentByUser = referral.sentBy!!)
       whenever(
         referralService.getSentReferralForUser(
           caseNote.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
@@ -61,7 +61,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
-      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -108,7 +107,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
-      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -148,7 +146,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
-      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -187,7 +184,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
-      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -232,7 +228,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
-      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -271,7 +266,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       caseNote.referral.id,
-      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(event)
@@ -302,7 +296,6 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       UUID.fromString("e5274827-fcbc-4891-a68b-d9b4d3b59dab"),
-      true,
     )
     var e = assertThrows<RuntimeException> { caseNotesNotificationsService.onApplicationEvent(event) }
     Assertions.assertThat(e.message).contains("Unable to retrieve referral for id e5274827-fcbc-4891-a68b-d9b4d3b59dab")


### PR DESCRIPTION
## What does this pull request do?

Reverts the case note email opt-out.

## What is the intent behind these changes?

To allow the release of GBSF it2v4.
