### PR TITLE
Ipb 1321/desired outcome filter rules response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -158,7 +158,7 @@ class ReferralController(
   @GetMapping("/service-category/{id}/contract-reference/{contractReference}")
   fun getServiceCategoryByIDAndContractReference(@PathVariable id: UUID, @PathVariable contractReference: String): ServiceCategoryFullDTO {
     val serviceCategory = serviceCategoryService.getServiceCategoryByIDAndContractReference(id, contractReference)
-    return serviceCategory?.let { ServiceCategoryWithActiveOutcomesDTO.from(it) }
+    return serviceCategory?.let { ServiceCategoryFullDTO.from(it) }
       ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "service category not found [id=$id]")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceCategoryFullDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceCategoryFullDTO.kt
@@ -8,10 +8,9 @@ import java.util.UUID
 data class DesiredOutcomeDTO(
   val id: UUID,
   val description: String,
-  val filterRules: MutableSet<DesiredOutcomeFilterRule> = mutableSetOf(),
 ) {
   companion object {
-    fun from(desiredOutcome: DesiredOutcome): DesiredOutcomeDTO = DesiredOutcomeDTO(desiredOutcome.id, desiredOutcome.description, desiredOutcome.desiredOutcomeFilterRules)
+    fun from(desiredOutcome: DesiredOutcome): DesiredOutcomeDTO = DesiredOutcomeDTO(desiredOutcome.id, desiredOutcome.description)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceCategoryFullDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/dto/ServiceCategoryFullDTO.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto
 
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcome
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.DesiredOutcomeFilterRule
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.ServiceCategory
 import java.util.UUID
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -490,7 +490,7 @@ internal class ReferralControllerTest {
       val response = referralController.getServiceCategoryByIDAndContractReference(serviceCategoryId, "ABC123")
       val expectedResponse = listOf(
         DesiredOutcomeDTO(desiredOutcomeId1, "description 1"),
-        DesiredOutcomeDTO(desiredOutcomeId2, "description 2")
+        DesiredOutcomeDTO(desiredOutcomeId2, "description 2"),
       )
 
       assertThat(response.id).isEqualTo(serviceCategoryId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -464,4 +464,38 @@ internal class ReferralControllerTest {
       assertThat(response.desiredOutcomes).isEqualTo(expectedResponse)
     }
   }
+
+  @Nested
+  inner class GetServiceCategoryByIDAndContractReference {
+    @Test
+    fun `returns service category with only desired outcomes`() {
+      val serviceCategoryId = UUID.randomUUID()
+      val desiredOutcomeId1 = UUID.randomUUID()
+      val desiredOutcomeId2 = UUID.randomUUID()
+
+      val desiredOutcomes = listOf(
+        DesiredOutcome(
+          id = desiredOutcomeId1,
+          serviceCategoryId = serviceCategoryId,
+          description = "description 1",
+          deprecatedAt = null,
+          desiredOutcomeFilterRules = mutableSetOf(),
+        ),
+        DesiredOutcome(id = desiredOutcomeId2, serviceCategoryId = serviceCategoryId, description = "description 2", deprecatedAt = null, desiredOutcomeFilterRules = mutableSetOf()),
+      )
+
+      val serviceCategory = serviceCategoryFactory.create(id = serviceCategoryId, desiredOutcomes = desiredOutcomes)
+
+      whenever(serviceCategoryService.getServiceCategoryByIDAndContractReference(serviceCategoryId, "ABC123")).thenReturn(serviceCategory)
+      val response = referralController.getServiceCategoryByIDAndContractReference(serviceCategoryId, "ABC123")
+      val expectedResponse = listOf(
+        DesiredOutcomeDTO(desiredOutcomeId1, "description 1"),
+        DesiredOutcomeDTO(desiredOutcomeId2, "description 2")
+      )
+
+      assertThat(response.id).isEqualTo(serviceCategoryId)
+      assertThat(response.desiredOutcomes.size).isEqualTo(2)
+      assertThat(response.desiredOutcomes).isEqualTo(expectedResponse)
+    }
+  }
 }


### PR DESCRIPTION
## What does this pull request do?

Removes empty filter rules array from desired outcomes dto as it isn't needed.
Tests the new endpoint.

## What is the intent behind these changes?

As above
