### PR TITLE
upgrade owasp dependency check jdk version to 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,3 +339,4 @@ workflows:
           cache_key: "v2-bump"
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context: [hmpps-common-vars]
+          jdk_tag: "21.0"


### PR DESCRIPTION
## What does this pull request do?

- upgrade owasp dependency check jdk version to 21

## What is the intent behind these changes?

- The new version of dps gradle spring boot will only support jdk 21 and above
