### PR TITLE
Increase dashboard replica count to 3

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/deployment-suspect.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 2
   minReadySeconds: 10
   strategy:


### PR DESCRIPTION
## What does this pull request do?

Increase dashboard replica count to 3

## What is the intent behind these changes?

Spread load to additional instance with a view of reducing overall load level on DB
