### PR TITLE
Reset referral status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadstatus/LoadStatusReader.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadstatus/LoadStatusReader.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referra
 @Component
 @JobScope
 class LoadStatusReader(
-  entityManagerFactory: EntityManagerFactory
+  entityManagerFactory: EntityManagerFactory,
 ) : JpaCursorItemReader<Referral>() {
   init {
     this.setName("loadStatusReader")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadstatus/LoadStatusReader.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadstatus/LoadStatusReader.kt
@@ -1,21 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.loadstatus
 
-import org.hibernate.SessionFactory
+import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.configuration.annotation.JobScope
-import org.springframework.batch.item.database.HibernateCursorItemReader
+import org.springframework.batch.item.database.JpaCursorItemReader
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Referral
 
 @Component
 @JobScope
 class LoadStatusReader(
-  sessionFactory: SessionFactory,
-) : HibernateCursorItemReader<Referral>() {
+  entityManagerFactory: EntityManagerFactory
+) : JpaCursorItemReader<Referral>() {
   init {
     this.setName("loadStatusReader")
-    this.setSessionFactory(sessionFactory)
+    this.setEntityManagerFactory(entityManagerFactory)
     this.setQueryString(
-      "SELECT r FROM Referral r where r.status is null",
+      "SELECT r FROM Referral r where r.status = 'POST_ICA'",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadstatus/LoadStatusReaderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/loadstatus/LoadStatusReaderTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jobs.oneoff.loads
 
 import jakarta.persistence.EntityManagerFactory
 import org.assertj.core.api.Assertions.assertThat
-import org.hibernate.SessionFactory
 import org.junit.jupiter.api.Test
 import org.springframework.batch.item.ExecutionContext
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
## What does this pull request do?

Amend LoadStatusReader to only look for post-ICA referrals

## What is the intent behind these changes?

To re-run the batch job and reset the status for referrals with no attended delivery sessions back to pre-ICA