### PR TITLE
expected probation office not known feature

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -182,6 +182,7 @@ data class DraftReferralDTO(
         expectedReleaseDate = referral.referralLocation?.expectedReleaseDate,
         expectedReleaseDateMissingReason = referral.referralLocation?.expectedReleaseDateMissingReason,
         expectedProbationOffice = referral.referralLocation?.expectedProbationOffice,
+        expectedProbationOfficeUnKnownReason = referral.referralLocation?.expectedProbationOfficeUnknownReason,
         isReferralReleasingIn12Weeks = referral.referralLocation?.isReferralReleasingIn12Weeks,
         allocatedCommunityPP = referral.referralLocation?.isReferralReleasingIn12Weeks == false,
         ndeliusPPName = referral.probationPractitionerDetails?.nDeliusName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -308,9 +308,11 @@ class DraftReferralService(
     }
     update.expectedProbationOffice?.let {
       draftReferral.expectedProbationOffice = it
+      draftReferral.expectedProbationOfficeUnknownReason = null
     }
     update.expectedProbationOfficeUnKnownReason?.let {
       draftReferral.expectedProbationOfficeUnknownReason = it
+      draftReferral.expectedProbationOffice = null
     }
   }
 


### PR DESCRIPTION
## What does this pull request do?

- sets the field required for expected probation office not known reason

## What is the intent behind these changes?

- The PP who is creating the referral is allowed to enter to reason why he does not know the expected probation office