### PR TITLE
Fix final column affected by not null protection issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralPerformanceReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralPerformanceReportRepository.kt
@@ -9,6 +9,6 @@ interface ReferralPerformanceReportRepository {
   // queries for reporting
   fun serviceProviderReportReferrals(from: OffsetDateTime, to: OffsetDateTime, contractReferences: String): List<ReferralPerformanceReport>
   fun eosrAchievementScore(eosrId: UUID): BigDecimal
-  fun firstAttendanceDate(referralId: UUID): OffsetDateTime
+  fun firstAttendanceDate(referralId: UUID): OffsetDateTime?
   fun attendanceCount(referralId: UUID): Integer
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralPerformanceReportRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralPerformanceReportRepositoryImpl.kt
@@ -112,11 +112,11 @@ class ReferralPerformanceReportRepositoryImpl : ReferralPerformanceReportReposit
     }
   }
 
-  override fun firstAttendanceDate(referralId: UUID): OffsetDateTime {
+  override fun firstAttendanceDate(referralId: UUID): OffsetDateTime? {
     val query = entityManager.createNativeQuery(firstAttendanceDateQuery())
     query.setParameter("referralId", referralId)
     val result = query.resultList as ArrayList<Timestamp?>
-    return timestampToOffsetNotNull(result.get(0))
+    return timestampToOffset(result.get(0))
   }
 
   override fun attendanceCount(referralId: UUID): Integer {


### PR DESCRIPTION
## What does this pull request do?

Allows date of first attended session to be nullable instead of defaulting to current data

## What is the intent behind these changes?

Fix issue with nulls not being shown in the SP performance report
