### PR TITLE
Move NDMIS to use readOnlyJobLauncher

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
@@ -14,7 +14,7 @@ import kotlin.io.path.pathString
 
 @Service
 class ReportingService(
-  private val asyncJobLauncher: JobLauncher,
+  // private val asyncJobLauncher: JobLauncher,
   private val asyncReadOnlyJobLauncher: JobLauncher,
   private val performanceReportJob: Job,
   private val ndmisPerformanceReportJob: Job,
@@ -42,7 +42,7 @@ class ReportingService(
 
   fun generateNdmisPerformanceReport() {
     val outputDir = createTempDirectory("test")
-    asyncJobLauncher.run(
+    asyncReadOnlyJobLauncher.run(
       ndmisPerformanceReportJob,
       JobParametersBuilder()
         .addString("outputPath", outputDir.pathString)


### PR DESCRIPTION
## What does this pull request do?

Move NDMIS report to read only connection via asyncReadOnlyJobLauncher

## What is the intent behind these changes?

Make reports source data consistent and check if this resolves issue with batch job status error.