### PR TITLE
Fix json-smart related vulnerability fail

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("plugin.spring") version "2.0.10"
   id("org.jetbrains.kotlin.plugin.jpa") version "2.0.10"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.2"
   id("jacoco")
   id("project-report")
 }


### PR DESCRIPTION
## What does this pull request do?

bumps dps spring version handle vulnerability CVE-2024-57699

## What is the intent behind these changes?

Fix the referenced security vulnerability and allow deployment
