### PR TITLE
Temporarily check notifyProbationPractitioner  in feedback requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
@@ -65,7 +65,7 @@ class DeliverySessionController(
       updateAppointmentDTO.attendanceFeedback?.attended,
       updateAppointmentDTO.attendanceFeedback?.didSessionHappen,
       updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-      updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+      updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: updateAppointmentDTO.sessionFeedback?.notifyProbationPractitioner,
       updateAppointmentDTO.sessionFeedback?.late,
       updateAppointmentDTO.sessionFeedback?.lateReason,
       updateAppointmentDTO.sessionFeedback?.futureSessionPlans,
@@ -172,7 +172,7 @@ class DeliverySessionController(
       request.attendanceFeedback?.attended,
       request.attendanceFeedback?.didSessionHappen,
       request.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-      request.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+      request.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: request.sessionFeedback?.notifyProbationPractitioner,
       request.sessionFeedback?.late,
       request.sessionFeedback?.lateReason,
       request.sessionFeedback?.futureSessionPlans,
@@ -216,7 +216,7 @@ class DeliverySessionController(
       request.attendanceFeedback?.attended,
       request.attendanceFeedback?.didSessionHappen,
       request.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-      request.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+      request.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: request.sessionFeedback?.notifyProbationPractitioner,
       request.sessionFeedback?.late,
       request.sessionFeedback?.lateReason,
       request.sessionFeedback?.futureSessionPlans,
@@ -286,7 +286,7 @@ class DeliverySessionController(
       request.sessionBehaviour,
       request.sessionConcerns,
       request.notifyProbationPractitionerOfBehaviour,
-      request.notifyProbationPractitionerOfConcerns,
+      request.notifyProbationPractitionerOfConcerns ?: request.notifyProbationPractitioner,
     )
     return DeliverySessionAppointmentDTO.from(updatedSessionAppointment.first.sessionNumber, updatedSessionAppointment.second)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -55,7 +55,7 @@ class SupplierAssessmentController(
         updateAppointmentDTO.attendanceFeedback?.attended,
         updateAppointmentDTO.attendanceFeedback?.didSessionHappen,
         updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-        updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+        updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: updateAppointmentDTO.sessionFeedback?.notifyProbationPractitioner,
         updateAppointmentDTO.sessionFeedback?.late,
         updateAppointmentDTO.sessionFeedback?.lateReason,
         updateAppointmentDTO.sessionFeedback?.futureSessionPlans,
@@ -140,7 +140,7 @@ class SupplierAssessmentController(
         request.sessionBehaviour,
         request.sessionConcerns,
         request.notifyProbationPractitionerOfBehaviour,
-        request.notifyProbationPractitionerOfConcerns,
+        request.notifyProbationPractitionerOfConcerns ?: request.notifyProbationPractitioner,
         user,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -69,8 +69,9 @@ data class SessionFeedbackRequestDTO(
   val sessionResponse: String? = null,
   val sessionConcerns: String? = null,
   val sessionBehaviour: String? = null,
-  val notifyProbationPractitionerOfBehaviour: Boolean,
-  val notifyProbationPractitionerOfConcerns: Boolean,
+  val notifyProbationPractitioner: Boolean? = null,
+  val notifyProbationPractitionerOfBehaviour: Boolean? = null,
+  val notifyProbationPractitionerOfConcerns: Boolean? = null,
 )
 
 data class DeliverySessionDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -183,8 +183,8 @@ class AppointmentService(
     sessionResponse: String?,
     sessionBehaviour: String?,
     sessionConcerns: String?,
-    notifyProbationPractitionerOfBehaviour: Boolean,
-    notifyProbationPractitionerOfConcerns: Boolean,
+    notifyProbationPractitionerOfBehaviour: Boolean?,
+    notifyProbationPractitionerOfConcerns: Boolean?,
     submittedBy: AuthUser,
   ): Appointment {
     if (appointment.appointmentFeedbackSubmittedAt != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -436,8 +436,8 @@ class DeliverySessionService(
     sessionResponse: String?,
     sessionBehaviour: String?,
     sessionConcerns: String?,
-    notifyProbationPractitionerOfBehaviour: Boolean,
-    notifyProbationPractitionerOfConcerns: Boolean,
+    notifyProbationPractitionerOfBehaviour: Boolean?,
+    notifyProbationPractitionerOfConcerns: Boolean?,
   ): Pair<DeliverySession, Appointment> {
     val sessionAndAppointment = getDeliverySessionAppointmentOrThrowException(referralId, appointmentId)
     val updatedAppointment = appointmentService.recordSessionFeedback(
@@ -517,8 +517,8 @@ class DeliverySessionService(
         sessionResponse,
         sessionBehaviour,
         sessionConcerns,
-        notifyProbationPractitionerOfBehaviour!!,
-        notifyProbationPractitionerOfConcerns!!,
+        notifyProbationPractitionerOfBehaviour,
+        notifyProbationPractitionerOfConcerns,
         updatedBy,
       )
       appointmentService.submitAppointmentFeedback(appointment, updatedBy, SERVICE_DELIVERY, session)
@@ -559,8 +559,8 @@ class DeliverySessionService(
     sessionResponse: String?,
     sessionBehaviour: String?,
     sessionConcerns: String?,
-    notifyProbationPractitionerOfBehaviour: Boolean,
-    notifyProbationPractitionerOfConcerns: Boolean,
+    notifyProbationPractitionerOfBehaviour: Boolean?,
+    notifyProbationPractitionerOfConcerns: Boolean?,
     actor: AuthUser,
   ) {
     appointment.late = late


### PR DESCRIPTION
## What does this pull request do?

Temporarily check notifyProbationPractitioner  in feedback requests

## What is the intent behind these changes?

To prevent issues with in-progress feedback in between deployments.
