### PR TITLE
Change isolation level to a value H2 supports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -48,7 +48,7 @@ class BatchConfiguration(
     factory.setDataSource(dataSource)
     factory.setDatabaseType("H2")
     factory.transactionManager = transactionManager
-    factory.setIsolationLevelForCreateEnum(Isolation.REPEATABLE_READ)
+    factory.setIsolationLevelForCreateEnum(Isolation.READ_COMMITTED)
     factory.afterPropertiesSet()
     return factory.`object`
   }


### PR DESCRIPTION
(to prevent fallback to SERIALIZED)

## What does this pull request do?

Sets isolation level to h2 supported value

## What is the intent behind these changes?

Allow use of H2 database for reporting batch config, allowing read only replica to serve the report
