### PR TITLE
remove validation checks that aren't necessary for this flow

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/validator/AppointmentValidator.kt
@@ -158,7 +158,6 @@ class AppointmentValidator {
             POP_UNACCEPTABLE -> checkValueSupplied(noSessionReasonPopUnacceptable, "sessionFeedback.noSessionReasonPopUnacceptable", Code.CANNOT_BE_EMPTY, errors)
             LOGISTICS -> checkValueSupplied(noSessionReasonLogistics, "sessionFeedback.noSessionReasonLogistics", Code.CANNOT_BE_EMPTY, errors)
           }
-          checkValueSupplied(notifyProbationPractitionerOfBehaviour, "sessionFeedback.notifyProbationPractitionerOfBehaviour", Code.CANNOT_BE_EMPTY, errors)
           checkValueSupplied(notifyProbationPractitionerOfConcerns, "sessionFeedback.notifyProbationPractitionerOfConcerns", Code.CANNOT_BE_EMPTY, errors)
           if (notifyProbationPractitionerOfBehaviour == true) {
             checkValueSupplied(sessionBehaviour, "sessionFeedback.sessionBehaviour", Code.CANNOT_BE_EMPTY, errors)
@@ -169,7 +168,6 @@ class AppointmentValidator {
         }
         NO -> {
           checkValueSupplied(noAttendanceInformation, "sessionFeedback.noAttendanceInformation", Code.CANNOT_BE_EMPTY, errors)
-          checkValueSupplied(notifyProbationPractitionerOfBehaviour, "sessionFeedback.notifyProbationPractitionerOfBehaviour", Code.CANNOT_BE_EMPTY, errors)
           checkValueSupplied(notifyProbationPractitionerOfConcerns, "sessionFeedback.notifyProbationPractitionerOfConcerns", Code.CANNOT_BE_EMPTY, errors)
           if (notifyProbationPractitionerOfBehaviour == true) {
             checkValueSupplied(sessionBehaviour, "sessionFeedback.sessionBehaviour", Code.CANNOT_BE_EMPTY, errors)


### PR DESCRIPTION
## What does this pull request do?

Removes validation checks that aren't needed for the flow where did-session-happen is false.

## What is the intent behind these changes?

Current you are prevented from submitting feedback for a historic appointment if you select did-session-happen as false, as the validation is expecting fields to be there that aren't.
