### PR TITLE
Ipb 1062/add notify email for pp name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -191,7 +191,7 @@ class ReferralEventPublisher(
     )
   }
 
-  fun referralProbationPractitionerNameChangedEvent(referral: Referral, newPpName: MutableList<String>, previousPpName: MutableList<String>) {
+  fun referralProbationPractitionerNameChangedEvent(referral: Referral, newPpName: String, previousPpName: String) {
     applicationEventPublisher.publishEvent(
       ReferralEvent(
         this,
@@ -199,8 +199,8 @@ class ReferralEventPublisher(
         referral,
         getSentReferralURL(referral),
         mapOf(
-          "newProbationPractitionerName" to newPpName?.get(0),
-          "oldProbationPractitionerName" to previousPpName?.get(0),
+          "newProbationPractitionerName" to newPpName,
+          "oldProbationPractitionerName" to previousPpName,
           "currentAssignee" to referral.currentAssignee?.let { AuthUserDTO.from(it) },
           "crn" to referral.serviceUserCRN,
           "sentBy" to referral.sentBy,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisher.kt
@@ -191,7 +191,7 @@ class ReferralEventPublisher(
     )
   }
 
-  fun referralProbationPractitionerNameChangedEvent(referral: Referral, newPpName: String, previousPpName: String) {
+  fun referralProbationPractitionerNameChangedEvent(referral: Referral, newPpName: String, previousPpName: String, user: AuthUser) {
     applicationEventPublisher.publishEvent(
       ReferralEvent(
         this,
@@ -205,6 +205,7 @@ class ReferralEventPublisher(
           "crn" to referral.serviceUserCRN,
           "sentBy" to referral.sentBy,
           "createdBy" to referral.createdBy,
+          "updater" to user,
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -408,8 +408,8 @@ class AmendReferralService(
     probationPractitionerDetails?.let { probationPractitionerDetailsRepository.save(it) }
     referralEventPublisher.referralProbationPractitionerNameChangedEvent(
       referral,
-      oldValues,
-      newValues,
+      newValues.get(0),
+      oldValues.get(0),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -410,6 +410,7 @@ class AmendReferralService(
       referral,
       newValues.get(0),
       oldValues.get(0),
+      user,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/events/ReferralEventPublisherTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.component.Location
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller.ReferralController
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.ASSIGNED
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.events.ReferralEventType.SENT
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.AuthUser
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralConcludedState
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.ReferralWithdrawalState
@@ -19,6 +20,7 @@ import java.net.URI
 class ReferralEventPublisherTest {
   private val eventPublisher = mock<ApplicationEventPublisher>()
   private val locationMapper = mock<LocationMapper>()
+  private val targetUser = mock<AuthUser>()
 
   @Test
   fun `builds an referral sent event and publishes it`() {
@@ -89,7 +91,7 @@ class ReferralEventPublisherTest {
     whenever(locationMapper.getPathFromControllerMethod(ReferralController::getSentReferral)).thenReturn("/sent-referral/{id}")
     val publisher = ReferralEventPublisher(eventPublisher, locationMapper)
 
-    publisher.referralProbationPractitionerNameChangedEvent(referral, "new", "original")
+    publisher.referralProbationPractitionerNameChangedEvent(referral, "new", "original", targetUser)
 
     val eventCaptor = argumentCaptor<ReferralEvent>()
     verify(eventPublisher).publishEvent(eventCaptor.capture())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
@@ -346,6 +347,8 @@ class AmendReferralServiceTest @Autowired constructor(
     assertThat(changelog.newVal.values.size).isEqualTo(1)
     assertThat(changelog.newVal.values).contains("Bob Moore")
     assertThat(changelog.oldVal.values).contains("Bob Wills")
+
+    verify(referralEventPublisher).referralProbationPractitionerNameChangedEvent(eq(referral), eq("Bob Moore"), eq("Bob Wills"))
 
     val newReferral = referralRepository.findById(referral.id).get()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralServiceTest.kt
@@ -348,7 +348,7 @@ class AmendReferralServiceTest @Autowired constructor(
     assertThat(changelog.newVal.values).contains("Bob Moore")
     assertThat(changelog.oldVal.values).contains("Bob Wills")
 
-    verify(referralEventPublisher).referralProbationPractitionerNameChangedEvent(eq(referral), eq("Bob Moore"), eq("Bob Wills"))
+    verify(referralEventPublisher).referralProbationPractitionerNameChangedEvent(eq(referral), eq("Bob Moore"), eq("Bob Wills"), eq(user))
 
     val newReferral = referralRepository.findById(referral.id).get()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -123,6 +123,7 @@ class NotifyReferralServiceTest {
     assertThat(personalisationCaptor.firstValue["referralUrl"]).isEqualTo("http://interventions-ui.example.com/referral/42c7d267-0776-4272-a8e8-a673bfe30d0d")
   }
 
+
   @Nested
   inner class ReferralDetailsChangedEvent {
     private val referralDetailsFactory = ReferralDetailsFactory()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/NotifyReferralServiceTest.kt
@@ -123,7 +123,6 @@ class NotifyReferralServiceTest {
     assertThat(personalisationCaptor.firstValue["referralUrl"]).isEqualTo("http://interventions-ui.example.com/referral/42c7d267-0776-4272-a8e8-a673bfe30d0d")
   }
 
-
   @Nested
   inner class ReferralDetailsChangedEvent {
     private val referralDetailsFactory = ReferralDetailsFactory()


### PR DESCRIPTION
## What does this pull request do?

Passes required user parameter into the pp name email template

## What is the intent behind these changes?

Fix bug with initial implementation preventing email send
