### PR TITLE
Fallback to single connection for reporting

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{- include "deployment-reporting.envs" . | nindent 10 }}
+  {{- include "deployment.envs" . | nindent 10 }}
       volumes:
         - name: heap-dumps
           emptyDir: {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,20 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
-import org.springframework.batch.core.explore.JobExplorer
-import org.springframework.batch.core.explore.support.JobExplorerFactoryBean
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.repository.JobRepository
-import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
-import org.springframework.transaction.PlatformTransactionManager
-import javax.sql.DataSource
 
 @Configuration
 class BatchConfiguration(
@@ -23,7 +15,7 @@ class BatchConfiguration(
 ) {
 
   @Bean("asyncJobLauncher")
-  fun asyncJobLauncher(@Qualifier("jobRepository") jobRepository: JobRepository): JobLauncher {
+  fun asyncJobLauncher(jobRepository: JobRepository): JobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
     taskExecutor.corePoolSize = poolSize
     taskExecutor.queueCapacity = queueSize
@@ -34,53 +26,5 @@ class BatchConfiguration(
     launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher
-  }
-
-  @Bean("asyncReadOnlyJobLauncher")
-  fun asyncReadOnlyJobLauncher(@Qualifier("batchJobRepository") jobRepository: JobRepository): JobLauncher {
-    val taskExecutor = ThreadPoolTaskExecutor()
-    taskExecutor.corePoolSize = poolSize
-    taskExecutor.queueCapacity = queueSize
-    taskExecutor.afterPropertiesSet()
-
-    val launcher = SimpleJobLauncher()
-    launcher.setJobRepository(jobRepository)
-    launcher.setTaskExecutor(taskExecutor)
-    launcher.afterPropertiesSet()
-    return launcher
-  }
-
-  @Bean("batchJobRepository")
-  fun batchJobRepository(
-    @Qualifier("batchDataSource") dataSource: DataSource,
-    transactionManager: PlatformTransactionManager,
-  ): JobRepository {
-    val factory = JobRepositoryFactoryBean()
-    factory.setDataSource(batchDataSource())
-    factory.setDatabaseType("H2")
-    factory.transactionManager = transactionManager
-    factory.afterPropertiesSet()
-    return factory.`object`
-  }
-
-  @Bean("batchDataSource")
-  fun batchDataSource(): DataSource {
-    return EmbeddedDatabaseBuilder()
-      .setType(EmbeddedDatabaseType.H2)
-      .addScript("/org/springframework/batch/core/schema-drop-h2.sql")
-      .addScript("/org/springframework/batch/core/schema-h2.sql")
-      .build()
-  }
-
-  @Bean("batchJobExplorer")
-  fun jobExplorer(
-    @Qualifier("batchDataSource") dataSource: DataSource,
-    transactionManager: PlatformTransactionManager,
-  ): JobExplorer {
-    val factory = JobExplorerFactoryBean()
-    factory.setDataSource(dataSource)
-    factory.setTransactionManager(transactionManager)
-    factory.afterPropertiesSet()
-    return factory.getObject()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.Timestam
 
 @Configuration
 @EnableBatchProcessing
-@EnableTransactionManagement
 class ConcludeReferralsJobConfiguration(
   private val jobRepository: JobRepository,
   private val transactionManager: JpaTransactionManager,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/concludereferrals/ConcludeReferralsJobConfiguration.kt
@@ -10,7 +10,6 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.orm.jpa.JpaTransactionManager
-import org.springframework.transaction.annotation.EnableTransactionManagement
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
@@ -11,7 +11,6 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.orm.jpa.JpaTransactionManager
-import org.springframework.transaction.annotation.EnableTransactionManagement
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.TimestampIncrementer

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/transferreferrals/TransferReferralsJobConfiguration.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.Timestam
 
 @Configuration
 @EnableBatchProcessing
-@EnableTransactionManagement
 class TransferReferralsJobConfiguration(
   private val jobRepository: JobRepository,
   private val transactionManager: JpaTransactionManager,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -37,7 +37,6 @@ import java.nio.file.Path
 @Configuration
 @EnableBatchProcessing
 class NdmisPerformanceReportJobConfiguration(
-  /*@Qualifier("batchJobRepository") */
   private val jobRepository: JobRepository,
   private val transactionManager: PlatformTransactionManager,
   private val batchUtils: BatchUtils,
@@ -60,19 +59,6 @@ class NdmisPerformanceReportJobConfiguration(
     return onStartupJobLauncherFactory.makeBatchLauncher(ndmisPerformanceReportJob)
   }
 
-/*  @Bean
-  @JobScope
-  fun ndmisReader(
-    sessionFactory: SessionFactory,
-  ): JpaPagingItemReader<Referral> {
-    // this reader returns referral entities which need processing for the report.
-    return JpaPagingItemReaderBuilder<Referral>()
-      .name("ndmisPerformanceReportReader")
-      .sessionFactory(sessionFactory)
-      .queryString("from Referral")
-      .build()
-  }
-*/
   @Bean
   @JobScope
   fun ndmisReader(entityManagerFactory: EntityManagerFactory): JpaPagingItemReader<Referral> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
@@ -13,7 +13,6 @@ import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
 import org.springframework.batch.item.file.FlatFileItemWriter
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -26,7 +25,7 @@ import java.util.Date
 @Configuration
 @EnableBatchProcessing
 class PerformanceReportJobConfiguration(
-  @Qualifier("batchJobRepository") private val jobRepository: JobRepository,
+  private val jobRepository: JobRepository,
   private val transactionManager: PlatformTransactionManager,
   private val batchUtils: BatchUtils,
   private val listener: PerformanceReportJobListener,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
@@ -15,7 +15,6 @@ import kotlin.io.path.pathString
 @Service
 class ReportingService(
   private val asyncJobLauncher: JobLauncher,
-  private val asyncReadOnlyJobLauncher: JobLauncher,
   private val performanceReportJob: Job,
   private val ndmisPerformanceReportJob: Job,
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper,
@@ -26,7 +25,7 @@ class ReportingService(
     val contracts = serviceProviderAccessScopeMapper.fromUser(user).contracts
     val userDetail = hmppsAuthService.getUserDetail(user)
 
-    asyncReadOnlyJobLauncher.run(
+    asyncJobLauncher.run(
       performanceReportJob,
       JobParametersBuilder()
         .addString("contractReferences", contracts.joinToString(",") { it.contractReference })


### PR DESCRIPTION
## What does this pull request do?

Reverts earlier changes and falls back to using a single connection for transactional / reporting use

## What is the intent behind these changes?

Fix issues observed in dev for Spring upgrade due to EntityManagerFactory being closed.
