### PR TITLE
Make main db transaction manager a prototyoe bean

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/DataSourceConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/config/DataSourceConfig.kt
@@ -46,6 +46,7 @@ class DataSourceConfig(
   }
 
   @Bean("transactionManager")
+  @Scope("prototype")
   @Primary
   fun transactionManager(): PlatformTransactionManager {
     return JpaTransactionManager()


### PR DESCRIPTION
Make main db transaction manager a prototyoe bean & pass to individual flows instead of at global job level

(cherry picked from commit ea50da77ff48b5e11ad5596c5ed47fd1f082d894)

## What does this pull request do?

Passes a prototype bean for TX manager down to individual flows

## What is the intent behind these changes?

Make parallel processing of NDMIS report work and speed up the process
