### PR TITLE
new api to saving any new user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionUserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionUserController.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.AuthUserDTO
+
+@RestController
+@PreAuthorize("hasRole('ROLE_PROBATION') or hasRole('ROLE_CRS_PROVIDER') or hasRole('ROLE_INTERVENTIONS_API_READ_ALL')")
+class InterventionUserController(private val userMapper: UserMapper) {
+
+  @PostMapping("/intervention/user")
+  fun createNewUserFromToken(authenticationToken: JwtAuthenticationToken): AuthUserDTO {
+    return AuthUserDTO.from(userMapper.fromToken(authenticationToken))
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

- New api with end point `/intervention/user` which saves new user into interventions auth repository db

## What is the intent behind these changes?

- When the dashboard api was pointing to read replica db, the new users trying to access the db, the new users were not able to store in our auth db.
- So this new api will store the users first and then the dashboard api will not need to store the new user which will allow them to point it back to read replica
