### PR TITLE
Move concluded / withdrawal event to post db update

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -49,18 +49,18 @@ class ReferralConcluder(
 ) {
   fun concludeIfEligible(referral: Referral) {
     val deliveryState = deliveryState(referral)
-    signalEnding(referral, deliveryState.concludedState)
 
     val endState = endState(deliveryState, referral.endOfServiceReport)
     if (endState == ReferralEndState.CAN_CONCLUDE) {
       conclude(referral, deliveryState.concludedState)
     }
+    signalEnding(referral, deliveryState.concludedState)
   }
 
   fun withdrawReferral(referral: Referral, withdrawalState: ReferralWithdrawalState) {
     val deliveryState = deliveryState(referral)
-    signalEnding(referral, deliveryState.concludedState)
     conclude(referral, deliveryState.concludedState, withdrawalState)
+    signalEnding(referral, deliveryState.concludedState)
   }
 
   private fun signalEnding(referral: Referral, concludedState: ReferralConcludedState) {


### PR DESCRIPTION
## What does this pull request do?

Move notification event(s) to after the updates are applied in R&M

## What is the intent behind these changes?

Avoid out of sync notifications when database change in unsuccessful causing issues with NDelius