### PR TITLE
Removed draft referrals from API EP response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ProbationCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ProbationCaseService.kt
@@ -5,14 +5,12 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ProbationCaseReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 
 @Service
 @Transactional
 class ProbationCaseService(
   val referralRepository: ReferralRepository,
-  val draftReferralRepository: DraftReferralRepository,
   val referralService: ReferralService,
   val hmppsAuthService: HMPPSAuthService,
   val deliverySessionService: DeliverySessionService,
@@ -22,7 +20,6 @@ class ProbationCaseService(
     crn: String,
   ): List<ProbationCaseReferralDTO> {
     val sentReferrals = referralRepository.findByServiceUserCRN(crn)
-    val draftReferrals = draftReferralRepository.findByServiceUserCRN(crn)
     val probationCaseDetails: MutableList<ProbationCaseReferralDTO> = mutableListOf()
 
     sentReferrals.forEach { referral ->
@@ -39,15 +36,6 @@ class ProbationCaseService(
       )
     }
 
-    draftReferrals.forEach { referral ->
-      val referringOfficerDetails = hmppsAuthService.getUserDetail(referral.createdBy)
-      probationCaseDetails.add(
-        ProbationCaseReferralDTO.from(
-          referral,
-          referringOfficerDetails,
-        ),
-      )
-    }
     return probationCaseDetails
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ProbationCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ProbationCaseServiceTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ProbationCaseReferralDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.DraftReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.DeliverySessionFactory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.util.ReferralFactory
@@ -13,7 +12,6 @@ import java.time.OffsetDateTime
 
 internal class ProbationCaseServiceTest {
   private val referralRepository: ReferralRepository = mock()
-  private val draftReferralRepository: DraftReferralRepository = mock()
   private val referralService: ReferralService = mock()
   private val hmppsAuthService: HMPPSAuthService = mock()
   private val deliverySessionService: DeliverySessionService = mock()
@@ -23,7 +21,6 @@ internal class ProbationCaseServiceTest {
 
   private val probationCaseService = ProbationCaseService(
     referralRepository,
-    draftReferralRepository,
     referralService,
     hmppsAuthService,
     deliverySessionService,
@@ -40,7 +37,6 @@ internal class ProbationCaseServiceTest {
     val serviceProviderUser = UserDetail(firstName = "service", lastName = "provider", email = "aaa")
 
     whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findByServiceUserCRN(crn)).thenReturn(emptyList())
     whenever(referralService.getResponsibleProbationPractitioner(referral)).thenReturn(responsibleOfficer)
     whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(referringOfficerDetails)
     whenever(hmppsAuthService.getUserDetail(referral.currentAssignee!!)).thenReturn(serviceProviderUser)
@@ -75,19 +71,15 @@ internal class ProbationCaseServiceTest {
     whenever(hmppsAuthService.getUserDetail(referral2.createdBy)).thenReturn(referringOfficerDetails)
     whenever(hmppsAuthService.getUserDetail(referral2.currentAssignee!!)).thenReturn(serviceProviderUser)
 
-    whenever(draftReferralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(draftReferral))
-    whenever(hmppsAuthService.getUserDetail(draftReferral.createdBy)).thenReturn(referringOfficerDetails)
-
     val expectedResult = listOf(
       ProbationCaseReferralDTO.from(referral, responsibleOfficer, serviceProviderUser, referringOfficerDetails),
       ProbationCaseReferralDTO.from(referral2, responsibleOfficer, serviceProviderUser, referringOfficerDetails),
-      ProbationCaseReferralDTO.Companion.from(draftReferral, referringOfficerDetails),
     )
 
     val result = probationCaseService.getProbationCaseDetails(crn)
 
     assertThat(result).isNotNull
-    assertThat(result).size().isEqualTo(3)
+    assertThat(result).size().isEqualTo(2)
     assertThat(result).isEqualTo(expectedResult)
   }
 
@@ -100,7 +92,6 @@ internal class ProbationCaseServiceTest {
     val referringOfficerDetails = UserDetail(firstName = "referring", lastName = "officer", email = "aaa")
 
     whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findByServiceUserCRN(crn)).thenReturn(emptyList())
     whenever(referralService.getResponsibleProbationPractitioner(referral)).thenReturn(responsibleOfficer)
     whenever(hmppsAuthService.getUserDetail(referral.createdBy)).thenReturn(referringOfficerDetails)
 


### PR DESCRIPTION
## What does this pull request do?

Removes the draft referrals from the API EP response

## What is the intent behind these changes?

There are many hanging draft referrals which is not needed in the API EP response. There is no contact created in nDelius for draft referrals.