### PR TITLE
adding intervention to be completed by field to performance report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportData.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.serviceprovider.performance
 
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -29,6 +30,7 @@ data class PerformanceReportData(
   val eosrSubmittedAt: OffsetDateTime?,
   val concludedAt: OffsetDateTime?,
   val referralEndState: String?,
+  val dateInterventionToBeCompletedBy: LocalDate?,
 ) {
   companion object {
     // it would be neater to use reflection to get the fields, but we cannot guarantee the order
@@ -58,6 +60,7 @@ data class PerformanceReportData(
       "eosrSubmittedAt",
       "concludedAt",
       "referralEndState",
+      "dateInterventionToBeCompletedBy",
     )
     val headers = listOf(
       "referral_ref",
@@ -85,6 +88,7 @@ data class PerformanceReportData(
       "date_eosr_submitted",
       "concluded_at",
       "referral_end_state",
+      "date_intervention_to_be_completed_by",
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/performance/PerformanceReportProcessor.kt
@@ -50,6 +50,7 @@ class PerformanceReportProcessor(
       eosrSubmittedAt = referral.endOfServiceReport?.submittedAt,
       concludedAt = referral.concludedAt,
       referralEndState = referral.endState,
+      dateInterventionToBeCompletedBy = referral.referralDetails?.completionDeadline,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/serviceprovider/PerformanceReportDataProcessorTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ActionPlanFac
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.SupplierAssessmentFactory
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 internal class PerformanceReportDataProcessorTest {
@@ -30,11 +31,10 @@ internal class PerformanceReportDataProcessorTest {
     val supplierAssessmentFirstAppointment = appointmentFactory.create(attended = Attended.NO, createdAt = OffsetDateTime.parse("2022-07-01T10:42:43+00:00"))
     val supplierAssessmentNewAppointment = appointmentFactory.create(attended = Attended.YES, createdAt = OffsetDateTime.parse("2022-07-02T10:42:43+00:00"))
     val approvedActionPlanAppointment = appointmentFactory.create(attended = Attended.YES, appointmentFeedbackSubmittedAt = OffsetDateTime.parse("2022-07-02T10:42:43+00:00"))
-    val unApprovedAppointment = appointmentFactory.create()
     val supplierAssessment = supplierAssessmentFactory.create(appointment = supplierAssessmentFirstAppointment)
     supplierAssessment.appointments.add(supplierAssessmentNewAppointment)
     val actionPlan = actionPlanFactory.createApproved()
-    val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan), supplierAssessment = supplierAssessment)
+    val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan), supplierAssessment = supplierAssessment, completionDeadline = LocalDate.of(2024, 5, 20))
 
     whenever(appointmentRepository.findAllByReferralId(referral.id)).thenReturn(listOf(supplierAssessmentFirstAppointment, supplierAssessmentNewAppointment))
     whenever(actionPlanService.getFirstAttendedAppointment(actionPlan)).thenReturn(approvedActionPlanAppointment)
@@ -53,5 +53,6 @@ internal class PerformanceReportDataProcessorTest {
     assertThat(performanceReportData.firstSessionAttendedAt).isEqualTo(approvedActionPlanAppointment.appointmentTime)
     assertThat(performanceReportData.numberOfSessionsAttended).isEqualTo(1)
     assertThat(performanceReportData.supplierAssessmentAttendedOnTime).isEqualTo(true)
+    assertThat(performanceReportData.dateInterventionToBeCompletedBy).isEqualTo(referral.referralDetails?.completionDeadline)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

- add `intervention to be completed by` date field to service provider performance report

## What is the intent behind these changes?

client wanted this field to be part of the report
