### PR TITLE
Upgrade to latest version of spring dps for cve-2025-22228

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("plugin.spring") version "2.1.20"
   id("org.jetbrains.kotlin.plugin.jpa") version "2.1.20"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.0.0"
   id("jacoco")
   id("project-report")
 }
@@ -137,4 +137,5 @@ dependencies {
   testImplementation("org.mockito:mockito-inline:5.2.0")
   testImplementation("org.springframework.batch:spring-batch-test")
   testImplementation("com.github.tomakehurst:wiremock-jre8:3.0.1")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
 }


### PR DESCRIPTION
## What does this pull request do?

Upgrades spring dps version to move spring security update (crypto) to 6.4.4

## What is the intent behind these changes?

Resolve a security related issue which was causing owasp scan/pipeline to fail