### PR TITLE
Ignoring CVE-2024-22234 temporarily to let build run

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,3 +13,8 @@ CVE-2022-45868
 # Suppression for logback-classic and logback-core as we don't let third parties control our appenders.
 # See https://logback.qos.ch/news.html#1.3.12 for further information.
 CVE-2023-6378
+# Suppression for spring-security-core CVE-2024-22234 temporarily to the release roll on.
+# The fix would be available very soon on the main dps spring boot build
+CVE-2024-22234
+
+


### PR DESCRIPTION
## What does this pull request do?

- Ignoring trivy issue temporarily
- The fix is available very soon and this ignore will be reverted back

## What is the intent behind these changes?

- Ignoring the trivy issue just to get the build going
