### PR TITLE
add config for batch job and update reader to only update null values

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/job-rescheduled-reason.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/job-rescheduled-reason.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rescheduled-reason
+spec:
+  schedule: "0 20 11 10 *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
+          restartPolicy: "Never"
+          containers:
+            - name: rescheduled-reason
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: Always
+              args: ["--jobName=rescheduledReasonJob"]
+{{- include "deployment.envs" . | nindent 14 }}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/rescheduledreason/RescheduledReasonReader.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jobs/oneoff/rescheduledreason/RescheduledReasonReader.kt
@@ -17,7 +17,8 @@ class RescheduledReasonReader(
     this.setQueryString(
       "SELECT ap " +
         "FROM Appointment ap " +
-        "WHERE ap.superseded is true ",
+        "WHERE ap.superseded is true " +
+        "and ap.rescheduledReason is null ",
     )
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds scheduling to batch job. Ensures only null values are updated.

## What is the intent behind these changes?

Adds scheduling to batch job. Ensures only null values are updated.
