### PR TITLE
contract offboarding for ETE contracts

### DIFF
--- a/src/main/resources/db/migration/V1_153__update_contract_reference_for_ete.sql
+++ b/src/main/resources/db/migration/V1_153__update_contract_reference_for_ete.sql
@@ -1,0 +1,2 @@
+update dynamic_framework_contract set referral_end_at = '2023-12-31 23:59:00+00'
+where contract_reference in ('PRJ_6310', 'PRJ_5462','PRJ_5471','PRJ_5468','PRJ_5428','PRJ_5430','PRJ_5455','PRJ_5466','PRJ_5470','PRJ_5467','PRJ_5469');


### PR DESCRIPTION
## What does this pull request do?

- contract offboarding for ETE contracts. The contract referral end date is set at 31st December 2023 23:59:00

## What is the intent behind these changes?

- ETE contract needs to be off boarded by the end of 2023
