### PR TITLE
Revert sar dates to use ISO format

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataService.kt
@@ -17,12 +17,10 @@ class SarsDataService(
   val deliverySessionRepository: DeliverySessionRepository,
 ) {
 
-  val ukDatePattern = "dd-MM-yyyy"
-
   fun getSarsReferralData(crn: String, fromDateString: String? = null, toDateString: String? = null): List<SarsReferralData> {
     val referrals: List<Referral> = if (fromDateString != null && toDateString != null) {
-      val fromDate = OffsetDateTime.of(LocalDate.parse(fromDateString, DateTimeFormatter.ofPattern(ukDatePattern)), LocalTime.MIDNIGHT, ZoneOffset.UTC)
-      val toDate = OffsetDateTime.of(LocalDate.parse(toDateString, DateTimeFormatter.ofPattern(ukDatePattern)), LocalTime.MIDNIGHT, ZoneOffset.UTC)
+      val fromDate = OffsetDateTime.of(LocalDate.parse(fromDateString, DateTimeFormatter.ISO_DATE), LocalTime.MIDNIGHT, ZoneOffset.UTC)
+      val toDate = OffsetDateTime.of(LocalDate.parse(toDateString, DateTimeFormatter.ISO_DATE), LocalTime.MIDNIGHT, ZoneOffset.UTC)
       referralRepository.referralForSar(crn, fromDate, toDate)
     } else {
       referralRepository.findByServiceUserCRN(crn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SarsDataServiceTest.kt
@@ -80,7 +80,7 @@ class SarsDataServiceTest @Autowired constructor(
     deliverySessionFactory.createAttended(referral = referral1, sessionNumber = 2)
     deliverySessionFactory.createAttended(referral = referral2, sessionNumber = 1)
 
-    val sarsData = sarsDataService.getSarsReferralData("crn", "01-01-2024", "01-06-2024")
+    val sarsData = sarsDataService.getSarsReferralData("crn", "2024-01-01", "2024-06-01")
 
     assertThat(sarsData.size).isEqualTo(2)
     assertThat(sarsData.map { it.referral })


### PR DESCRIPTION
## What does this pull request do?

Revert sar dates to use ISO format

## What is the intent behind these changes?

Match format used by SAR data gatherer
