### PR TITLE
Fix for SAR data controller so it accepts UK dates (not ISO)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SarsDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SarsDataController.kt
@@ -23,10 +23,26 @@ class SarsDataController(
     @RequestParam toDate: String? = null,
     authentication: JwtAuthenticationToken,
   ): ResponseEntity<SarDataDTO> {
+    var from: String?
+    var to: String?
+
     if (crn == null) {
       return ResponseEntity(null, null, 209)
     }
-    val sarsData = sarsDataService.getSarsReferralData(crn, fromDate, toDate)
+
+    if (fromDate != null && fromDate.equals("")) {
+      from = null
+    } else {
+      from = fromDate
+    }
+
+    if (toDate != null && toDate.equals("")) {
+      to = null
+    } else {
+      to = toDate
+    }
+
+    val sarsData = sarsDataService.getSarsReferralData(crn, from, to)
     if (sarsData.isEmpty()) {
       return ResponseEntity(SarDataDTO.from(crn, sarsData), HttpStatus.NO_CONTENT)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataService.kt
@@ -16,10 +16,13 @@ class SarsDataService(
   val referralRepository: ReferralRepository,
   val deliverySessionRepository: DeliverySessionRepository,
 ) {
+
+  val ukDatePattern = "dd-MM-yyyy"
+
   fun getSarsReferralData(crn: String, fromDateString: String? = null, toDateString: String? = null): List<SarsReferralData> {
     val referrals: List<Referral> = if (fromDateString != null && toDateString != null) {
-      val fromDate = OffsetDateTime.of(LocalDate.parse(fromDateString, DateTimeFormatter.ISO_DATE), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-      val toDate = OffsetDateTime.of(LocalDate.parse(toDateString, DateTimeFormatter.ISO_DATE), LocalTime.MIDNIGHT, ZoneOffset.UTC)
+      val fromDate = OffsetDateTime.of(LocalDate.parse(fromDateString, DateTimeFormatter.ofPattern(ukDatePattern)), LocalTime.MIDNIGHT, ZoneOffset.UTC)
+      val toDate = OffsetDateTime.of(LocalDate.parse(toDateString, DateTimeFormatter.ofPattern(ukDatePattern)), LocalTime.MIDNIGHT, ZoneOffset.UTC)
       referralRepository.referralForSar(crn, fromDate, toDate)
     } else {
       referralRepository.findByServiceUserCRN(crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SarsDataControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/SarsDataControllerTest.kt
@@ -99,6 +99,76 @@ internal class SarsDataControllerTest {
   }
 
   @Test
+  fun `retrieve referral sars data when empty string dates`() {
+    val jwtAuthenticationToken = JwtAuthenticationToken(mock())
+
+    val id = UUID.randomUUID()
+    val createdAt = OffsetDateTime.parse("2020-12-04T10:42:43+00:00")
+
+    val referral = SampleData.sampleReferral(
+      "X123456",
+      "Provider",
+      id = id,
+      createdAt = createdAt,
+      referenceNumber = "1234",
+      accessibilityNeeds = "wheelchair",
+      additionalNeedsInformation = "english",
+      whenUnavailable = "tomorrow",
+      endRequestedComments = "appointment needed",
+      endOfServiceReport = endOfServiceReportFactory.create(
+        outcomes = mutableSetOf(
+          EndOfServiceReportOutcome(
+            progressionComments = "progressing level",
+            additionalTaskComments = "he needs interview",
+            achievementLevel = AchievementLevel.ACHIEVED,
+            desiredOutcome = DesiredOutcome(id = UUID.randomUUID(), description = "desired outcome", serviceCategoryId = UUID.randomUUID()),
+          ),
+        ),
+      ),
+    )
+
+    val session1 = deliverySessionFactory.createAttended(
+      referral = referral,
+      sessionNumber = 1,
+      sessionConcerns = "some concern",
+      sessionSummary = "PP attended",
+      sessionResponse = "It went well",
+      lateReason = "Have to go the hosiptal",
+      futureSessionPlan = "have to invite him again",
+    )
+    val session2 = deliverySessionFactory.createAttended(
+      referral = referral,
+      sessionNumber = 2,
+      sessionConcerns = "some other concern",
+      sessionSummary = "PP did not attended",
+      sessionResponse = "It didn't go well",
+      lateReason = "Have been drinking",
+      futureSessionPlan = "have to invite him again",
+    )
+
+    val actionPlan = actionPlanFactory.createApproved(
+      referral = referral,
+      activities = mutableListOf(ActionPlanActivity(description = "action plan approved")),
+    )
+
+    referral.referenceNumber = "something"
+    referral.needsInterpreter = true
+    referral.interpreterLanguage = "french"
+    referral.supplementaryRiskId = UUID.fromString("1c893c33-a373-435e-b13f-7efbc6206e2a")
+    referral.relevantSentenceId = 123456L
+    referral.actionPlans = mutableListOf(actionPlan)
+
+    val sarsReferralData = listOf(SarsReferralData(referral, session1.appointments.toList() + session2.appointments.toList()))
+
+    whenever(sarsDataService.getSarsReferralData("crn")).thenReturn(sarsReferralData)
+
+    val sarsData = sarsDataController.sarData(crn = "crn", authentication = jwtAuthenticationToken, fromDate = "", toDate = "")
+
+    assertThat(sarsData.statusCode).isEqualTo(HttpStatusCode.valueOf(200))
+    assertThat(sarsData.body?.content?.referral?.size).isEqualTo(1)
+  }
+
+  @Test
   fun `returns 209 when crn is not passed as parameter`() {
     val jwtAuthenticationToken = JwtAuthenticationToken(mock())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataServiceTest.kt
@@ -80,7 +80,7 @@ class SarsDataServiceTest @Autowired constructor(
     deliverySessionFactory.createAttended(referral = referral1, sessionNumber = 2)
     deliverySessionFactory.createAttended(referral = referral2, sessionNumber = 1)
 
-    val sarsData = sarsDataService.getSarsReferralData("crn", "2024-01-01", "2024-06-01")
+    val sarsData = sarsDataService.getSarsReferralData("crn", "01-01-2024", "01-06-2024")
 
     assertThat(sarsData.size).isEqualTo(2)
     assertThat(sarsData.map { it.referral })


### PR DESCRIPTION
## What does this pull request do?

Fix for SAR data controller so it accepts UK dates (not ISO) and empty string date submissions

## What is the intent behind these changes?

Fix integration issues with SAR data gathering process 
