### PR TITLE
replace cancellation codes/descriptions with withdrawal ones

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
@@ -38,8 +38,8 @@ class ReferralsProcessor(
         endRequestedAt = referral.endRequestedAt?.let { t -> NdmisDateTime(t) },
         interventionEndReason = referral.endState,
         eosrSubmittedAt = referral.endOfServiceReport?.submittedAt?.let { t -> NdmisDateTime(t) },
-        endReasonCode = referral.withdrawalReasonCode,
-        endReasonDescription = referral.withdrawalReasonCode?.let { referralService.getWithdrawalReason(it)?.description },
+        endReasonCode = referral.withdrawalReasonCode ?: referral.endRequestedReason?.code,
+        endReasonDescription = referral.withdrawalReasonCode?.let { referralService.getWithdrawalReason(it)?.description } ?: referral.endRequestedReason?.description,
         concludedAt = referral.concludedAt?.let { t -> NdmisDateTime(t) },
       )
     } catch (e: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/reporting/ndmis/performance/ReferralsProcessor.kt
@@ -5,10 +5,12 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.reporting.SentReferralProcessor
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ActionPlanService
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralService
 
 @Component
 class ReferralsProcessor(
   private val actionPlanService: ActionPlanService,
+  private val referralService: ReferralService,
 ) : SentReferralProcessor<ReferralsData> {
   companion object : KLogging()
 
@@ -36,8 +38,8 @@ class ReferralsProcessor(
         endRequestedAt = referral.endRequestedAt?.let { t -> NdmisDateTime(t) },
         interventionEndReason = referral.endState,
         eosrSubmittedAt = referral.endOfServiceReport?.submittedAt?.let { t -> NdmisDateTime(t) },
-        endReasonCode = referral.endRequestedReason?.code,
-        endReasonDescription = referral.endRequestedReason?.description,
+        endReasonCode = referral.withdrawalReasonCode,
+        endReasonDescription = referral.withdrawalReasonCode?.let { referralService.getWithdrawalReason(it)?.description },
         concludedAt = referral.concludedAt?.let { t -> NdmisDateTime(t) },
       )
     } catch (e: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -289,6 +289,10 @@ class ReferralService(
     return withdrawalReasonRepository.findAll()
   }
 
+  fun getWithdrawalReason(code: String): WithdrawalReason? {
+    return withdrawalReasonRepository.findByCode(code)
+  }
+
   fun getResponsibleProbationPractitioner(referral: Referral): ResponsibleProbationPractitioner {
     return getResponsibleProbationPractitioner(referral.serviceUserCRN, referral.sentBy, referral.createdBy)
   }


### PR DESCRIPTION
## What does this pull request do?

Updates the ndmis report data to include withdrawal codes & descriptions, rather than cancellation codes/descriptions.

## What is the intent behind these changes?

To bring the report up to date with recent cancellation/withdrawal changes.
