### PR TITLE
Bump dps spring plugin version to fix vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("plugin.spring") version "1.9.22"
   id("org.jetbrains.kotlin.plugin.jpa") version "1.9.22"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.14.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.1"
   id("jacoco")
 }
 


### PR DESCRIPTION
## What does this pull request do?

Increased dps spring version to cope with a trivy vulnerability

## What is the intent behind these changes?

Address security concern and move to latest available spring version in the dps plugin
