### PR TITLE
NDMIS reader singleton > prototype

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -23,6 +23,7 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
+import org.springframework.context.annotation.Scope
 import org.springframework.core.io.FileSystemResource
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.core.task.TaskExecutor
@@ -69,6 +70,7 @@ class NdmisPerformanceReportJobConfiguration(
 
   @Bean
   @StepScope
+  @Scope("prototype")
   fun ndmisReader(
     sessionFactory: SessionFactory,
   ): HibernateCursorItemReader<Referral> {
@@ -148,7 +150,7 @@ class NdmisPerformanceReportJobConfiguration(
         ),
       )
       .next(pushToS3Step)
-      .build()
+      .end()
       .build()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -23,7 +23,6 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
-import org.springframework.context.annotation.Scope
 import org.springframework.core.io.FileSystemResource
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.core.task.TaskExecutor

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/NdmisPerformanceReportJobConfiguration.kt
@@ -23,6 +23,7 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
+import org.springframework.context.annotation.Scope
 import org.springframework.core.io.FileSystemResource
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.core.task.TaskExecutor
@@ -77,6 +78,7 @@ class NdmisPerformanceReportJobConfiguration(
       .name("ndmisPerformanceReportReader")
       .sessionFactory(sessionFactory)
       .queryString("select r from Referral r where sentAt is not null")
+      .saveState(false)
       .build()
   }
 


### PR DESCRIPTION
## What does this pull request do?

Makes job reader a prototype bean to prevent sharing in the NDMIS report config

## What is the intent behind these changes?

Overcome issues observed when parallel processor is deployed to DEV
