### PR TITLE
Remove redundant jobRepository bean which is a duplicate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -63,19 +63,6 @@ class BatchConfiguration(
     return factory.`object`
   }
 
-  @Bean("jobRepository")
-  fun jobRepository(
-    @Qualifier("mainDataSource") dataSource: DataSource,
-    transactionManager: PlatformTransactionManager,
-  ): JobRepository {
-    val factory = JobRepositoryFactoryBean()
-    factory.setDataSource(dataSource)
-    factory.setDatabaseType("POSTGRES")
-    factory.transactionManager = transactionManager
-    factory.afterPropertiesSet()
-    return factory.`object`
-  }
-
   @Bean("batchDataSource")
   fun batchDataSource(): DataSource {
     return EmbeddedDatabaseBuilder()


### PR DESCRIPTION
## What does this pull request do?

Removes a redundant jobRepository bean as it's already defined.

## What is the intent behind these changes?

Fix deploy issue observed releasing into DEV
