### PR TITLE
Move batch jobs to run with a JpaTransactionManager

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
@@ -9,7 +9,7 @@ import org.springframework.batch.core.step.builder.StepBuilder
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.orm.jpa.JpaTransactionManager
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.Timestam
 @EnableBatchProcessing
 class ConcludeReferralsJobConfiguration(
   private val jobRepository: JobRepository,
-  private val transactionManager: PlatformTransactionManager,
+  private val transactionManager: JpaTransactionManager,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
 ) {
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
@@ -10,7 +10,7 @@ import org.springframework.batch.core.step.builder.StepBuilder
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.orm.jpa.JpaTransactionManager
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.Timestam
 @EnableBatchProcessing
 class TransferReferralsJobConfiguration(
   private val jobRepository: JobRepository,
-  private val transactionManager: PlatformTransactionManager,
+  private val transactionManager: JpaTransactionManager,
   private val listener: TransferReferralsJobListener,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -22,7 +22,7 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.FileSystemResource
-import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.orm.jpa.JpaTransactionManager
 import org.springframework.transaction.annotation.Transactional
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
@@ -39,7 +39,7 @@ import java.nio.file.Path
 @EnableBatchProcessing
 class NdmisPerformanceReportJobConfiguration(
   private val jobRepository: JobRepository,
-  private val transactionManager: PlatformTransactionManager,
+  private val transactionManager: JpaTransactionManager,
   private val batchUtils: BatchUtils,
   private val s3Service: S3Service,
   private val ndmisS3Bucket: S3Bucket,


### PR DESCRIPTION
## What does this pull request do?

Moves tranaction manager from platform to JPA

## What is the intent behind these changes?

Fix issue observed in dev with closed EntotyManagerFactory, preventing reports running
