### PR TITLE
Filter out SAA from first attendance column

### DIFF
--- a/src/main/resources/db/migration/V1_189__update_referral_performance_report_first_attendance_srf.sql
+++ b/src/main/resources/db/migration/V1_189__update_referral_performance_report_first_attendance_srf.sql
@@ -1,0 +1,18 @@
+create or replace function performance_report_first_attendance(referral_id UUID)
+  returns timestamp
+as
+$body$
+SELECT MIN(a.appointment_time)
+FROM appointment a
+WHERE a.referral_id = $1
+	AND a.stale = false
+	AND ((a.did_session_happen is null AND (a.late = true OR a.attended = 'YES'))
+	OR (a.did_session_happen = true AND a.attended = 'YES'))
+    AND NOT EXISTS
+    (
+        SELECT 1
+        FROM supplier_assessment_appointment saa
+        WHERE saa.appointment_id = a.id
+    )
+$body$
+language sql;


### PR DESCRIPTION
## What does this pull request do?

Filter out SAA from first attendance column

## What is the intent behind these changes?

Avoid saa appointment being returned as a first attendance
