### PR TITLE
Remove referral status check from completed referrals criteria

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
@@ -441,7 +441,7 @@ WHERE  assigned_at_desc_seq = 1
     contracts: Set<DynamicFrameworkContract>,
   ): String {
     val customCriteria = StringBuilder()
-    completed?.let { if (it) customCriteria.append("and (r.concluded_at is not null and eosr.id is not null and r.status = 'POST_ICA')") else customCriteria.append("and not(r.concluded_at is not null and eosr.id is not null and r.status = 'POST_ICA')") }
+    completed?.let { if (it) customCriteria.append("and (r.concluded_at is not null and eosr.id is not null and eosr.submitted_at is not null)") else customCriteria.append("and not(r.concluded_at is not null and eosr.id is not null and eosr.submitted_at is not null)") }
     cancelled?.let { if (it) customCriteria.append("and (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null and r.status = 'PRE_ICA') ") else customCriteria.append("and not (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null and r.status = 'PRE_ICA') ") }
     unassigned?.let { if (it) customCriteria.append("and ra.assigned_to_id is null ") else customCriteria.append("and not (ra.assigned_to_id is null) ") }
     assignedToUserId?.let { customCriteria.append("and au.id = :assignedToUserId ") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralServiceTest.kt
@@ -807,7 +807,7 @@ class ReferralServiceTest @Autowired constructor(
         concludedAt = OffsetDateTime.now(),
         status = Status.POST_ICA,
       ).also { referral ->
-        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral)
+        referral.endOfServiceReport = endOfServiceReportFactory.create(referral = referral, submittedAt = OffsetDateTime.now())
       }
 
       completedSentReferralSummary = referralSummariesFactory.getReferralSummary(completedReferral)


### PR DESCRIPTION
## What does this pull request do?

Removes referral status check from completed referrals criteria 

## What is the intent behind these changes?

To include old referrals which are pre-ica but have a submitted end of service report in the Completed cases dashboard tab.