### PR TITLE
retrieve the cancelled referral without SAA

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecifications.kt
@@ -2,14 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.specification
 
 import jakarta.persistence.criteria.JoinType
 import org.springframework.data.jpa.domain.Specification
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DynamicFrameworkContract
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.EndOfServiceReport
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import java.time.OffsetDateTime
 import java.util.UUID
 class ReferralSpecifications {
@@ -21,21 +19,9 @@ class ReferralSpecifications {
       }
     }
 
-    fun <T> concluded(concluded: Boolean?): Specification<T> {
-      return if (concluded == true) {
-        Specification<T> { root, _, cb ->
-          val supplierAssessmentJoin = root.join<T, SupplierAssessment>("supplierAssessment", JoinType.LEFT)
-          cb.and(
-            cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
-            cb.isNotEmpty(supplierAssessmentJoin.get<MutableSet<Appointment>>("appointments")),
-          )
-        }
-      } else {
-        Specification<T> { root, _, cb ->
-          cb.and(
-            cb.isNotNull(root.get<OffsetDateTime>("concludedAt")),
-          )
-        }
+    fun <T> concluded(): Specification<T> {
+      return Specification<T> { root, _, cb ->
+        cb.isNotNull(root.get<OffsetDateTime>("concludedAt"))
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -158,7 +158,7 @@ class ReferralService(
   ): Specification<T> {
     var findSentReferralsSpec = ReferralSpecifications.sent<T>()
 
-    findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, concluded, ReferralSpecifications.concluded(concluded))
+    findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, concluded, ReferralSpecifications.concluded())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, cancelled, ReferralSpecifications.cancelled())
     findSentReferralsSpec = applyOptionalConjunction(findSentReferralsSpec, unassigned, ReferralSpecifications.unassigned())
     assignedToUserId?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/specification/ReferralSpecificationsTest.kt
@@ -120,7 +120,7 @@ class ReferralSpecificationsTest @Autowired constructor(
       val sentReferralSummary = referralSumariesFactory.getReferralSummary(sent)
       val cancelledReferralSummary = referralSumariesFactory.getReferralSummary(cancelled)
       val completedReferralSummary = referralSumariesFactory.getReferralSummary(completed, endOfServiceReport)
-      val result = sentReferralSummariesRepository.findAll(ReferralSpecifications.concluded(true))
+      val result = sentReferralSummariesRepository.findAll(ReferralSpecifications.concluded())
       assertThat(result)
         .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
         .contains(completedReferralSummary)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -880,7 +880,7 @@ class ReferralServiceTest @Autowired constructor(
       val result = referralService.getSentReferralSummaryForUser(user, true, null, null, null, pageRequest)
       assertThat(result)
         .usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration)
-        .containsExactlyInAnyOrder(completedSentReferralSummary)
+        .containsExactlyInAnyOrder(completedSentReferralSummary, cancelledSentReferralSummary)
       assertThat(result).doesNotContain(liveSentReferralSummary, selfAssignedSentReferralSummary, otherAssignedSentReferralSummary)
     }
 
@@ -980,7 +980,7 @@ class ReferralServiceTest @Autowired constructor(
       entityManager.refresh(completedReferral)
       completedSentReferralSummary = sentReferralSummariesFactory.getReferralSummary(completedReferral)
       val result = referralService.getSentReferralSummaryForUser(user, true, true, true, null, pageRequest)
-      assertThat(result).isEmpty()
+      assertThat(result).isNotEmpty
     }
 
     @Test


### PR DESCRIPTION
## What does this pull request do?

- retrieve the cancelled referral done pre SAA

## What is the intent behind these changes?

- The cancelled referral done pre SAA has not been shown in the dashboard and now we have decided to show it to them
