### PR TITLE
Ipb 1062/add notify email for pp name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
-kotlin.incremental.useClasspathSnapshot=false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -24,6 +24,7 @@ enum class ReferralEventType {
   PRISON_ESTABLISHMENT_AMENDED,
   EXPECTED_RELEASE_DATE,
   PROBATION_OFFICE_AMENDED,
+  PROBATION_PRACTITIONER_NAME_AMENDED,
 }
 
 class ReferralEvent(
@@ -33,9 +34,7 @@ class ReferralEvent(
   val detailUrl: String,
   val data: Map<String, Any?> = emptyMap(),
 ) : ApplicationEvent(source) {
-  override fun toString(): String {
-    return "ReferralEvent(type=$type, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
-  }
+  override fun toString(): String = "ReferralEvent(type=$type, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
 }
 
 class ReferralEndingEvent(
@@ -44,9 +43,7 @@ class ReferralEndingEvent(
   val referral: Referral,
   val detailUrl: String,
 ) : ApplicationEvent(source) {
-  override fun toString(): String {
-    return "ReferralEndingEvent(state=$state, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
-  }
+  override fun toString(): String = "ReferralEndingEvent(state=$state, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
 }
 
 class ReferralConcludedEvent(
@@ -56,9 +53,7 @@ class ReferralConcludedEvent(
   val detailUrl: String,
   val referralWithdrawalState: ReferralWithdrawalState? = null,
 ) : ApplicationEvent(source) {
-  override fun toString(): String {
-    return "ReferralConcludedEvent(type=$type, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
-  }
+  override fun toString(): String = "ReferralConcludedEvent(type=$type, referralId=${referral.id}, detailUrl='$detailUrl', source=$source)"
 }
 
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/notifications/ReferralNotificationService.kt
@@ -38,6 +38,7 @@ class ReferralNotificationService(
   @Value("\${notify.templates.prison-establishment-updated}") private val prisonEstablishmentUpdatedTemplateID: String,
   @Value("\${notify.templates.expected-release-date-updated}") private val expectedReleaseDateUpdatedTemplateID: String,
   @Value("\${notify.templates.probation-office-updated}") private val probationOfficeUpdatedTemplateID: String,
+  @Value("\${notify.templates.probation-practitioner-name-updated}") private val probationPractitionerNameUpdatedTemplateID: String,
   @Value("\${interventions-ui.baseurl}") private val interventionsUIBaseURL: String,
   @Value("\${interventions-ui.locations.service-provider.referral-details}") private val spReferralDetailsLocation: String,
   private val emailSender: EmailSender,
@@ -101,6 +102,10 @@ class ReferralNotificationService(
         notifyCaseWorkerThatPrisonEstablishmentChanged(event)
       }
 
+      ReferralEventType.PROBATION_PRACTITIONER_NAME_AMENDED -> {
+        notifyCaseWorkerThatProbationPractitonerNameChanged(event)
+      }
+
       ReferralEventType.EXPECTED_RELEASE_DATE -> {
         notifyCaseWorkerThatExpectedReleaseDateChanged(event)
       }
@@ -110,6 +115,19 @@ class ReferralNotificationService(
         if (preventEmailNotification == true) return
         notifyCaseWorkerThatProbationOfficeChanged(event)
       }
+    }
+  }
+
+  private fun notifyCaseWorkerThatProbationPractitonerNameChanged(event: ReferralEvent) {
+    val oldValue = event.data["oldProbationPractitionerName"] as String
+    val newValue = event.data["newProbationPractitionerName"] as String
+    if (oldValue != newValue) {
+      notifyCaseWorker(
+        event,
+        "oldProbationPractitionerName" to oldValue,
+        "newProbationPractitionerName" to newValue,
+        probationPractitionerNameUpdatedTemplateID,
+      )
     }
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,7 +132,7 @@ notify:
     referral-pre-ica-withdrawn: "dc41a8ab-0760-4274-bf1c-fc7530e648fa"
     referral-post-ica-withdrawn: "17641582-310b-4960-bd00-1ae400a70b6e"
     referral-withdraw-early: "110f37e1-69e9-404b-b89e-b05162d3affd"
-
+    probation-practitioner-name-updated: "273a7e82-8ad6-4e86-b9ea-530716b80583"
 interventions-ui:
   locations:
     service-provider:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -123,7 +123,6 @@ class NotifyReferralServiceTest {
     assertThat(personalisationCaptor.firstValue["referralUrl"]).isEqualTo("http://interventions-ui.example.com/referral/42c7d267-0776-4272-a8e8-a673bfe30d0d")
   }
 
-
   @Nested
   inner class ReferralDetailsChangedEvent {
     private val referralDetailsFactory = ReferralDetailsFactory()
@@ -238,7 +237,6 @@ class NotifyReferralServiceTest {
         ),
       )
     }
-
 
     @Test
     fun `amending 'probation practitioner name' notifies the assigned caseworker via email`() {


### PR DESCRIPTION
## What does this pull request do?

Adds email notification on PP name change

## What is the intent behind these changes?

Keep service provider notified of probation practitioner name changes
