### PR TITLE
Revert "Update existing appointment with rescheduled details when did…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentService.kt
@@ -70,7 +70,7 @@ class AppointmentService(
   ): Appointment {
     val appointment = when {
       // an initial appointment is required or an additional appointment is required
-      existingAppointment == null || (existingAppointment.attended == Attended.NO && existingAppointment.didSessionHappen == null) -> {
+      existingAppointment == null || (existingAppointment.attended == Attended.NO && existingAppointment.didSessionHappen == null) || existingAppointment.didSessionHappen == false -> {
         val (deliusAppointmentId, appointmentId) =
           communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode, attended, notifyProbationPractitionerOfBehaviour, notifyProbationPractitionerOfConcerns, didSessionHappen, noSessionReasonType, rescheduleRequestedBy)
         createAppointment(
@@ -104,7 +104,7 @@ class AppointmentService(
         )
       }
       // the current appointment needs to be updated
-      existingAppointment.didSessionHappen == null || existingAppointment.didSessionHappen == false -> {
+      existingAppointment.didSessionHappen == null -> {
         val (deliusAppointmentId, appointmentId) =
           communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, appointmentType, npsOfficeCode, attended, notifyProbationPractitionerOfBehaviour, notifyProbationPractitionerOfConcerns, didSessionHappen, noSessionReasonType, rescheduleRequestedBy)
         updateAppointment(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AppointmentServiceTest.kt
@@ -246,7 +246,7 @@ class AppointmentServiceTest {
     val referral = referralFactory.createSent()
     val additionalDeliusAppointmentId = 99L
 
-    whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
+    whenever(communityAPIBookingService.book(referral, null, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null))
       .thenReturn(Pair(additionalDeliusAppointmentId, UUID.randomUUID()))
     whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
 
@@ -274,51 +274,6 @@ class AppointmentServiceTest {
     assertThat(newAppointment.attendanceBehaviourSubmittedBy).isNull()
     assertThat(newAppointment.appointmentFeedbackSubmittedAt).isNull()
     assertThat(newAppointment.appointmentFeedbackSubmittedBy).isNull()
-    assertThat(existingAppointment.rescheduleRequestedBy).isNull()
-    assertThat(existingAppointment.rescheduledReason).isNull()
-  }
-
-  @Test
-  fun `appointment with none attendance will create a new appointment and update rescheduled details`() {
-    // Given
-    val durationInMinutes = 60
-    val appointmentTime = OffsetDateTime.parse("2022-12-04T10:42:43+00:00")
-    val existingAppointment = appointmentFactory.create(deliusAppointmentId = 98L, didSessionHappen = false)
-    val referral = referralFactory.createSent()
-    val additionalDeliusAppointmentId = 99L
-    val rescheduleRequestedBy = "Service Provider"
-    val rescheduledReason = "test reason"
-
-    whenever(communityAPIBookingService.book(referral, existingAppointment, appointmentTime, durationInMinutes, SUPPLIER_ASSESSMENT, null, null, null, null, null, null, rescheduleRequestedBy))
-      .thenReturn(Pair(additionalDeliusAppointmentId, UUID.randomUUID()))
-    whenever(appointmentRepository.save(any())).thenAnswer { it.arguments[0] }
-
-    // When
-    val newAppointment = appointmentService.createOrUpdateAppointment(referral, existingAppointment, durationInMinutes, appointmentTime, SUPPLIER_ASSESSMENT, createdByUser, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE, rescheduleRequestedBy = rescheduleRequestedBy, rescheduledReason = rescheduledReason)
-
-    // Then
-    verifyResponse(
-      newAppointment,
-      existingAppointment.id,
-      additionalDeliusAppointmentId,
-      appointmentTime,
-      durationInMinutes,
-      AppointmentDeliveryType.PHONE_CALL,
-      AppointmentSessionType.ONE_TO_ONE,
-    )
-    verifySavedAppointment(appointmentTime, durationInMinutes, additionalDeliusAppointmentId, AppointmentDeliveryType.PHONE_CALL, AppointmentSessionType.ONE_TO_ONE)
-    assertThat(newAppointment.attended).isNull()
-    assertThat(newAppointment.additionalAttendanceInformation).isNull()
-    assertThat(newAppointment.attendanceBehaviour).isNull()
-    assertThat(newAppointment.notifyPPOfAttendanceBehaviour).isNull()
-    assertThat(newAppointment.attendanceSubmittedAt).isNull()
-    assertThat(newAppointment.attendanceSubmittedBy).isNull()
-    assertThat(newAppointment.attendanceBehaviourSubmittedAt).isNull()
-    assertThat(newAppointment.attendanceBehaviourSubmittedBy).isNull()
-    assertThat(newAppointment.appointmentFeedbackSubmittedAt).isNull()
-    assertThat(newAppointment.appointmentFeedbackSubmittedBy).isNull()
-    assertThat(existingAppointment.rescheduleRequestedBy).isEqualTo(rescheduleRequestedBy)
-    assertThat(existingAppointment.rescheduledReason).isEqualTo(rescheduledReason)
   }
 
   @Test


### PR DESCRIPTION
…SessionHappen is false (#2034)"

This reverts commit a9eabdb561c28613aa17cdaf60f4a4c0f21c3fd7.

## What does this pull request do?

Revert "Update existing appointment with rescheduled details when didSessionHappen is false"

## What is the intent behind these changes?

Revert "Update existing appointment with rescheduled details when didSessionHappen is false"
