### PR TITLE
deleting the test table and columns

### DIFF
--- a/src/main/resources/db/migration/R__data_dictionary.sql
+++ b/src/main/resources/db/migration/R__data_dictionary.sql
@@ -207,13 +207,4 @@ COMMENT ON COLUMN referral_summary.end_requested_at IS 'referral end requested a
 COMMENT ON COLUMN referral_summary.eosr_id IS 'referral end of service id';
 COMMENT ON COLUMN referral_summary.appointment_id IS 'supplier assessment appointment id';
 
-COMMENT ON TABLE test_reports IS 'testing read replica works fine';
-
-COMMENT ON COLUMN test_reports.referral_id IS 'referral uuid';
-COMMENT ON COLUMN test_reports.test_id IS 'id for the table';
-COMMENT ON COLUMN test_reports.topic IS 'topic for the test';
-
-COMMENT ON COLUMN referral_location.test_reports IS 'additional column for testing'
-
-
 -- some definitions are in V1_34__document_contract_table.sql; needs lifting

--- a/src/main/resources/db/migration/V1_155__delete_test_report_create_temp_table.sql
+++ b/src/main/resources/db/migration/V1_155__delete_test_report_create_temp_table.sql
@@ -1,0 +1,9 @@
+DROP TABLE test_reports;
+
+alter table referral_location
+drop column test_reports;
+
+DELETE FROM metadata where table_name = 'referral_location' AND column_name = 'test_reports';
+DELETE FROM metadata where table_name = 'test_reports' AND column_name = 'referral_id';
+DELETE FROM metadata where table_name = 'test_reports' AND column_name = 'test_id';
+DELETE FROM metadata where table_name = 'test_reports' AND column_name = 'topic';


### PR DESCRIPTION
## What does this pull request do?

- Deleting the test table and column which was used to test the read replica and migration
- Reverting the PR https://github.com/ministryofjustice/hmpps-interventions-service/pull/1734

## What is the intent behind these changes?

- Reverting the PR https://github.com/ministryofjustice/hmpps-interventions-service/pull/1734
