### PR TITLE
new endpoint for retrieving referral appointment information

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ProbationCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ProbationCaseController.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.LocationMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ProbationCaseReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAppointmentDetailsDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ProbationCaseService
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 
@@ -27,5 +28,14 @@ class ProbationCaseController(
     val location = locationMapper.expandPathToCurrentRequestUrl("/probation-case/{crn}/referral", crn)
 
     return ResponseEntity.created(location).body(probationCaseDetails)
+  }
+
+  @PreAuthorize("hasRole('ROLE_INTERVENTIONS_REFER_AND_MONITOR')")
+  @GetMapping("/appointments-location/{crn}")
+  fun getAppointmentLocationByCrn(
+    @PathVariable crn: String,
+    authentication: JwtAuthenticationToken,
+  ): ReferralAppointmentDetailsDTO {
+    return ReferralAppointmentDetailsDTO.from(crn, probationCaseService.getAppointmentLocationDetails(crn))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralAppointmentDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralAppointmentDetailsDTO.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
+
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralAppointmentLocationDetails
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ReferralAppointmentDetailsDTO(
+  val crn: String,
+  val referrals: List<ReferralDetailDTO>,
+) {
+
+  companion object {
+    fun from(crn: String, referralAppointmentDetails: List<ReferralAppointmentLocationDetails>): ReferralAppointmentDetailsDTO {
+      return ReferralAppointmentDetailsDTO(
+        crn = crn,
+        referrals = referralAppointmentDetails.map { ReferralDetailDTO.from(it) },
+      )
+    }
+  }
+}
+
+class ReferralDetailDTO(
+  val referral_number: String?,
+  val appointments: List<AppointmentDetailsDTO>,
+) {
+  companion object {
+    fun from(referralAppointmentDetails: ReferralAppointmentLocationDetails): ReferralDetailDTO {
+      return ReferralDetailDTO(
+        referral_number = referralAppointmentDetails.referral.referenceNumber,
+        appointments = AppointmentDetailsDTO.from(referralAppointmentDetails.appointments),
+      )
+    }
+  }
+}
+
+class AppointmentDetailsDTO(
+  val appointment_id: UUID?,
+  val appointment_date_time: OffsetDateTime?,
+  val appointment_duration_in_minutes: Int?,
+  val superseded_indicator: Boolean?,
+  val appointment_delivery_first_address_line: String?,
+  val appointment_delivery_second_address_line: String?,
+  val appointment_delivery_town_city: String?,
+  val appointment_delivery_county: String?,
+  val appointment_delivery_postcode: String?,
+) {
+  companion object {
+
+    fun from(appointments: List<Appointment>): List<AppointmentDetailsDTO> {
+      return appointments.map {
+        AppointmentDetailsDTO(
+          appointment_id = it.id,
+          appointment_date_time = it.appointmentTime,
+          appointment_duration_in_minutes = it.durationInMinutes,
+          superseded_indicator = it.superseded,
+          appointment_delivery_first_address_line = it.appointmentDelivery?.appointmentDeliveryAddress?.firstAddressLine ?: "",
+          appointment_delivery_second_address_line = it.appointmentDelivery?.appointmentDeliveryAddress?.secondAddressLine ?: "",
+          appointment_delivery_town_city = it.appointmentDelivery?.appointmentDeliveryAddress?.townCity ?: "",
+          appointment_delivery_county = it.appointmentDelivery?.appointmentDeliveryAddress?.county ?: "",
+          appointment_delivery_postcode = it.appointmentDelivery?.appointmentDeliveryAddress?.postCode ?: "",
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ProbationCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ProbationCaseService.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ProbationCaseReferralDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 
@@ -13,6 +15,7 @@ class ProbationCaseService(
   val draftReferralRepository: DraftReferralRepository,
   val referralService: ReferralService,
   val hmppsAuthService: HMPPSAuthService,
+  val deliverySessionService: DeliverySessionService,
 ) {
 
   fun getProbationCaseDetails(
@@ -47,4 +50,18 @@ class ProbationCaseService(
     }
     return probationCaseDetails
   }
+
+  fun getAppointmentLocationDetails(crn: String): List<ReferralAppointmentLocationDetails> {
+    val sentReferrals = referralRepository.findByServiceUserCRN(crn)
+    return sentReferrals.map {
+      val deliverySessions = deliverySessionService.getSessions(it.id)
+      val appointments = deliverySessions.flatMap { ds -> ds.appointments }
+      ReferralAppointmentLocationDetails(it, appointments)
+    }
+  }
 }
+
+data class ReferralAppointmentLocationDetails(
+  val referral: Referral,
+  val appointments: List<Appointment>,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralAppointmentDetailsDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralAppointmentDetailsDTOTest.kt
@@ -1,0 +1,287 @@
+package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralAppointmentDetailsDTO
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AppointmentDeliveryType
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralAppointmentLocationDetails
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentDeliveryAddressFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.AppointmentDeliveryFactory
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DeliverySessionFactory
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@JsonTest
+class ReferralAppointmentDetailsDTOTest(@Autowired private val json: JacksonTester<ReferralAppointmentDetailsDTO>) {
+  private val deliverySessionFactory = DeliverySessionFactory()
+  private val appointmentDeliveryFactory = AppointmentDeliveryFactory()
+  private val appointmentDeliveryAddressFactory = AppointmentDeliveryAddressFactory()
+
+  @Test
+  fun `return referral appointments data in the request format`() {
+    val id = UUID.randomUUID()
+    val createdAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+
+    val referral = SampleData.sampleReferral(
+      "X123456",
+      "Provider",
+      id = id,
+      createdAt = createdAt,
+      referenceNumber = "1234",
+      accessibilityNeeds = "wheelchair",
+      additionalNeedsInformation = "english",
+      whenUnavailable = "tomorrow",
+      endRequestedComments = "appointment needed",
+    )
+
+    val session1 = deliverySessionFactory.createAttended(
+      referral = referral,
+      sessionNumber = 1,
+      sessionConcerns = "some concern",
+      sessionSummary = "PP attended",
+      sessionResponse = "It went well",
+      lateReason = "Have to go the hosiptal",
+      futureSessionPlan = "have to invite him again",
+      appointmentTime = OffsetDateTime.parse("2024-06-30T10:41:32.767668+01:00"),
+    )
+    val session2 = deliverySessionFactory.createAttended(
+      referral = referral,
+      sessionNumber = 2,
+      sessionConcerns = "some other concern",
+      sessionSummary = "PP did not attended",
+      sessionResponse = "It didn't go well",
+      lateReason = "Have been drinking",
+      futureSessionPlan = "have to invite him again",
+      appointmentTime = OffsetDateTime.parse("2024-07-31T10:41:32.767668+01:00"),
+    )
+
+    val appointmentDeliveryAddress1 = appointmentDeliveryAddressFactory.create()
+    val appointment1 = session1.appointments.first()
+    val appointmentDelivery1 = appointmentDeliveryFactory.create(appointmentId = appointment1.id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, npsOfficeCode = "CRSEXT")
+    appointmentDelivery1.appointmentDeliveryAddress = appointmentDeliveryAddress1
+    appointment1.appointmentDelivery = appointmentDelivery1
+
+    val appointmentDeliveryAddress2 = appointmentDeliveryAddressFactory.create(
+      firstAddressLine = "44 northwood boluvard",
+      secondAddressLine = "castle street",
+      townCity = "Warwick",
+      postCode = "NH14 3GA",
+      county = "Warwickshire",
+    )
+    val appointment2 = session2.appointments.first()
+    val appointmentDelivery2 = appointmentDeliveryFactory.create(appointmentId = appointment2.id, appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL, npsOfficeCode = "CRSEXT")
+    appointmentDelivery2.appointmentDeliveryAddress = appointmentDeliveryAddress2
+    appointment2.appointmentDelivery = appointmentDelivery2
+
+    referral.referenceNumber = "something"
+    referral.needsInterpreter = true
+    referral.interpreterLanguage = "french"
+    referral.supplementaryRiskId = UUID.fromString("1c893c33-a373-435e-b13f-7efbc6206e2a")
+    referral.relevantSentenceId = 123456L
+
+    val referralAppointmentLocationDetails = ReferralAppointmentLocationDetails(referral, session1.appointments.toList() + session2.appointments.toList())
+
+    val out = json.write(ReferralAppointmentDetailsDTO.from("X123456", listOf(referralAppointmentLocationDetails)))
+
+    assertThat(out).isEqualToJson(
+      """
+        {
+          "crn": "X123456",
+          "referrals": [
+            {
+              "referral_number": "something",
+              "appointments": [
+                {
+                  "appointment_id": ${appointment1.id},
+                  "appointment_date_time": "2024-06-30T10:41:32.767668+01:00",
+                  "appointment_duration_in_minutes": 120,
+                  "superseded_indicator": false,
+                  "appointment_delivery_first_address_line": "Harmony Living Office, Room 4",
+                  "appointment_delivery_second_address_line": "44 Bouverie Road",
+                  "appointment_delivery_town_city": "Blackpool",
+                  "appointment_delivery_county": "Lancashire",
+                  "appointment_delivery_postcode": "SY4 0RE"
+                },
+                {
+                  "appointment_id": ${appointment2.id},
+                  "appointment_date_time": "2024-07-31T10:41:32.767668+01:00",
+                  "appointment_duration_in_minutes": 120,
+                  "superseded_indicator": false,
+                  "appointment_delivery_first_address_line": "44 northwood boluvard",
+                  "appointment_delivery_second_address_line": "castle street",
+                  "appointment_delivery_town_city": "Warwick",
+                  "appointment_delivery_county": "Warwickshire",
+                  "appointment_delivery_postcode": "NH14 3GA"
+                }
+              ]
+            }
+          ]
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `return referral appointments data when there is no appointment`() {
+    val id = UUID.randomUUID()
+    val createdAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+
+    val referral = SampleData.sampleReferral(
+      "X123456",
+      "Provider",
+      id = id,
+      createdAt = createdAt,
+      referenceNumber = "1234",
+      accessibilityNeeds = "wheelchair",
+      additionalNeedsInformation = "english",
+      whenUnavailable = "tomorrow",
+      endRequestedComments = "appointment needed",
+    )
+
+    referral.referenceNumber = "something"
+    referral.needsInterpreter = true
+    referral.interpreterLanguage = "french"
+    referral.supplementaryRiskId = UUID.fromString("1c893c33-a373-435e-b13f-7efbc6206e2a")
+    referral.relevantSentenceId = 123456L
+
+    val referralAppointmentLocationDetails = ReferralAppointmentLocationDetails(referral, emptyList())
+
+    val out = json.write(ReferralAppointmentDetailsDTO.from("X123456", listOf(referralAppointmentLocationDetails)))
+
+    assertThat(out).isEqualToJson(
+      """
+        {
+          "crn": "X123456",
+          "referrals": [
+            {
+              "referral_number": "something",
+              "appointments": []
+            }
+          ]
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `return referral appointments data when there is no referral associated with the crn`() {
+    val out = json.write(ReferralAppointmentDetailsDTO.from("X123456", emptyList()))
+
+    assertThat(out).isEqualToJson(
+      """
+        {
+          "crn": "X123456",
+          "referrals": []
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `return referral appointments data when some of the fields are not present`() {
+    val id = UUID.randomUUID()
+    val createdAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+
+    val referral = SampleData.sampleReferral(
+      "X123456",
+      "Provider",
+      id = id,
+      createdAt = createdAt,
+      referenceNumber = "1234",
+      accessibilityNeeds = "wheelchair",
+      additionalNeedsInformation = "english",
+      whenUnavailable = "tomorrow",
+      endRequestedComments = "appointment needed",
+    )
+
+    val session1 = deliverySessionFactory.createAttended(
+      referral = referral,
+      sessionNumber = 1,
+      sessionConcerns = "some concern",
+      sessionSummary = "PP attended",
+      sessionResponse = "It went well",
+      lateReason = "Have to go the hosiptal",
+      futureSessionPlan = "have to invite him again",
+      appointmentTime = OffsetDateTime.parse("2024-06-30T10:41:32.767668+01:00"),
+    )
+    val session2 = deliverySessionFactory.createAttended(
+      referral = referral,
+      sessionNumber = 2,
+      sessionConcerns = "some other concern",
+      sessionSummary = "PP did not attended",
+      sessionResponse = "It didn't go well",
+      lateReason = "Have been drinking",
+      futureSessionPlan = "have to invite him again",
+      appointmentTime = OffsetDateTime.parse("2024-07-31T10:41:32.767668+01:00"),
+    )
+
+    val appointmentDeliveryAddress1 = appointmentDeliveryAddressFactory.create()
+    val appointment1 = session1.appointments.first()
+    val appointmentDelivery1 = appointmentDeliveryFactory.create(appointmentId = appointment1.id, appointmentDeliveryType = AppointmentDeliveryType.IN_PERSON_MEETING_PROBATION_OFFICE, npsOfficeCode = "CRSEXT")
+    appointmentDelivery1.appointmentDeliveryAddress = appointmentDeliveryAddress1
+    appointment1.appointmentDelivery = appointmentDelivery1
+
+    val appointmentDeliveryAddress2 = appointmentDeliveryAddressFactory.create(
+      firstAddressLine = "44 northwood boluvard",
+      secondAddressLine = null,
+      townCity = null,
+      postCode = "NH14 3GA",
+      county = null,
+    )
+    val appointment2 = session2.appointments.first()
+    val appointmentDelivery2 = appointmentDeliveryFactory.create(appointmentId = appointment2.id, appointmentDeliveryType = AppointmentDeliveryType.PHONE_CALL, npsOfficeCode = "CRSEXT")
+    appointmentDelivery2.appointmentDeliveryAddress = appointmentDeliveryAddress2
+    appointment2.appointmentDelivery = appointmentDelivery2
+
+    referral.referenceNumber = "something"
+    referral.needsInterpreter = true
+    referral.interpreterLanguage = "french"
+    referral.supplementaryRiskId = UUID.fromString("1c893c33-a373-435e-b13f-7efbc6206e2a")
+    referral.relevantSentenceId = 123456L
+
+    val referralAppointmentLocationDetails = ReferralAppointmentLocationDetails(referral, session1.appointments.toList() + session2.appointments.toList())
+
+    val out = json.write(ReferralAppointmentDetailsDTO.from("X123456", listOf(referralAppointmentLocationDetails)))
+
+    assertThat(out).isEqualToJson(
+      """
+        {
+          "crn": "X123456",
+          "referrals": [
+            {
+              "referral_number": "something",
+              "appointments": [
+                {
+                  "appointment_id": ${appointment1.id},
+                  "appointment_date_time": "2024-06-30T10:41:32.767668+01:00",
+                  "appointment_duration_in_minutes": 120,
+                  "superseded_indicator": false,
+                  "appointment_delivery_first_address_line": "Harmony Living Office, Room 4",
+                  "appointment_delivery_second_address_line": "44 Bouverie Road",
+                  "appointment_delivery_town_city": "Blackpool",
+                  "appointment_delivery_county": "Lancashire",
+                  "appointment_delivery_postcode": "SY4 0RE"
+                },
+                {
+                  "appointment_id": ${appointment2.id},
+                  "appointment_date_time": "2024-07-31T10:41:32.767668+01:00",
+                  "appointment_duration_in_minutes": 120,
+                  "superseded_indicator": false,
+                  "appointment_delivery_first_address_line": "44 northwood boluvard",
+                  "appointment_delivery_second_address_line": "",
+                  "appointment_delivery_town_city": "",
+                  "appointment_delivery_county": "",
+                  "appointment_delivery_postcode": "NH14 3GA"
+                }
+              ]
+            }
+          ]
+        }
+      """.trimIndent(),
+    )
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

- new endpoint for retrieving the appointment location information for a given crn
- anyone with `ROLE_INTERVENTIONS_REFER_AND_MONITOR` can access that

## What is the intent behind these changes?

- The passport resetlement team needs this api for their feature
