### PR TITLE
Revert "Pointed the perf report to read-replica"

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{- include "deployment-reporting.envs" . | nindent 10 }}
+  {{- include "deployment.envs" . | nindent 10 }}
       volumes:
         - name: heap-dumps
           emptyDir: {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportJobConfiguration.kt
@@ -13,7 +13,6 @@ import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
 import org.springframework.batch.item.file.FlatFileItemWriter
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -26,7 +25,6 @@ import java.util.Date
 @Configuration
 @EnableBatchProcessing
 class PerformanceReportJobConfiguration(
-  @Qualifier("batchJobRepository")
   private val jobRepository: JobRepository,
   private val transactionManager: PlatformTransactionManager,
   private val batchUtils: BatchUtils,


### PR DESCRIPTION
This reverts commit 7b95fb6d812d9381816e88a7e5f651bb4dbaea62.

## What does this pull request do?

Reverted the previous commit which was pointing to read-replica.

## What is the intent behind these changes?

The change did not work as expected hence reverting so other changes can go.
