### PR TITLE
Update supplier code which was previously too long for auth mapping

### DIFF
--- a/src/main/resources/contracts/DN671065_ROCHDALE_FBD.json
+++ b/src/main/resources/contracts/DN671065_ROCHDALE_FBD.json
@@ -20,7 +20,7 @@
   "providers": {
     "prime_provider_code": "BIG_LIFE_GROUP",
     "subcontractor_codes": [
-      "ROCHDALE_CONNECTIONS_TRUST"
+      "ROCHDALE_CONNECTIONS_TR"
     ]
   },
   "internal_intervention_id": "35f6d96d-c731-4732-893d-cec1ea2abddd",

--- a/src/main/resources/contracts/DN671065_ROCHDALE_PWB.json
+++ b/src/main/resources/contracts/DN671065_ROCHDALE_PWB.json
@@ -20,7 +20,7 @@
   "providers": {
     "prime_provider_code": "BIG_LIFE_GROUP",
     "subcontractor_codes": [
-      "ROCHDALE_CONNECTIONS_TRUST"
+      "ROCHDALE_CONNECTIONS_TR"
     ]
   },
   "internal_intervention_id": "ae4ab8bd-18a4-4956-ab77-d3f7a57cb96c",

--- a/src/main/resources/providers/providers.json
+++ b/src/main/resources/providers/providers.json
@@ -340,7 +340,7 @@
     "name": "ROAR Turning Point"
   },
   {
-    "code": "ROCHDALE_CONNECTIONS_TRUST",
+    "code": "ROCHDALE_CONNECTIONS_TR",
     "name": "Rochdale Connections Trust"
   },
   {


### PR DESCRIPTION
## What does this pull request do?

Update supplier code which was previously too long for auth mapping for rochdale connections trust

## What is the intent behind these changes?

Allow auth mappings to work correctly for this supplier and users to gain access
