### PR TITLE
adding referral creation reason before allocation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/DraftReferralDTO.kt
@@ -75,6 +75,7 @@ data class DraftReferralDTO(
   val reasonForReferral: String? = null,
   val expectedProbationOffice: String? = null,
   val expectedProbationOfficeUnKnownReason: String? = null,
+  val reasonForReferralCreationBeforeAllocation: String? = null,
 ) {
   companion object {
     fun from(referral: DraftReferral): DraftReferralDTO {
@@ -137,6 +138,7 @@ data class DraftReferralDTO(
         reasonForReferral = referral.referralDetails?.reasonForReferral,
         expectedProbationOffice = referral.expectedProbationOffice,
         expectedProbationOfficeUnKnownReason = referral.expectedProbationOfficeUnknownReason,
+        reasonForReferralCreationBeforeAllocation = referral.referralDetails?.reasonForReferralCreationBeforeAllocation,
       )
     }
 
@@ -148,6 +150,7 @@ data class DraftReferralDTO(
         createdAt = referral.createdAt,
         completionDeadline = referral.referralDetails?.completionDeadline,
         reasonForReferral = referral.referralDetails?.reasonForReferral,
+        reasonForReferralCreationBeforeAllocation = referral.referralDetails?.reasonForReferralCreationBeforeAllocation,
         complexityLevels = referral.complexityLevelIds?.ifEmpty { null }
           ?.map { ReferralComplexityLevel(it.key, it.value) }
           ?.sortedBy { it.serviceCategoryId },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ReferralDetailsDTO.kt
@@ -13,8 +13,9 @@ data class UpdateReferralDetailsDTO(
   val expectedReleaseDateMissingReason: String?,
   val reasonForChange: String,
   val reasonForReferral: String?,
+  val reasonForReferralCreationBeforeAllocation: String?,
 ) {
-  val isValidUpdate: Boolean get() = maximumEnforceableDays != null || completionDeadline !== null || furtherInformation !== null || reasonForReferral != null
+  val isValidUpdate: Boolean get() = maximumEnforceableDays != null || completionDeadline !== null || furtherInformation !== null || reasonForReferral != null || reasonForReferralCreationBeforeAllocation != null
 }
 
 data class ReferralDetailsDTO(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/ReferralDetails.kt
@@ -21,4 +21,5 @@ data class ReferralDetails(
   var furtherInformation: String? = null,
   var maximumEnforceableDays: Int? = null,
   @Column(name = "reason_for_referral") var reasonForReferral: String? = null,
+  @Column(name = "reason_for_referral_before_allocation") var reasonForReferralCreationBeforeAllocation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/DraftReferralService.kt
@@ -113,6 +113,7 @@ class DraftReferralService(
         update.expectedReleaseDateMissingReason,
         "initial referral details",
         update.reasonForReferral,
+        update.reasonForReferralCreationBeforeAllocation,
       ),
       referral.createdBy,
     )
@@ -273,6 +274,10 @@ class DraftReferralService(
 
     update.reasonForReferral?.let {
       newDetails.reasonForReferral = it
+    }
+
+    update.reasonForReferralCreationBeforeAllocation?.let {
+      newDetails.reasonForReferralCreationBeforeAllocation = it
     }
 
     referralDetailsRepository.saveAndFlush(newDetails)

--- a/src/main/resources/db/migration/V1_175__reason_for_referral_before_allocation.sql
+++ b/src/main/resources/db/migration/V1_175__reason_for_referral_before_allocation.sql
@@ -1,0 +1,5 @@
+alter table referral_details
+add column reason_for_referral_before_allocation text null;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral_details','reason_for_referral_before_allocation',TRUE, TRUE);
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
@@ -488,7 +488,7 @@ class AmendReferralServiceTest @Autowired constructor(
       saved = true,
     )
 
-    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough", "some reason for making a referral")
+    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough", "some reason for making a referral", "some reason for making a referral before allocation")
 
     whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(user)
     whenever(referralService.getSentReferralForUser(any(), any())).thenReturn(referral)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -1069,7 +1069,7 @@ class ReferralServiceTest @Autowired constructor(
     )
     whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
 
-    val referralToUpdate = UpdateReferralDetailsDTO(20, completionDateToChange, "new information", expectedreleaseDate, null, "we decided 10 days wasn't enough", "some reason for making a referral")
+    val referralToUpdate = UpdateReferralDetailsDTO(20, completionDateToChange, "new information", expectedreleaseDate, null, "we decided 10 days wasn't enough", "some reason for making a referral", null)
     val referralDetailsReturned = referralService.updateReferralDetails(referral, referralToUpdate, user)
     val referralDetailsValue = referralService.getReferralDetailsById(referralDetailsReturned?.id)
 
@@ -1104,7 +1104,7 @@ class ReferralServiceTest @Autowired constructor(
 
     whenever(userMapper.fromToken(jwtAuthenticationToken)).thenReturn(authUser)
 
-    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough", "some reason for making a referral")
+    val referralToUpdate = UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough", "some reason for making a referral", null)
     val referralDetailsReturned = referralService.updateReferralDetails(referral, referralToUpdate, user)
     val referralDetailsValue = referralService.getReferralDetailsById(referralDetailsReturned?.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceUnitTest.kt
@@ -263,7 +263,7 @@ class ReferralServiceUnitTest {
     @Test
     fun `a new version is not created if the update contains no data`() {
       val referral = referralFactory.createSent()
-      val update = UpdateReferralDetailsDTO(null, null, null, null, null, reasonForChange = "blah blah", null)
+      val update = UpdateReferralDetailsDTO(null, null, null, null, null, reasonForChange = "blah blah", null, null)
       val returnedValue = referralService.updateReferralDetails(referral, update, referral.createdBy)
 
       verify(referralDetailsRepository, times(0)).save(any())
@@ -290,7 +290,7 @@ class ReferralServiceUnitTest {
 
       val returnedValue = referralService.updateReferralDetails(
         referral,
-        UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough", "some reason for making a referral"),
+        UpdateReferralDetailsDTO(20, null, "new information", null, null, "we decided 10 days wasn't enough", "some reason for making a referral", "some reason for making a referral before allocation"),
         referral.createdBy,
       )
 


### PR DESCRIPTION
## What does this pull request do?

- adding new field `reason for referral creation before allocation` to the referral details

## What is the intent behind these changes?

- this is due to a new requirement where the pp wants to input the reason for referral creation for unallocated referral
