### PR TITLE
Restore legacy cursors fir eager fetch in Hibernate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -1,12 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config
 
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.explore.JobExplorer
+import org.springframework.batch.core.explore.support.JobExplorerFactoryBean
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher
 import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
 
 @Configuration
 class BatchConfiguration(
@@ -26,5 +36,46 @@ class BatchConfiguration(
     launcher.setTaskExecutor(taskExecutor)
     launcher.afterPropertiesSet()
     return launcher
+  }
+
+  @Bean("batchJobRepository")
+  fun jobRepository(
+    @Qualifier("batchDataSource") dataSource: DataSource,
+    transactionManager: PlatformTransactionManager,
+  ): JobRepository {
+    val factory = JobRepositoryFactoryBean()
+    factory.setDataSource(dataSource)
+    factory.setDatabaseType("H2")
+    factory.transactionManager = transactionManager
+    factory.afterPropertiesSet()
+    return factory.`object`
+  }
+
+  @Bean("batchDataSource")
+  fun batchDataSource(): DataSource {
+    return EmbeddedDatabaseBuilder()
+      .setType(EmbeddedDatabaseType.H2)
+      .addScript("/org/springframework/batch/core/schema-drop-h2.sql")
+      .addScript("/org/springframework/batch/core/schema-h2.sql")
+      .build()
+  }
+
+  @Bean("batchJobBuilderFactory")
+  fun jobBuilderFactory(jobRepository: JobRepository): JobBuilderFactory {
+    return JobBuilderFactory(jobRepository)
+  }
+
+  @Bean("batchStepBuilderFactory")
+  fun stepBuilderFactory(jobRepository: JobRepository, transactionManager: PlatformTransactionManager): StepBuilderFactory {
+    return StepBuilderFactory(jobRepository)
+  }
+
+  @Bean("batchJobExplorer")
+  fun jobExplorer(@Qualifier("batchDataSource") dataSource: DataSource, transactionManager: PlatformTransactionManager): JobExplorer {
+    val factory = JobExplorerFactoryBean()
+    factory.setDataSource(dataSource)
+    factory.transactionManager = transactionManager
+    factory.afterPropertiesSet()
+    return factory.getObject()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance
 
-import jakarta.persistence.EntityManagerFactory
 import mu.KLogging
 import org.hibernate.SessionFactory
 import org.springframework.batch.core.Job

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -2,27 +2,28 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.p
 
 import jakarta.persistence.EntityManagerFactory
 import mu.KLogging
+import org.hibernate.SessionFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
 import org.springframework.batch.core.StepContribution
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
 import org.springframework.batch.core.configuration.annotation.JobScope
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.core.job.DefaultJobParametersValidator
-import org.springframework.batch.core.job.builder.JobBuilder
-import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.scope.context.ChunkContext
-import org.springframework.batch.core.step.builder.StepBuilder
-import org.springframework.batch.item.database.JpaPagingItemReader
-import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder
+import org.springframework.batch.item.database.HibernateCursorItemReader
+import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
 import org.springframework.batch.item.file.FlatFileItemWriter
 import org.springframework.batch.repeat.RepeatStatus
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.FileSystemResource
-import org.springframework.orm.jpa.JpaTransactionManager
+import org.springframework.transaction.PlatformTransactionManager
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.config.S3Bucket
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.OnStartupJobLauncherFactory
@@ -37,12 +38,13 @@ import java.nio.file.Path
 @Configuration
 @EnableBatchProcessing
 class NdmisPerformanceReportJobConfiguration(
-  private val jobRepository: JobRepository,
-  private val transactionManager: JpaTransactionManager,
+  @Qualifier("batchJobBuilderFactory") private val jobBuilderFactory: JobBuilderFactory,
+  @Qualifier("batchStepBuilderFactory") private val stepBuilderFactory: StepBuilderFactory,
   private val batchUtils: BatchUtils,
   private val s3Service: S3Service,
   private val ndmisS3Bucket: S3Bucket,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
+  private val transactionManager: PlatformTransactionManager,
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
   companion object : KLogging()
@@ -60,13 +62,15 @@ class NdmisPerformanceReportJobConfiguration(
   }
 
   @Bean
-  fun ndmisReader(entityManagerFactory: EntityManagerFactory): JpaPagingItemReader<Referral> {
+  @JobScope
+  fun ndmisReader(
+    sessionFactory: SessionFactory,
+  ): HibernateCursorItemReader<Referral> {
     // this reader returns referral entities which need processing for the report.
-    return JpaPagingItemReaderBuilder<Referral>()
-      .entityManagerFactory(entityManagerFactory)
-      .queryString("select r from Referral r")
-      .pageSize(20)
-      .name("ndmisReader")
+    return HibernateCursorItemReaderBuilder<Referral>()
+      .name("ndmisPerformanceReportReader")
+      .sessionFactory(sessionFactory)
+      .queryString("select r from Referral r where sentAt is not null")
       .build()
   }
 
@@ -124,7 +128,8 @@ class NdmisPerformanceReportJobConfiguration(
   ): Job {
     val validator = DefaultJobParametersValidator()
     validator.setRequiredKeys(arrayOf("timestamp", "outputPath"))
-    return JobBuilder("ndmisPerformanceReportJob", jobRepository)
+
+    return jobBuilderFactory["ndmisPerformanceReportJob"]
       .incrementer { parameters -> OutputPathIncrementer().getNext(TimestampIncrementer().getNext(parameters)) }
       .validator(validator)
       .start(ndmisWriteReferralToCsvStep)
@@ -137,72 +142,76 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   fun ndmisWriteReferralToCsvStep(
-    ndmisReader: JpaPagingItemReader<Referral>,
+    ndmisReader: HibernateCursorItemReader<Referral>,
     processor: ReferralsProcessor,
     writer: FlatFileItemWriter<ReferralsData>,
   ): Step {
-    return StepBuilder("ndmisWriteReferralToCsvStep", jobRepository)
+    return stepBuilderFactory.get("ndmisWriteReferralToCsvStep")
       .chunk<Referral, ReferralsData>(chunkSize, transactionManager)
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
       .faultTolerant()
       .skipPolicy(skipPolicy)
+      .transactionManager(transactionManager)
       .build()
   }
 
   @Bean
   fun ndmisWriteComplexityToCsvStep(
-    ndmisReader: JpaPagingItemReader<Referral>,
+    ndmisReader: HibernateCursorItemReader<Referral>,
     processor: ComplexityProcessor,
     writer: FlatFileItemWriter<Collection<ComplexityData>>,
   ): Step {
-    return StepBuilder("ndmisWriteComplexityToCsvStep", jobRepository)
+    return stepBuilderFactory.get("ndmisWriteComplexityToCsvStep")
       .chunk<Referral, List<ComplexityData>>(chunkSize, transactionManager)
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
       .faultTolerant()
       .skipPolicy(skipPolicy)
+      .transactionManager(transactionManager)
       .build()
   }
 
   @Bean
   fun ndmisWriteAppointmentToCsvStep(
-    ndmisReader: JpaPagingItemReader<Referral>,
+    ndmisReader: HibernateCursorItemReader<Referral>,
     processor: AppointmentProcessor,
     writer: FlatFileItemWriter<Collection<AppointmentData>>,
   ): Step {
-    return StepBuilder("ndmisWriteAppointmentToCsvStep", jobRepository)
+    return stepBuilderFactory.get("ndmisWriteAppointmentToCsvStep")
       .chunk<Referral, List<AppointmentData>>(chunkSize, transactionManager)
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
       .faultTolerant()
       .skipPolicy(skipPolicy)
+      .transactionManager(transactionManager)
       .build()
   }
 
   @Bean
   fun ndmisWriteOutcomeToCsvStep(
-    ndmisReader: JpaPagingItemReader<Referral>,
+    ndmisReader: HibernateCursorItemReader<Referral>,
     processor: OutcomeProcessor,
     writer: FlatFileItemWriter<Collection<OutcomeData>>,
   ): Step {
-    return StepBuilder("ndmisWriteOutcomeToCsvStep", jobRepository)
+    return stepBuilderFactory.get("ndmisWriteOutcomeToCsvStep")
       .chunk<Referral, List<OutcomeData>>(chunkSize, transactionManager)
       .reader(ndmisReader)
       .processor(processor)
       .writer(writer)
       .faultTolerant()
       .skipPolicy(skipPolicy)
+      .transactionManager(transactionManager)
       .build()
   }
 
   @JobScope
   @Bean
   fun pushToS3Step(@Value("#{jobParameters['outputPath']}") outputPath: String): Step =
-    StepBuilder("pushToS3Step", jobRepository).tasklet(pushFilesToS3(outputPath), transactionManager).build()
+    stepBuilderFactory["pushToS3Step"].tasklet(pushFilesToS3(outputPath), transactionManager).build()
 
   private fun pushFilesToS3(outputPath: String) = { _: StepContribution, _: ChunkContext ->
     listOf(referralReportFilename, complexityReportFilename, appointmentReportFilename, outcomeReportFilename).forEach { file ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
@@ -7,6 +7,7 @@ import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.JobExecution
 import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.test.JobLauncherTestUtils
@@ -70,8 +71,6 @@ class NdmisPerformanceReportJobConfigurationTest : IntegrationTestBase() {
       attended = Attended.YES,
       referral = referral,
     )
-
-    logger.info { "We are setup" }
 
     val parameters = JobParametersBuilder()
       .addString("outputPath", outputDir.pathString)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfigurationTest.kt
@@ -7,7 +7,6 @@ import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.JobExecution
 import org.springframework.batch.core.JobParametersBuilder
-import org.springframework.batch.core.launch.support.SimpleJobLauncher
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.test.JobLauncherTestUtils


### PR DESCRIPTION
## What does this pull request do?

Falls back to using hibernate cursors due to LazyInitialisation exceptiona

## What is the intent behind these changes?

Make NDMIS report work in Spring 6
