### PR TITLE
Prevent ReferralConcluder from sending referral.ended event when not eligible

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -54,7 +54,14 @@ class ReferralConcluder(
     if (endState == ReferralEndState.CAN_CONCLUDE) {
       conclude(referral, deliveryState.concludedState)
     }
-    signalEnding(referral, deliveryState.concludedState)
+
+    // cancelling or can be concluded - notify external listening system(s)
+    if (referral.endRequestedAt != null ||
+      referral.concludedAt != null ||
+      endState == ReferralEndState.CAN_CONCLUDE
+    ) {
+      signalEnding(referral, deliveryState.concludedState)
+    }
   }
 
   fun withdrawReferral(referral: Referral, withdrawalState: ReferralWithdrawalState) {


### PR DESCRIPTION
## What does this pull request do?

Prevent ReferralConcluder from sending referral.ended event when not eligible

Add additional test to ESoR service

## What is the intent behind these changes?

Avoid premature signalling of end of referral getting to nDelius