### PR TITLE
fix error where no previous team phone number would throw out of bounds error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -536,10 +536,15 @@ class AmendReferralService(
     )
     changelogRepository.save(changelog)
     probationPractitionerDetails?.let { probationPractitionerDetailsRepository.save(it) }
+    val oldValue = if(oldValues.size == 0) {
+      " "
+    } else {
+      oldValues[0]
+    }
     referralEventPublisher.referralProbationPractitionerTeamPhoneNumberChangedEvent(
       referral,
-      newValues.get(0),
-      oldValues.get(0),
+      newValues[0],
+      oldValue,
       user,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/AmendReferralService.kt
@@ -536,7 +536,7 @@ class AmendReferralService(
     )
     changelogRepository.save(changelog)
     probationPractitionerDetails?.let { probationPractitionerDetailsRepository.save(it) }
-    val oldValue = if(oldValues.size == 0) {
+    val oldValue = if (oldValues.size == 0) {
       " "
     } else {
       oldValues[0]


### PR DESCRIPTION
## What does this pull request do?

Allows team phone number to be amended when no previous one was stored.

## What is the intent behind these changes?

Allows team phone number to be amended when no previous one was stored.
