### PR TITLE
Apply fix for not null failures when number of outcomes is null 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralPerformanceReportRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralPerformanceReportRepositoryImpl.kt
@@ -62,7 +62,7 @@ class ReferralPerformanceReportRepositoryImpl : ReferralPerformanceReportReposit
       val firstActionPlanSubmittedAt = timestampToOffset(row[13] as Timestamp?) as OffsetDateTime?
       val firstActionPlanApprovedAt = timestampToOffset(row[14] as Timestamp?) as OffsetDateTime?
       val approvedActionPlanId = row[15] as UUID?
-      val numberOfOutcomes = (row[16] as Int).toLong()
+      val numberOfOutcomes = (row[16] as Int?)?.toLong()
       val endOfServiceReportId = row[17] as UUID?
       val numberOfSessions = row[18] as Int?
       val endRequestedAt = timestampToOffset(row[19] as Timestamp?) as OffsetDateTime?


### PR DESCRIPTION
## What does this pull request do?

Apply fix for not nulll failures when number of outcomes is null in ihe SP Perf Report

## What is the intent behind these changes?

Prevent errors some SP's have reported with report generation