### PR TITLE
Point ndmis jobs back to use primary database

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-appointment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-appointment-performance-report.yaml
@@ -20,7 +20,7 @@ spec:
               volumeMounts:
                 - name: heap-dumps
                   mountPath: /dumps
-  {{- include "deployment-replica.envs" . | nindent 14 }}
+  {{- include "deployment.envs" . | nindent 14 }}
           volumes:
             - name: heap-dumps
               emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-complexity-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-complexity-performance-report.yaml
@@ -20,7 +20,7 @@ spec:
               volumeMounts:
                 - name: heap-dumps
                   mountPath: /dumps
-  {{- include "deployment-replica.envs" . | nindent 14 }}
+  {{- include "deployment.envs" . | nindent 14 }}
           volumes:
             - name: heap-dumps
               emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-outcome-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-outcome-performance-report.yaml
@@ -20,7 +20,7 @@ spec:
               volumeMounts:
                 - name: heap-dumps
                   mountPath: /dumps
-  {{- include "deployment-replica.envs" . | nindent 14 }}
+  {{- include "deployment.envs" . | nindent 14 }}
           volumes:
             - name: heap-dumps
               emptyDir: {}

--- a/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-referral-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/cronjob-ndmis-referral-performance-report.yaml
@@ -20,7 +20,7 @@ spec:
               volumeMounts:
                 - name: heap-dumps
                   mountPath: /dumps
-  {{- include "deployment-replica.envs" . | nindent 14 }}
+  {{- include "deployment.envs" . | nindent 14 }}
           volumes:
             - name: heap-dumps
               emptyDir: {}


### PR DESCRIPTION
## What does this pull request do?

Moves NDMIS jobs back to using primary database

## What is the intent behind these changes?

Deal with errors observed when reporting against read replica
