### PR TITLE
add withdrawal comments to sentReferralDTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/SentReferralDTO.kt
@@ -28,6 +28,7 @@ class SentReferralDTO(
   val createdBy: AuthUserDTO,
   val withdrawalState: String?,
   val withdrawalCode: String?,
+  val withdrawalComments: String?,
 ) {
   companion object {
     fun from(
@@ -59,6 +60,7 @@ class SentReferralDTO(
         createdBy = AuthUserDTO.from(referral.createdBy),
         withdrawalState = withdrawalState,
         withdrawalCode = referral.withdrawalReasonCode,
+        withdrawalComments = referral.withdrawalComments,
       )
     }
   }


### PR DESCRIPTION
## What does this pull request do?

add withdrawal comments to sentReferralDTO

## What is the intent behind these changes?

The intervention ended notification box on the UI now requires the withdrawal comments to be passed to it.
