### PR TITLE
Make transaction manager a prototype bean 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/DataSourceConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/DataSourceConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.jdbc.DataSourceBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Scope
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
 import org.springframework.orm.jpa.JpaTransactionManager
@@ -39,6 +40,7 @@ class DataSourceConfig(
   }
 
   @Bean("batchTransactionManager")
+  @Scope("prototype")
   fun batchTransactionManager(): PlatformTransactionManager {
     return JpaTransactionManager()
   }


### PR DESCRIPTION

## What does this pull request do?

Make transaction manager a prototype bean to avoid issues with share transactions in parallel scope.

## What is the intent behind these changes?

Fix issues with runtime errors appearing in DEV believed to be related to shared transaction manager.
