### PR TITLE
Reduce batch sizing for load end of sentence job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadendofsentence/LoadEndOfSentenceJobConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadendofsentence/LoadEndOfSentenceJobConfiguration.kt
@@ -46,7 +46,7 @@ class LoadEndOfSentenceJobConfiguration(
     transactionManager: PlatformTransactionManager,
   ): Step {
     return stepBuilderFactory.get("loadEndOfSentenceStep")
-      .chunk<Referral, Referral>(20000, transactionManager)
+      .chunk<Referral, Referral>(5000, transactionManager)
       .reader(reader)
       .processor(processor)
       .writer(writer)


### PR DESCRIPTION
## What does this pull request do?

Reduced load job transaction size to 5000 records

## What is the intent behind these changes?

Prevent out of memory errors when running the end of sentence loading job
