### PR TITLE
pointing performance report to main db

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-performance-report.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 5
             failureThreshold: 10
-  {{- include "deployment-replica.envs" . | nindent 10 }}
+  {{- include "deployment.envs" . | nindent 10 }}
       volumes:
         - name: heap-dumps
           emptyDir: {}


### PR DESCRIPTION
## What does this pull request do?

- configuring the performance report to point to main db

## What is the intent behind these changes?

- This is done to split the load between the dashboard and performance report
