### PR TITLE
introducing H2 database for performance report jobs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.hibernate:hibernate-core:5.6.15.Final")
   implementation("com.vladmihalcea:hibernate-types-55:2.21.1")
+  implementation("com.h2database:h2:2.2.224")
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql:42.7.1")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,20 +1,31 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.explore.JobExplorer
+import org.springframework.batch.core.explore.support.JobExplorerFactoryBean
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
 
 @Configuration
 class BatchConfiguration(
   @Value("\${spring.batch.concurrency.pool-size}") private val poolSize: Int,
   @Value("\${spring.batch.concurrency.queue-size}") private val queueSize: Int,
 ) {
-  @Bean
-  fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
+
+  @Bean("asyncJobLauncher")
+  fun asyncJobLauncher(@Qualifier("batchJobRepository") jobRepository: JobRepository): JobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
     taskExecutor.corePoolSize = poolSize
     taskExecutor.queueCapacity = queueSize
@@ -25,5 +36,55 @@ class BatchConfiguration(
     launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher
+  }
+
+  @Bean("batchJobRepository")
+  fun batchJobRepository(
+    @Qualifier("batchDataSource") dataSource: DataSource,
+    transactionManager: PlatformTransactionManager,
+  ): JobRepository {
+    val factory = JobRepositoryFactoryBean()
+    factory.setDataSource(dataSource)
+    factory.setDatabaseType("H2")
+    factory.transactionManager = transactionManager
+    factory.afterPropertiesSet()
+    return factory.`object`
+  }
+
+  @Bean("batchDataSource")
+  fun batchDataSource(): DataSource {
+    return EmbeddedDatabaseBuilder()
+      .setType(EmbeddedDatabaseType.H2)
+      .addScript("/org/springframework/batch/core/schema-drop-h2.sql")
+      .addScript("/org/springframework/batch/core/schema-h2.sql")
+      .build()
+  }
+
+  @Bean("batchJobBuilderFactory")
+  fun batchJobBuilderFactory(@Qualifier("batchJobRepository") jobRepository: JobRepository): JobBuilderFactory {
+    return JobBuilderFactory(jobRepository)
+  }
+
+  @Bean("batchStepBuilderFactory")
+  fun batchStepBuilderFactory(@Qualifier("batchJobRepository") jobRepository: JobRepository, transactionManager: PlatformTransactionManager): StepBuilderFactory {
+    return StepBuilderFactory(jobRepository, transactionManager)
+  }
+
+  @Bean("batchJobExplorer")
+  fun jobExplorer(@Qualifier("batchDataSource") dataSource: DataSource): JobExplorer {
+    val factory = JobExplorerFactoryBean()
+    factory.setDataSource(dataSource)
+    factory.afterPropertiesSet()
+    return factory.getObject()
+  }
+
+  @Bean("jobBuilderFactory")
+  fun jobBuilderFactory(@Qualifier("jobRepository") jobRepository: JobRepository): JobBuilderFactory {
+    return JobBuilderFactory(jobRepository)
+  }
+
+  @Bean("stepBuilderFactory")
+  fun stepBuilderFactory(@Qualifier("jobRepository") jobRepository: JobRepository, transactionManager: PlatformTransactionManager): StepBuilderFactory {
+    return StepBuilderFactory(jobRepository, transactionManager)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/DataSourceConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/DataSourceConfig.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import javax.sql.DataSource
+
+@Configuration
+class DataSourceConfig(
+  @Value("\${spring.datasource.url}") private val dataSourceUrl: String,
+  @Value("\${spring.datasource.username}") private val dataSourceUserName: String,
+  @Value("\${spring.datasource.password}") private val dataSourcePassword: String,
+) {
+
+  @Bean("mainDataSource")
+  @Primary
+  fun dataSource(): DataSource {
+    return DataSourceBuilder.create()
+      .driverClassName("org.postgresql.Driver")
+      .url(dataSourceUrl)
+      .username(dataSourceUserName)
+      .password(dataSourcePassword)
+      .build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
@@ -12,6 +12,7 @@ import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
 import org.springframework.batch.item.file.FlatFileItemWriter
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -23,8 +24,8 @@ import java.util.Date
 @Configuration
 @EnableBatchProcessing
 class PerformanceReportJobConfiguration(
-  private val jobBuilderFactory: JobBuilderFactory,
-  private val stepBuilderFactory: StepBuilderFactory,
+  @Qualifier("batchJobBuilderFactory") private val jobBuilderFactory: JobBuilderFactory,
+  @Qualifier("batchStepBuilderFactory") private val stepBuilderFactory: StepBuilderFactory,
   private val batchUtils: BatchUtils,
   private val listener: PerformanceReportJobListener,
   @Value("\${spring.batch.jobs.service-provider.performance-report.chunk-size}") private val chunkSize: Int,


### PR DESCRIPTION
## What does this pull request do?

- introducing H2 database for managing spring batch transactions

## What is the intent behind these changes?

- performance report now points to read only replica and we need a separate db for maintaining spring batch transaction tables
