### PR TITLE
Add preventEmailNotification flags to the amend probation office flows

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AmendProbationOfficeDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/AmendProbationOfficeDTO.kt
@@ -2,4 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 data class AmendProbationOfficeDTO(
   val probationOffice: String,
+  val preventEmailNotification: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -143,7 +143,7 @@ class ReferralEventPublisher(
     oldProbationOffice: String,
     newProbationOffice: String,
     user: AuthUser,
-    preventEmailNotification: Boolean?
+    preventEmailNotification: Boolean?,
   ) {
     applicationEventPublisher.publishEvent(
       ReferralEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -143,6 +143,7 @@ class ReferralEventPublisher(
     oldProbationOffice: String,
     newProbationOffice: String,
     user: AuthUser,
+    preventEmailNotification: Boolean?
   ) {
     applicationEventPublisher.publishEvent(
       ReferralEvent(
@@ -158,6 +159,7 @@ class ReferralEventPublisher(
           "sentBy" to referral.sentBy,
           "createdBy" to referral.createdBy,
           "updater" to user,
+          "preventEmailNotification" to preventEmailNotification,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -324,7 +324,13 @@ class AmendReferralService(
     )
     changelogRepository.save(changelog)
     referralLocation?.let { referralLocationRepository.save(it) }
-    referralEventPublisher.referralProbationOfficeChangedEvent(referral, oldValues[0], newValues[0], user)
+    referralEventPublisher.referralProbationOfficeChangedEvent(
+      referral,
+      oldValues[0],
+      newValues[0],
+      user,
+      amendProbationOfficeDTO.preventEmailNotification
+    )
   }
 
   fun amendProbationPractitionerProbationOffice(
@@ -356,7 +362,13 @@ class AmendReferralService(
     )
     changelogRepository.save(changelog)
     probationPractitionerDetails?.let { probationPractitionerDetailsRepository.save(it) }
-    referralEventPublisher.referralProbationOfficeChangedEvent(referral, oldValues[0], newValues[0], user)
+    referralEventPublisher.referralProbationOfficeChangedEvent(
+      referral,
+      oldValues[0],
+      newValues[0],
+      user,
+      amendProbationOfficeDTO.preventEmailNotification
+    )
   }
 
   fun getListOfChangeLogEntries(referral: Referral): List<Changelog> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -329,7 +329,7 @@ class AmendReferralService(
       oldValues[0],
       newValues[0],
       user,
-      amendProbationOfficeDTO.preventEmailNotification
+      amendProbationOfficeDTO.preventEmailNotification,
     )
   }
 
@@ -367,7 +367,7 @@ class AmendReferralService(
       oldValues[0],
       newValues[0],
       user,
-      amendProbationOfficeDTO.preventEmailNotification
+      amendProbationOfficeDTO.preventEmailNotification,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEve
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.exception.AsyncEventExceptionHandling
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PersonCurrentLocationType
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.HMPPSAuthService
@@ -106,6 +107,8 @@ class ReferralNotificationService(
       }
 
       ReferralEventType.PROBATION_OFFICE_AMENDED -> {
+        val preventEmailNotification = event.data["preventEmailNotification"] as Boolean?
+        if (preventEmailNotification == true) return
         notifyCaseWorkerThatProbationOfficeChanged(event)
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -682,7 +682,7 @@ class NotifyReferralServiceTest {
         referral,
         "http://localhost:8080/sent-referral/${referral.id}",
         data = mapOf(
-          "preventEmailNotification" to  true,
+          "preventEmailNotification" to true,
           "oldProbationOffice" to "Derby: Derwent Centre",
           "newProbationOffice" to "Bristol: Bridewell Police Station",
           "currentAssignee" to if (true) AuthUserDTO.from(referral.currentAssignee!!) else null,


### PR DESCRIPTION

## What does this pull request do?

Adds preventEmailNotification flags to the amend probation office flows.

## What is the intent behind these changes?

To be able to prevent duplicate emails being sent for pre-release referrals with no COM when both expected and PP probation offices are updated at the same time.