### PR TITLE
Fix logic in first attendance and session attendance counts

### DIFF
--- a/src/main/resources/db/migration/V1_190__update_referral_performance_report_first_attendance_srf.sql
+++ b/src/main/resources/db/migration/V1_190__update_referral_performance_report_first_attendance_srf.sql
@@ -1,0 +1,18 @@
+create or replace function performance_report_first_attendance(referral_id UUID)
+  returns timestamp
+as
+$body$
+SELECT MIN(a.appointment_time)
+FROM appointment a
+WHERE a.referral_id = $1
+	AND a.stale = false
+	AND ((a.did_session_happen is null AND (a.attended = 'LATE' OR a.attended = 'YES'))
+	OR (a.did_session_happen = true AND a.attended = 'YES'))
+    AND NOT EXISTS
+    (
+        SELECT 1
+        FROM supplier_assessment_appointment saa
+        WHERE saa.appointment_id = a.id
+    )
+$body$
+language sql;

--- a/src/main/resources/db/migration/V1_191__update_referral_performance_report_number_of_attendances_srf.sql
+++ b/src/main/resources/db/migration/V1_191__update_referral_performance_report_number_of_attendances_srf.sql
@@ -1,0 +1,19 @@
+create or replace function performance_report_attendances_count(referral_id UUID)
+  returns integer
+as
+$body$
+SELECT count(*)
+FROM appointment a
+WHERE a.referral_id = $1
+	AND a.stale = false
+	AND (a.superseded is null OR a.superseded = false)
+	AND ((a.did_session_happen is null AND (a.attended = 'LATE' OR a.attended = 'YES'))
+	OR (a.did_session_happen = true AND a.attended = 'YES'))
+	AND NOT EXISTS
+    (
+        SELECT 1
+        FROM supplier_assessment_appointment saa
+        WHERE saa.appointment_id = a.id
+    )
+$body$
+language sql;


### PR DESCRIPTION
## What does this pull request do?

Fix logic in first attendance and attendance counts to use a.attended = 'LATE' instead of a.late boolean flag.

## What is the intent behind these changes?

Fix incorrect reporting of attendance counts and date time of session