### PR TITLE
Remove redundant join from sent referrals summary entity tree 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SentReferralSummary.kt
@@ -30,7 +30,6 @@ import java.util.UUID
     NamedAttributeNode(value = "serviceUserData", subgraph = "serviceUserData"),
     NamedAttributeNode(value = "intervention", subgraph = "interventions"),
     NamedAttributeNode(value = "endOfServiceReport", subgraph = "endOfServiceReport"),
-    NamedAttributeNode(value = "supplierAssessment", subgraph = "supplierAssessmentData"),
   ],
   subgraphs = [
     NamedSubgraph(
@@ -52,13 +51,6 @@ import java.util.UUID
       attributeNodes = [
         NamedAttributeNode("disabilities"),
         NamedAttributeNode("referral"),
-      ],
-    ),
-    NamedSubgraph(
-      name = "supplierAssessmentData",
-      attributeNodes = [
-        NamedAttributeNode("referral"),
-        NamedAttributeNode("appointments"),
       ],
     ),
   ],
@@ -91,9 +83,6 @@ class SentReferralSummary(
   @OneToOne(mappedBy = "referral")
   @Fetch(FetchMode.JOIN)
   var endOfServiceReport: EndOfServiceReport? = null,
-  @OneToOne(mappedBy = "referral")
-  @Fetch(FetchMode.JOIN)
-  var supplierAssessment: SupplierAssessment? = null,
   @OneToOne(mappedBy = "referral")
   @Fetch(FetchMode.JOIN)
   var referralLocation: ReferralLocation? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/SentReferralSummariesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/SentReferralSummariesFactory.kt
@@ -35,7 +35,6 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
     referenceNumber: String = "JS18726AC",
     supplementaryRiskId: UUID = UUID.randomUUID(),
     assignments: List<ReferralAssignment> = emptyList(),
-    supplierAssessment: SupplierAssessment? = null,
     serviceUserData: ReferralServiceUserData? = null,
   ): SentReferralSummary {
     createReferral(
@@ -55,7 +54,6 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       supplementaryRiskId = supplementaryRiskId,
       assignments = assignments,
       concludedAt = concludedAt,
-      supplierAssessment = supplierAssessment,
     )
 
     return SentReferralSummary(
@@ -70,7 +68,6 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       assignments = assignments.toMutableList(),
       serviceUserData = serviceUserData,
       actionPlans = actionPlans,
-      supplierAssessment = supplierAssessment,
     )
   }
 
@@ -110,7 +107,6 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       supplementaryRiskId = supplementaryRiskId,
       assignments = assignments,
       concludedAt = concludedAt,
-      supplierAssessment = supplierAssessment,
     )
 
     val sentReferralSummary = SentReferralSummary(
@@ -125,7 +121,6 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       assignments = assignments.toMutableList(),
       serviceUserData = serviceUserData,
       actionPlans = actionPlans,
-      supplierAssessment = supplierAssessment,
     )
 
     return sentReferralSummary to referral
@@ -149,7 +144,6 @@ class SentReferralSummariesFactory(em: TestEntityManager? = null) : BaseReferral
       endOfServiceReport = referral.endOfServiceReport ?: endOfServiceReport,
       serviceUserData = referral.serviceUserData,
       actionPlans = referral.actionPlans,
-      supplierAssessment = referral.supplierAssessment,
       referralLocation = referral.referralLocation,
       probationPractitionerDetails = referral.probationPractitionerDetails,
     )


### PR DESCRIPTION
## What does this pull request do?

Remove redundant join from sent referrals summary entity tree  / fix tests

## What is the intent behind these changes?

Improve response time for frequently used views in the application