### PR TITLE
Suppress spring trivy issue

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,6 +13,9 @@ CVE-2022-45868
 # Suppression for logback-classic and logback-core as we don't let third parties control our appenders.
 # See https://logback.qos.ch/news.html#1.3.12 for further information.
 CVE-2023-6378
+# Supression for spring security / spring web while we await new DPS spring version
+CVE-2024-22257
+CVE-2024-22259
 # Suppression for spring vulnerability which hasn't yet been patched in DPS project,
 # remove once upgraded and don't apply to PROD
 CVE-2024-22262

--- a/.trivyignore
+++ b/.trivyignore
@@ -13,6 +13,6 @@ CVE-2022-45868
 # Suppression for logback-classic and logback-core as we don't let third parties control our appenders.
 # See https://logback.qos.ch/news.html#1.3.12 for further information.
 CVE-2023-6378
-# Supression for spring security / spring web while we await new DPS spring version
-CVE-2024-22257
-CVE-2024-22259
+# Suppression for spring vulnerability which hasn't yet been patched in DPS project,
+# remove once upgraded and don't apply to PROD
+CVE-2024-22262


### PR DESCRIPTION
To allow testing in dev while waiting for dps project upgrade

## What does this pull request do?

Suppress spring trivy issue while waiting for dps project update

## What is the intent behind these changes?

Allow testing in dev while awaiting new dep library upgrade
