### PR TITLE
adding intervention title to referral appointment location api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralAppointmentDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralAppointmentDetailsDTO.kt
@@ -22,12 +22,14 @@ class ReferralAppointmentDetailsDTO(
 
 class ReferralDetailDTO(
   val referral_number: String?,
+  val intervention_title: String?,
   val appointments: List<AppointmentDetailsDTO>,
 ) {
   companion object {
     fun from(referralAppointmentDetails: ReferralAppointmentLocationDetails): ReferralDetailDTO {
       return ReferralDetailDTO(
         referral_number = referralAppointmentDetails.referral.referenceNumber,
+        intervention_title = referralAppointmentDetails.referral.intervention.title,
         appointments = AppointmentDetailsDTO.from(referralAppointmentDetails.appointments),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralAppointmentDetailsDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralAppointmentDetailsDTOTest.kt
@@ -94,6 +94,7 @@ class ReferralAppointmentDetailsDTOTest(@Autowired private val json: JacksonTest
           "referrals": [
             {
               "referral_number": "something",
+              "intervention_title": "Accommodation Service",
               "appointments": [
                 {
                   "appointment_id": ${appointment1.id},
@@ -159,6 +160,7 @@ class ReferralAppointmentDetailsDTOTest(@Autowired private val json: JacksonTest
           "referrals": [
             {
               "referral_number": "something",
+              "intervention_title": "Accommodation Service",
               "appointments": []
             }
           ]
@@ -254,6 +256,7 @@ class ReferralAppointmentDetailsDTOTest(@Autowired private val json: JacksonTest
           "referrals": [
             {
               "referral_number": "something",
+              "intervention_title": "Accommodation Service",
               "appointments": [
                 {
                   "appointment_id": ${appointment1.id},


### PR DESCRIPTION
## What does this pull request do?

- adding `intervention_title` to the api `/appointments-location/{crn}`

## What is the intent behind these changes?

- the consumer needed intervention titie to the api
