### PR TITLE
Add referral status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -92,8 +92,8 @@ class ReferralController(
   fun getSentReferralsSummaries(
     authentication: JwtAuthenticationToken,
     @Nullable
-    @RequestParam(name = "concluded", required = false)
-    concluded: Boolean?,
+    @RequestParam(name = "completed", required = false)
+    completed: Boolean?,
     @Nullable
     @RequestParam(name = "cancelled", required = false)
     cancelled: Boolean?,
@@ -109,7 +109,7 @@ class ReferralController(
     @PageableDefault(page = 0, size = 50, sort = ["sentAt"]) page: Pageable,
   ): Page<SentReferralSummariesDTO> {
     val user = userMapper.fromToken(authentication)
-    return (referralService.getSentReferralSummaryForUser(user, concluded, cancelled, unassigned, assignedToUserId, page, searchText) as Page<ReferralSummary>).map { SentReferralSummariesDTO.from(it) }.also {
+    return (referralService.getSentReferralSummaryForUser(user, completed, cancelled, unassigned, assignedToUserId, page, searchText) as Page<ReferralSummary>).map { SentReferralSummariesDTO.from(it) }.also {
       telemetryClient.trackEvent(
         "PagedDashboardRequest",
         null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/Referral.kt
@@ -6,6 +6,8 @@ import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Embeddable
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
@@ -22,6 +24,8 @@ import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode.JOIN
+import org.hibernate.annotations.JdbcType
+import org.hibernate.dialect.PostgreSQLEnumJdbcType
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -33,6 +37,11 @@ class SelectedDesiredOutcomesMapping(
   @Column(name = "desired_outcome_id")
   var desiredOutcomeId: UUID,
 )
+
+enum class Status {
+  PRE_ICA,
+  POST_ICA,
+}
 
 @Entity
 @Table(name = "referral", indexes = [Index(columnList = "created_by_id")])
@@ -125,6 +134,12 @@ class Referral(
 
   @Column(name = "withdrawal_reason_code") var withdrawalReasonCode: String? = null,
   @Column(name = "withdrawal_comments") var withdrawalComments: String? = null,
+
+  @Enumerated(EnumType.STRING)
+  @Column(columnDefinition = "status")
+  @JdbcType(PostgreSQLEnumJdbcType::class)
+  @org.jetbrains.annotations.NotNull
+  var status: Status? = Status.PRE_ICA,
 ) {
   val urn: String
     get() = "urn:hmpps:interventions-referral:$id"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
@@ -232,7 +232,7 @@ WHERE  assigned_at_desc_seq = 1
     referralSummaryQuery: ReferralSummaryQuery,
   ): Page<ReferralSummary> {
     val (
-      concluded,
+      completed,
       cancelled,
       unassigned,
       assignedToUserId,
@@ -245,7 +245,7 @@ WHERE  assigned_at_desc_seq = 1
       contracts,
     ) = referralSummaryQuery
 
-    val queryBuilder = StringBuilder(referralSummaryQuery(constructCustomCriteria(concluded, cancelled, unassigned, assignedToUserId, searchText, isSpUser, isPPUser, contracts)))
+    val queryBuilder = StringBuilder(referralSummaryQuery(constructCustomCriteria(completed, cancelled, unassigned, assignedToUserId, searchText, isSpUser, isPPUser, contracts)))
 
     // Append ORDER BY clause if sorting is specified
     if (page.sort.isSorted) {
@@ -354,7 +354,7 @@ WHERE  assigned_at_desc_seq = 1
     }
 
     val totalCount = totalCount(
-      concluded,
+      completed,
       cancelled,
       unassigned,
       assignedToUserId,
@@ -373,7 +373,7 @@ WHERE  assigned_at_desc_seq = 1
   }
 
   private fun totalCount(
-    concluded: Boolean?,
+    completed: Boolean?,
     cancelled: Boolean?,
     unassigned: Boolean?,
     assignedToUserId: String?,
@@ -388,7 +388,7 @@ WHERE  assigned_at_desc_seq = 1
     val countQuery = "SELECT COUNT(*) FROM (${
       referralSummaryQuery(
         constructCustomCriteria(
-          concluded,
+          completed,
           cancelled,
           unassigned,
           assignedToUserId,
@@ -431,7 +431,7 @@ WHERE  assigned_at_desc_seq = 1
   }
 
   private fun constructCustomCriteria(
-    concluded: Boolean?,
+    completed: Boolean?,
     cancelled: Boolean?,
     unassigned: Boolean?,
     assignedToUserId: String?,
@@ -441,8 +441,8 @@ WHERE  assigned_at_desc_seq = 1
     contracts: Set<DynamicFrameworkContract>,
   ): String {
     val customCriteria = StringBuilder()
-    concluded?.let { if (it) customCriteria.append("and r.concluded_at  is not null ") else customCriteria.append("and r.concluded_at  is null ") }
-    cancelled?.let { if (it) customCriteria.append("and (r.concluded_at is not null and  r.end_requested_at is not null and eosr.id is null) ") else customCriteria.append("and not (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null) ") }
+    completed?.let { if (it) customCriteria.append("and (r.concluded_at is not null and eosr.id is not null and r.status = 'POST_ICA')") else customCriteria.append("and not(r.concluded_at is not null and eosr.id is not null and r.status = 'POST_ICA')") }
+    cancelled?.let { if (it) customCriteria.append("and (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null and r.status = 'PRE_ICA') ") else customCriteria.append("and not (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null and r.status = 'PRE_ICA') ") }
     unassigned?.let { if (it) customCriteria.append("and ra.assigned_to_id is null ") else customCriteria.append("and not (ra.assigned_to_id is null) ") }
     assignedToUserId?.let { customCriteria.append("and au.id = :assignedToUserId ") }
     searchText?.let { customCriteria.append(searchQuery(it)) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralAssignment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralDetails
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceProviderSentReferralSummary
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Status
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.WithdrawalReason
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.AuthUserRepository
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.repository.CancellationReasonRepository
@@ -55,7 +56,7 @@ data class ResponsibleProbationPractitioner(
 ) : ContactablePerson
 
 data class ReferralSummaryQuery(
-  val concluded: Boolean?,
+  val completed: Boolean?,
   val cancelled: Boolean?,
   val unassigned: Boolean?,
   val assignedToUserId: String?,
@@ -130,11 +131,16 @@ class ReferralService(
     return assignedReferral
   }
 
-  fun getSentReferralSummaryForUser(user: AuthUser, concluded: Boolean?, cancelled: Boolean?, unassigned: Boolean?, assignedToUserId: String?, page: Pageable, searchText: String? = null): Iterable<ReferralSummary> {
+  fun setReferralStatus(referral: Referral, status: Status) {
+    referral.status = status
+    referralRepository.save(referral)
+  }
+
+  fun getSentReferralSummaryForUser(user: AuthUser, completed: Boolean?, cancelled: Boolean?, unassigned: Boolean?, assignedToUserId: String?, page: Pageable, searchText: String? = null): Iterable<ReferralSummary> {
     if (userTypeChecker.isServiceProviderUser(user)) {
       val contracts = serviceProviderUserAccessScopeMapper.fromUser(user).contracts
       val referralSummary = ReferralSummaryQuery(
-        concluded,
+        completed,
         cancelled,
         unassigned,
         assignedToUserId,
@@ -151,7 +157,7 @@ class ReferralService(
     if (userTypeChecker.isProbationPractitionerUser(user)) {
       val serviceUserCrns = crnsAssociatedWithPP(user)
       val referralSummary = ReferralSummaryQuery(
-        concluded,
+        completed,
         cancelled,
         unassigned,
         assignedToUserId,

--- a/src/main/resources/db/migration/V1_199__add_referral_status.sql
+++ b/src/main/resources/db/migration/V1_199__add_referral_status.sql
@@ -1,0 +1,6 @@
+CREATE TYPE status AS ENUM ('PRE_ICA','POST_ICA');
+
+alter table referral
+    add column status status;
+
+INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral','status', FALSE, TRUE);

--- a/src/main/resources/db/migration/V1_199__add_referral_status.sql
+++ b/src/main/resources/db/migration/V1_199__add_referral_status.sql
@@ -3,4 +3,6 @@ CREATE TYPE status AS ENUM ('PRE_ICA','POST_ICA');
 alter table referral
     add column status status;
 
+create index idx_referral_status on referral (status);
+
 INSERT INTO metadata (table_name, column_name, sensitive, domain_data) VALUES ('referral','status', FALSE, TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/BaseReferralFactory.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SelectedDesiredOutcomesMapping
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceCategory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Status
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -61,6 +62,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
     needsInterpreter: Boolean? = null,
     interpreterLanguage: String? = null,
     probationPractitionerDetails: ProbationPractitionerDetails? = null,
+    status: Status? = null,
   ): Referral {
     val referral = save(
       Referral(
@@ -98,6 +100,7 @@ open class BaseReferralFactory(em: TestEntityManager? = null) : EntityFactory(em
         needsInterpreter = needsInterpreter,
         interpreterLanguage = interpreterLanguage,
         probationPractitionerDetails = probationPractitionerDetails,
+        status = status,
         referralDetailsHistory = if (referralDetails != null) {
           setOf(
             referralDetails.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/util/ReferralFactory.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ReferralServiceUserData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceCategory
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceUserData
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Status
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SupplierAssessment
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.WithdrawalReason
 import java.time.LocalDate
@@ -277,6 +278,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
     ppEmailAddress: String? = "alice@example.com",
     ppProbationOffice: String? = "London",
     ppPdu: String? = "East Sussex",
+    status: Status? = null,
   ): Referral {
     createDraft(
       id = id,
@@ -313,6 +315,7 @@ class ReferralFactory(em: TestEntityManager? = null) : BaseReferralFactory(em) {
       withdrawalComments = withdrawalComments,
       concludedAt = concludedAt,
       endOfServiceReport = endOfServiceReport,
+      status = status,
     )
     val probationPractitionerDetails = probationPractitionerDetailsFactory.create(
       referral = referral,


### PR DESCRIPTION
## What does this pull request do?

Adds a status column to the referral table in the database and updates this to POST_ICA when feedback is given for an attended delivery session.

## What is the intent behind these changes?

To correctly filter referrals in the dashboard tabs
