### PR TITLE
Update session attended check when setting POST_ICA status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionController.kt
@@ -81,7 +81,7 @@ class DeliverySessionController(
       updateAppointmentDTO.sessionFeedback?.sessionBehaviour,
       updateAppointmentDTO.sessionFeedback?.sessionConcerns,
     )
-    if (updateAppointmentDTO.attendanceFeedback?.attended != Attended.NO) {
+    if (updateAppointmentDTO.attendanceFeedback?.attended == Attended.YES) {
       val referral = session.currentAppointment?.referral ?: session.referral
       if (referral.status != Status.POST_ICA) {
         referralService.setReferralStatus(referral, Status.POST_ICA)
@@ -312,7 +312,7 @@ class DeliverySessionController(
     )
     referralAccessChecker.forUser(referral, user)
     val sessionAndAppointment = deliverySessionService.submitAppointmentFeedback(referralId, appointmentId, user)
-    if (sessionAndAppointment.second.attended != Attended.NO) {
+    if (sessionAndAppointment.second.attended == Attended.YES) {
       if (referral.status != Status.POST_ICA) {
         referralService.setReferralStatus(referral, Status.POST_ICA)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/DeliverySessionControllerTest.kt
@@ -265,7 +265,7 @@ internal class DeliverySessionControllerTest {
           updateAppointmentDTO.durationInMinutes,
           user,
           AppointmentDeliveryType.PHONE_CALL,
-          AppointmentSessionType.ONE_TO_ONE
+          AppointmentSessionType.ONE_TO_ONE,
         ),
       ).thenReturn(deliverySession)
 


### PR DESCRIPTION
## What does this pull request do?

Changes the Attended type check from does not equal to 'No' to equals 'Yes'.

## What is the intent behind these changes?

To resolve issues with referrals getting set to Post ICA when Attended is null.