### PR TITLE
Point batch jobs to use primary JobRepository

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
@@ -6,7 +6,6 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.Timestam
 @Configuration
 @EnableBatchProcessing
 class ConcludeReferralsJobConfiguration(
-  @Qualifier("jobRepository") private val jobRepository: JobRepository,
+  private val jobRepository: JobRepository,
   private val transactionManager: PlatformTransactionManager,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
@@ -7,7 +7,6 @@ import org.springframework.batch.core.job.DefaultJobParametersValidator
 import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.Timestam
 @Configuration
 @EnableBatchProcessing
 class TransferReferralsJobConfiguration(
-  @Qualifier("jobRepository") private val jobRepository: JobRepository,
+  private val jobRepository: JobRepository,
   private val transactionManager: PlatformTransactionManager,
   private val listener: TransferReferralsJobListener,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -17,7 +17,6 @@ import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
 import org.springframework.batch.item.file.FlatFileItemWriter
 import org.springframework.batch.repeat.RepeatStatus
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
@@ -38,7 +37,7 @@ import java.nio.file.Path
 @Configuration
 @EnableBatchProcessing
 class NdmisPerformanceReportJobConfiguration(
-  @Qualifier("jobRepository") private val jobRepository: JobRepository,
+  private val jobRepository: JobRepository,
   private val transactionManager: PlatformTransactionManager,
   private val batchUtils: BatchUtils,
   private val s3Service: S3Service,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
@@ -24,10 +24,10 @@ import kotlin.io.path.pathString
 class NdmisPerformanceJobLauncherTestUtils : JobLauncherTestUtils() {
 
   @Autowired
-  override fun setJobRepository(@Qualifier("batchJobRepository") jobRepository: JobRepository) = super.setJobRepository(jobRepository)
+  override fun setJobRepository(jobRepository: JobRepository) = super.setJobRepository(jobRepository)
 
   @Autowired
-  fun testJobLauncher(@Qualifier("jobRepository") jobRepository: JobRepository) {
+  fun testJobLauncher(jobRepository: JobRepository) {
     val testJobLauncher = SimpleJobLauncher()
     testJobLauncher.setJobRepository(jobRepository)
     testJobLauncher.afterPropertiesSet()


### PR DESCRIPTION
 instead of batchJobRepository due to issue with TM on H2

## What does this pull request do?

Point batch jobs to primary spring defined job repository

## What is the intent behind these changes?

Resolve issue with batch jobs seen in Dev
