### PR TITLE
point dashboard queries to read replica

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{- include "deployment.envs" . | nindent 10 }}
+  {{- include "deployment-replica.envs" . | nindent 10 }}
       volumes:
         - name: heap-dumps
           emptyDir: {}


### PR DESCRIPTION
## What does this pull request do?

point dashboard queries to read replica and allow instance size for primary database to be reduced in the future.

## What is the intent behind these changes?

Move load for read-only dashboard queries to read replica, to improve application performance 