### PR TITLE
Set job launcher for NDMIS job to be a read only job launcher

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -40,7 +40,7 @@ class BatchConfiguration(
   }
 
   @Bean("readOnlyJobLauncher")
-  fun readOnlyJobLauncher(@Qualifier("batchJobRepository") jobRepository: JobRepository): TaskExecutorJobLauncher {
+  fun readOnlyJobLauncher(@Qualifier("batchJobRepository") jobRepository: JobRepository): JobLauncher {
     val taskExecutor = ThreadPoolTaskExecutor()
     taskExecutor.corePoolSize = poolSize
     taskExecutor.queueCapacity = queueSize

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/BatchConfiguration.kt
@@ -39,6 +39,20 @@ class BatchConfiguration(
     return launcher
   }
 
+  @Bean("readOnlyJobLauncher")
+  fun readOnlyJobLauncher(@Qualifier("batchJobRepository") jobRepository: JobRepository): TaskExecutorJobLauncher {
+    val taskExecutor = ThreadPoolTaskExecutor()
+    taskExecutor.corePoolSize = poolSize
+    taskExecutor.queueCapacity = queueSize
+    taskExecutor.afterPropertiesSet()
+
+    val launcher = TaskExecutorJobLauncher()
+    launcher.setJobRepository(jobRepository)
+    launcher.setTaskExecutor(taskExecutor)
+    launcher.afterPropertiesSet()
+    return launcher
+  }
+
   @Bean("batchJobRepository")
   fun jobRepository(
     @Qualifier("batchDataSource") dataSource: DataSource,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/OnStartupJobLauncherFactory.kt
@@ -6,6 +6,7 @@ import org.springframework.batch.core.Job
 import org.springframework.batch.core.converter.DefaultJobParametersConverter
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.batch.core.launch.support.SimpleJvmExitCodeMapper
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component
@@ -41,6 +42,22 @@ class OnStartupJobLauncherFactory(
       } ?: rawParams
 
       val execution = jobLauncher.run(job, nextParams)
+      return exitCodeMapper.intValue(execution.exitStatus.exitCode)
+    }
+
+    return makeLauncher(job.name, entryPoint)
+  }
+  fun makeReadOnlyBatchLauncher(job: Job, readOnlyJobLauncher: TaskExecutorJobLauncher): ApplicationRunner {
+    val entryPoint = fun(args: ApplicationArguments): Int {
+      val rawParams = jobParametersConverter.getJobParameters(
+        StringUtils.splitArrayElementsIntoProperties(args.nonOptionArgs.toTypedArray(), "="),
+      )
+
+      val nextParams = job.jobParametersIncrementer?.let {
+        it.getNext(rawParams)
+      } ?: rawParams
+
+      val execution = readOnlyJobLauncher.run(job, nextParams)
       return exitCodeMapper.intValue(execution.exitStatus.exitCode)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -11,6 +11,7 @@ import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.core.job.DefaultJobParametersValidator
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher
 import org.springframework.batch.core.scope.context.ChunkContext
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
@@ -44,6 +45,7 @@ class NdmisPerformanceReportJobConfiguration(
   private val ndmisS3Bucket: S3Bucket,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
   private val transactionManager: PlatformTransactionManager,
+  private val readOnlyJobLauncher: TaskExecutorJobLauncher,
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
   companion object : KLogging()
@@ -57,7 +59,7 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   fun ndmisPerformanceReportJobLauncher(ndmisPerformanceReportJob: Job): ApplicationRunner {
-    return onStartupJobLauncherFactory.makeBatchLauncher(ndmisPerformanceReportJob)
+    return onStartupJobLauncherFactory.makeReadOnlyBatchLauncher(ndmisPerformanceReportJob, readOnlyJobLauncher)
   }
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -11,7 +11,6 @@ import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.core.job.DefaultJobParametersValidator
-import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher
 import org.springframework.batch.core.scope.context.ChunkContext
 import org.springframework.batch.item.database.HibernateCursorItemReader
 import org.springframework.batch.item.database.builder.HibernateCursorItemReaderBuilder
@@ -45,7 +44,6 @@ class NdmisPerformanceReportJobConfiguration(
   private val ndmisS3Bucket: S3Bucket,
   private val onStartupJobLauncherFactory: OnStartupJobLauncherFactory,
   private val transactionManager: PlatformTransactionManager,
-  private val readOnlyJobLauncher: TaskExecutorJobLauncher,
   @Value("\${spring.batch.jobs.ndmis.performance-report.chunk-size}") private val chunkSize: Int,
 ) {
   companion object : KLogging()
@@ -59,7 +57,7 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   fun ndmisPerformanceReportJobLauncher(ndmisPerformanceReportJob: Job): ApplicationRunner {
-    return onStartupJobLauncherFactory.makeReadOnlyBatchLauncher(ndmisPerformanceReportJob, readOnlyJobLauncher)
+    return onStartupJobLauncherFactory.makeReadOnlyBatchLauncher(ndmisPerformanceReportJob)
   }
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReportingService.kt
@@ -15,6 +15,7 @@ import kotlin.io.path.pathString
 @Service
 class ReportingService(
   private val asyncJobLauncher: JobLauncher,
+  private val readOnlyJobLauncher: JobLauncher,
   private val performanceReportJob: Job,
   private val ndmisPerformanceReportJob: Job,
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper,
@@ -41,7 +42,7 @@ class ReportingService(
 
   fun generateNdmisPerformanceReport() {
     val outputDir = createTempDirectory("test")
-    asyncJobLauncher.run(
+    readOnlyJobLauncher.run(
       ndmisPerformanceReportJob,
       JobParametersBuilder()
         .addString("outputPath", outputDir.pathString)


### PR DESCRIPTION
Set job launcher for NDMIS job to be a read only job launcher referencing the read only job repository in the batch job's configuration

## What does this pull request do?

Change how NDMIS report is launched, to use the batch job launcher instead of read / write launcher

## What is the intent behind these changes?

Fix problem with NDMIS report to allow it to run against read replica, thereby imoroving performance,
