### PR TITLE
Ipb 1305/conclusion notification ordering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -66,8 +66,9 @@ class EndOfServiceReportService(
 
     endOfServiceReportEventPublisher.endOfServiceReportSubmittedEvent(draftEndOfServiceReport)
 
-    return endOfServiceReportRepository.save(draftEndOfServiceReport)
-      .also { referralConcluder.concludeIfEligible(it.referral) }
+    var result = endOfServiceReportRepository.save(draftEndOfServiceReport)
+    referralConcluder.concludeIfEligible(result.referral)
+    return result
   }
 
   private fun updateDraftEndOfServiceReportAsSubmitted(endOfServiceReport: EndOfServiceReport, submittedByUser: AuthUser) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/EndOfServiceReportService.kt
@@ -66,7 +66,7 @@ class EndOfServiceReportService(
 
     endOfServiceReportEventPublisher.endOfServiceReportSubmittedEvent(draftEndOfServiceReport)
 
-    var result = endOfServiceReportRepository.save(draftEndOfServiceReport)
+    val result = endOfServiceReportRepository.save(draftEndOfServiceReport)
     referralConcluder.concludeIfEligible(result.referral)
     return result
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -263,8 +263,9 @@ class ReferralService(
     referral.endRequestedAt = now
     referral.endRequestedBy = authUserRepository.save(user)
     updateWithdrawalInformation(referral, withdrawReferralRequestDTO)
-    return referralRepository.save(referral)
-      .also { referralConcluder.withdrawReferral(it, ReferralWithdrawalState.valueOf(withdrawReferralRequestDTO.withdrawalState)) }
+    var result = referralRepository.save(referral)
+    referralConcluder.withdrawReferral(result, ReferralWithdrawalState.valueOf(withdrawReferralRequestDTO.withdrawalState))
+    return result
   }
 
   private fun updateWithdrawalInformation(referral: Referral, withdrawReferralRequestDTO: WithdrawReferralRequestDTO) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralService.kt
@@ -263,7 +263,7 @@ class ReferralService(
     referral.endRequestedAt = now
     referral.endRequestedBy = authUserRepository.save(user)
     updateWithdrawalInformation(referral, withdrawReferralRequestDTO)
-    var result = referralRepository.save(referral)
+    val result = referralRepository.save(referral)
     referralConcluder.withdrawReferral(result, ReferralWithdrawalState.valueOf(withdrawReferralRequestDTO.withdrawalState))
     return result
   }


### PR DESCRIPTION
## What does this pull request do?

Makes nDelius notification conditional on successful referral update

## What is the intent behind these changes?

Aims to resolve issue where withdrawn / concluded referrals are left open but nDelius is notified of closure/withdrawal
