### PR TITLE
add missing ifEmpty check to appointment processor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/AppointmentProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/AppointmentProcessor.kt
@@ -24,13 +24,13 @@ class AppointmentProcessor(
         appointmentTime = NdmisDateTime(it.appointmentTime),
         durationInMinutes = it.durationInMinutes,
         bookedAt = NdmisDateTime(it.createdAt),
-        didSessionHappen = it.didSessionHappen,
         attended = it.attended,
+        didSessionHappen = it.didSessionHappen,
         attendanceSubmittedAt = it.attendanceSubmittedAt?.let { t -> NdmisDateTime(t) },
         notifyPPOfAttendanceBehaviour = it.notifyPPOfAttendanceBehaviour,
         deliusAppointmentId = it.deliusAppointmentId.toString(),
         reasonForAppointment = if (saaAppointments.contains(it)) AppointmentReason.SAA else AppointmentReason.DELIVERY,
       )
-    }
+    }.ifEmpty { null }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/AppointmentProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/AppointmentProcessorTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance.AppointmentData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance.AppointmentProcessor
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.ndmis.performance.AppointmentReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.DeliverySessionService
@@ -69,10 +68,7 @@ internal class AppointmentProcessorTest {
     whenever(deliverySessionService.getSessions(referral.id)).thenReturn(emptyList())
 
     val result = processor.process(referral)
-
-    val expected: List<AppointmentData> = emptyList()
-
-    assertThat(result).isEqualTo(expected)
+    assertThat(result).isNull()
   }
 
   @Test


### PR DESCRIPTION
## What does this pull request do?

Adds back in the empty check to the appointment processor

## What is the intent behind these changes?

Currently the ndmis is failing in dev.
