### PR TITLE
Change EoSR check from created to submitted for cancelled referrals c…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
@@ -442,7 +442,7 @@ WHERE  assigned_at_desc_seq = 1
   ): String {
     val customCriteria = StringBuilder()
     completed?.let { if (it) customCriteria.append("and (r.concluded_at is not null and eosr.id is not null and eosr.submitted_at is not null)") else customCriteria.append("and not(r.concluded_at is not null and eosr.id is not null and eosr.submitted_at is not null)") }
-    cancelled?.let { if (it) customCriteria.append("and (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null and r.status = 'PRE_ICA') ") else customCriteria.append("and not (r.concluded_at is not null and r.end_requested_at is not null and eosr.id is null and r.status = 'PRE_ICA') ") }
+    cancelled?.let { if (it) customCriteria.append("and (r.concluded_at is not null and r.end_requested_at is not null and eosr.submitted_at is null and r.status = 'PRE_ICA') ") else customCriteria.append("and not (r.concluded_at is not null and r.end_requested_at is not null and eosr.submitted_at is null and r.status = 'PRE_ICA') ") }
     unassigned?.let { if (it) customCriteria.append("and ra.assigned_to_id is null ") else customCriteria.append("and not (ra.assigned_to_id is null) ") }
     assignedToUserId?.let { customCriteria.append("and au.id = :assignedToUserId ") }
     searchText?.let { customCriteria.append(searchQuery(it)) }


### PR DESCRIPTION
…riteria

## What does this pull request do?

Updates eosr.id to eosr.submitted_at in the cancelled referral criteria 

## What is the intent behind these changes?

To include old cancelled pre-ICA referrals which have end of service reports but not submitted in the Cancelled Cases dashboard tab.