### PR TITLE
Case note and notify pp hotfix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteController.kt
@@ -41,6 +41,7 @@ class CaseNoteController(
       referralId = sentReferral.id,
       subject = createCaseNote.subject,
       body = createCaseNote.body,
+      sendEmail = createCaseNote.sendEmail,
       sentByUser = user,
     )
     return CaseNoteDTO.from(caseNote)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
@@ -65,7 +65,7 @@ class DeliverySessionController(
       updateAppointmentDTO.attendanceFeedback?.attended,
       updateAppointmentDTO.attendanceFeedback?.didSessionHappen,
       updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-      updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+      updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: updateAppointmentDTO.sessionFeedback?.notifyProbationPractitioner,
       updateAppointmentDTO.sessionFeedback?.late,
       updateAppointmentDTO.sessionFeedback?.lateReason,
       updateAppointmentDTO.sessionFeedback?.futureSessionPlans,
@@ -172,7 +172,7 @@ class DeliverySessionController(
       request.attendanceFeedback?.attended,
       request.attendanceFeedback?.didSessionHappen,
       request.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-      request.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+      request.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: request.sessionFeedback?.notifyProbationPractitioner,
       request.sessionFeedback?.late,
       request.sessionFeedback?.lateReason,
       request.sessionFeedback?.futureSessionPlans,
@@ -216,7 +216,7 @@ class DeliverySessionController(
       request.attendanceFeedback?.attended,
       request.attendanceFeedback?.didSessionHappen,
       request.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-      request.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+      request.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: request.sessionFeedback?.notifyProbationPractitioner,
       request.sessionFeedback?.late,
       request.sessionFeedback?.lateReason,
       request.sessionFeedback?.futureSessionPlans,
@@ -286,7 +286,7 @@ class DeliverySessionController(
       request.sessionBehaviour,
       request.sessionConcerns,
       request.notifyProbationPractitionerOfBehaviour,
-      request.notifyProbationPractitionerOfConcerns,
+      request.notifyProbationPractitionerOfConcerns ?: request.notifyProbationPractitioner,
     )
     return DeliverySessionAppointmentDTO.from(updatedSessionAppointment.first.sessionNumber, updatedSessionAppointment.second)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SupplierAssessmentController.kt
@@ -55,7 +55,7 @@ class SupplierAssessmentController(
         updateAppointmentDTO.attendanceFeedback?.attended,
         updateAppointmentDTO.attendanceFeedback?.didSessionHappen,
         updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfBehaviour,
-        updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns,
+        updateAppointmentDTO.sessionFeedback?.notifyProbationPractitionerOfConcerns ?: updateAppointmentDTO.sessionFeedback?.notifyProbationPractitioner,
         updateAppointmentDTO.sessionFeedback?.late,
         updateAppointmentDTO.sessionFeedback?.lateReason,
         updateAppointmentDTO.sessionFeedback?.futureSessionPlans,
@@ -140,7 +140,7 @@ class SupplierAssessmentController(
         request.sessionBehaviour,
         request.sessionConcerns,
         request.notifyProbationPractitionerOfBehaviour,
-        request.notifyProbationPractitionerOfConcerns,
+        request.notifyProbationPractitionerOfConcerns ?: request.notifyProbationPractitioner,
         user,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/CaseNoteDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/CaseNoteDTO.kt
@@ -23,4 +23,5 @@ data class CreateCaseNoteDTO(
   val referralId: UUID,
   val subject: String,
   val body: String,
+  val sendEmail: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DeliverySessionDTO.kt
@@ -69,8 +69,9 @@ data class SessionFeedbackRequestDTO(
   val sessionResponse: String? = null,
   val sessionConcerns: String? = null,
   val sessionBehaviour: String? = null,
-  val notifyProbationPractitionerOfBehaviour: Boolean,
-  val notifyProbationPractitionerOfConcerns: Boolean,
+  val notifyProbationPractitioner: Boolean? = null,
+  val notifyProbationPractitionerOfBehaviour: Boolean? = null,
+  val notifyProbationPractitionerOfConcerns: Boolean? = null,
 )
 
 data class DeliverySessionDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisher.kt
@@ -15,6 +15,7 @@ class CreateCaseNoteEvent(
   val sentBy: AuthUser,
   val detailUrl: String,
   val referralId: UUID,
+  val sendEmail: Boolean?,
 ) : ApplicationEvent(source) {
   override fun toString(): String = "CreateCaseNoteEvent(caseNoteId=$caseNoteId, referralId=$referralId)"
 }
@@ -24,7 +25,7 @@ class CaseNoteEventPublisher(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val locationMapper: LocationMapper,
 ) {
-  fun caseNoteSentEvent(caseNote: CaseNote) {
+  fun caseNoteSentEvent(caseNote: CaseNote, sendEmail: Boolean?) {
     applicationEventPublisher.publishEvent(
       CreateCaseNoteEvent(
         this,
@@ -32,6 +33,7 @@ class CaseNoteEventPublisher(
         caseNote.sentBy,
         caseNoteUrl(caseNote),
         caseNote.referral.id,
+        sendEmail,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -183,8 +183,8 @@ class AppointmentService(
     sessionResponse: String?,
     sessionBehaviour: String?,
     sessionConcerns: String?,
-    notifyProbationPractitionerOfBehaviour: Boolean,
-    notifyProbationPractitionerOfConcerns: Boolean,
+    notifyProbationPractitionerOfBehaviour: Boolean?,
+    notifyProbationPractitionerOfConcerns: Boolean?,
     submittedBy: AuthUser,
   ): Appointment {
     if (appointment.appointmentFeedbackSubmittedAt != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteService.kt
@@ -24,7 +24,7 @@ class CaseNoteService(
   val caseNoteEventPublisher: CaseNoteEventPublisher,
 ) {
 
-  fun createCaseNote(referralId: UUID, subject: String, body: String, sentByUser: AuthUser): CaseNote {
+  fun createCaseNote(referralId: UUID, subject: String, body: String, sendEmail: Boolean?, sentByUser: AuthUser): CaseNote {
     val caseNote = CaseNote(
       id = UUID.randomUUID(),
       referral = referralRepository.getById(referralId),
@@ -34,7 +34,7 @@ class CaseNoteService(
       sentAt = OffsetDateTime.now(),
     )
     return caseNoteRepository.save(caseNote).also {
-      caseNoteEventPublisher.caseNoteSentEvent(it)
+      caseNoteEventPublisher.caseNoteSentEvent(it, sendEmail)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DeliverySessionService.kt
@@ -436,8 +436,8 @@ class DeliverySessionService(
     sessionResponse: String?,
     sessionBehaviour: String?,
     sessionConcerns: String?,
-    notifyProbationPractitionerOfBehaviour: Boolean,
-    notifyProbationPractitionerOfConcerns: Boolean,
+    notifyProbationPractitionerOfBehaviour: Boolean?,
+    notifyProbationPractitionerOfConcerns: Boolean?,
   ): Pair<DeliverySession, Appointment> {
     val sessionAndAppointment = getDeliverySessionAppointmentOrThrowException(referralId, appointmentId)
     val updatedAppointment = appointmentService.recordSessionFeedback(
@@ -517,8 +517,8 @@ class DeliverySessionService(
         sessionResponse,
         sessionBehaviour,
         sessionConcerns,
-        notifyProbationPractitionerOfBehaviour!!,
-        notifyProbationPractitionerOfConcerns!!,
+        notifyProbationPractitionerOfBehaviour,
+        notifyProbationPractitionerOfConcerns,
         updatedBy,
       )
       appointmentService.submitAppointmentFeedback(appointment, updatedBy, SERVICE_DELIVERY, session)
@@ -559,8 +559,8 @@ class DeliverySessionService(
     sessionResponse: String?,
     sessionBehaviour: String?,
     sessionConcerns: String?,
-    notifyProbationPractitionerOfBehaviour: Boolean,
-    notifyProbationPractitionerOfConcerns: Boolean,
+    notifyProbationPractitionerOfBehaviour: Boolean?,
+    notifyProbationPractitionerOfConcerns: Boolean?,
     actor: AuthUser,
   ) {
     appointment.late = late

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/CaseNotesNotificationsService.kt
@@ -33,7 +33,9 @@ class CaseNotesNotificationsService(
   override fun onApplicationEvent(event: CreateCaseNoteEvent) {
     referralService.getSentReferralForUser(event.referralId, event.sentBy)?.let { referral ->
       emailAssignedCaseWorker(referral, event.sentBy, event.caseNoteId)
-      emailResponsibleProbationPractitioner(referral, event.sentBy, event.caseNoteId)
+      if (event.sendEmail == null || event.sendEmail) {
+        emailResponsibleProbationPractitioner(referral, event.sentBy, event.caseNoteId)
+      }
     } ?: run {
       throw RuntimeException("Unable to retrieve referral for id ${event.referralId}")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/CaseNoteControllerTest.kt
@@ -45,11 +45,11 @@ class CaseNoteControllerTest {
       val userToken = tokenFactory.create(user)
       val caseNote = caseNoteFactory.create(subject = "subject", body = "body")
       val referralId = caseNote.referral.id
-      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body")
+      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body", sendEmail = true)
 
       whenever(authUserRepository.save(any())).thenReturn(user)
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(referralFactory.createSent(id = referralId))
-      whenever(caseNoteService.createCaseNote(referralId = referralId, subject = "subject", body = "body", sentByUser = user)).thenReturn(caseNote)
+      whenever(caseNoteService.createCaseNote(referralId = referralId, subject = "subject", body = "body", sendEmail = true, sentByUser = user)).thenReturn(caseNote)
 
       val caseNoteDTO = caseNoteController.createCaseNote(createCaseNoteDTO, userToken)
       assertThat(caseNoteDTO).isEqualTo(CaseNoteDTO.from(caseNote))
@@ -61,7 +61,7 @@ class CaseNoteControllerTest {
       val userToken = tokenFactory.create(user)
       val caseNote = caseNoteFactory.create(subject = "subject", body = "body")
       val referralId = caseNote.referral.id
-      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body")
+      val createCaseNoteDTO = CreateCaseNoteDTO(referralId = referralId, subject = "subject", body = "body", sendEmail = true)
       whenever(referralService.getSentReferralForUser(id = referralId, user = user)).thenReturn(null)
       whenever(authUserRepository.save(any())).thenReturn(user)
       val e = assertThrows<ResponseStatusException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/CaseNoteEventPublisherTest.kt
@@ -25,7 +25,7 @@ internal class CaseNoteEventPublisherTest {
     whenever(locationMapper.getPathFromControllerMethod(CaseNoteController::getCaseNote)).thenReturn("/case-note/{id}")
     val publisher = CaseNoteEventPublisher(eventPublisher, locationMapper)
 
-    publisher.caseNoteSentEvent(caseNote)
+    publisher.caseNoteSentEvent(caseNote, true)
 
     val eventCaptor = argumentCaptor<CreateCaseNoteEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())
@@ -36,5 +36,6 @@ internal class CaseNoteEventPublisherTest {
     assertThat(event.sentBy).isSameAs(caseNote.sentBy)
     assertThat(event.detailUrl).isEqualTo(uri.toString())
     assertThat(event.referralId).isSameAs(caseNote.referral.id)
+    assertThat(event.sendEmail).isEqualTo(true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/authorization/RequestFactory.kt
@@ -50,7 +50,7 @@ class RequestFactory(private val webTestClient: WebTestClient, private val setup
       Request.GetServiceProviderReferralsSummary -> webTestClient.get().uri("/sent-referrals/summary/service-provider")
 
       Request.CreateCaseNote -> webTestClient.post().uri("/case-note").bodyValue(
-        if (body != null) body as CreateCaseNoteDTO else CreateCaseNoteDTO(urlParams[0] as UUID, "subject", "body"),
+        if (body != null) body as CreateCaseNoteDTO else CreateCaseNoteDTO(urlParams[0] as UUID, "subject", "body", false),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNoteServiceTest.kt
@@ -50,7 +50,8 @@ class CaseNoteServiceTest @Autowired constructor(
     fun `can create case note`() {
       val referral = referralFactory.createSent()
       val user = userFactory.create()
-      val caseNote = caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", user)
+      val sendEmail = false
+      val caseNote = caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sendEmail = sendEmail, user)
       val savedCaseNote = caseNoteRepository.findById(caseNote.id).get()
       assertThat(caseNote).isEqualTo(savedCaseNote)
       assertThat(caseNote.referral.id).isEqualTo(referral.id)
@@ -59,7 +60,7 @@ class CaseNoteServiceTest @Autowired constructor(
       assertThat(caseNote.sentAt).isNotNull()
       assertThat(caseNote.sentBy).isEqualTo(user)
 
-      verify(caseNoteEventPublisher).caseNoteSentEvent(caseNote)
+      verify(caseNoteEventPublisher).caseNoteSentEvent(caseNote, sendEmail)
     }
   }
 
@@ -159,7 +160,7 @@ class CaseNoteServiceTest @Autowired constructor(
     fun `can get case note by id`() {
       val referral = referralFactory.createSent()
       val caseNote =
-        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sentByUser = referral.sentBy!!)
+        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sendEmail = false, sentByUser = referral.sentBy!!)
 
       val retrievedCaseNote = caseNoteService.getCaseNoteForUser(caseNote.id, referral.sentBy!!)
       assertThat(retrievedCaseNote).isEqualTo(caseNote)
@@ -169,7 +170,7 @@ class CaseNoteServiceTest @Autowired constructor(
     fun `user can't get case note without access to referral`() {
       val referral = referralFactory.createSent()
       val caseNote =
-        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sentByUser = referral.sentBy!!)
+        caseNoteService.createCaseNote(referral.id, subject = "subject", body = "body", sendEmail = false, sentByUser = referral.sentBy!!)
       whenever(
         referralService.getSentReferralForUser(
           caseNote.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/CaseNotesNotificationsServiceTest.kt
@@ -61,6 +61,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
+      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -108,6 +109,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
+      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -147,6 +149,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
+      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -185,6 +188,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
+      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -230,6 +234,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       referral.id,
+      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(eventRequiringSPNotification)
@@ -269,6 +274,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       caseNote.referral.id,
+      true,
     )
 
     caseNotesNotificationsService.onApplicationEvent(event)
@@ -300,6 +306,7 @@ internal class CaseNotesNotificationsServiceTest {
       caseNote.sentBy,
       "detailUrl",
       UUID.fromString("e5274827-fcbc-4891-a68b-d9b4d3b59dab"),
+      true,
     )
     var e = assertThrows<RuntimeException> { caseNotesNotificationsService.onApplicationEvent(event) }
     Assertions.assertThat(e.message).contains("Unable to retrieve referral for id e5274827-fcbc-4891-a68b-d9b4d3b59dab")


### PR DESCRIPTION
## What does this pull request do?

Reverts the revert of case note email opt out commit and adds the notify pp of poor behaviour changes backwards compatibility commit

## What is the intent behind these changes?

Reverts the revert of case note email opt out commit and adds the notify pp of poor behaviour changes backwards compatibility commit