### PR TITLE
do not filter out desired outcomes on old get service cateogry method

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -152,7 +152,7 @@ class ReferralController(
 
   @GetMapping("/service-category/{id}")
   fun getServiceCategoryByID(@PathVariable id: UUID): ServiceCategoryFullDTO = serviceCategoryService.getServiceCategoryByID(id)
-    ?.let { ServiceCategoryWithActiveOutcomesDTO.from(it) }
+    ?.let { ServiceCategoryFullDTO.from(it) }
     ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "service category not found [id=$id]")
 
   @GetMapping("/service-category/{id}/contract-reference/{contractReference}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralController.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ReferralDetail
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SentReferralSummariesDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryFullDTO
-import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.ServiceCategoryWithActiveOutcomesDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.SupplierAssessmentDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.UpdateReferralDetailsDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.Views

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/ReferralControllerTest.kt
@@ -433,7 +433,7 @@ internal class ReferralControllerTest {
   @Nested
   inner class GetServiceCategory {
     @Test
-    fun `returns service category with only desired outcomes that are not deprecated`() {
+    fun `returns service category with desired outcomes that are both deprecated and not deprecated`() {
       val serviceCategoryId = UUID.randomUUID()
       val desiredOutcomeId1 = UUID.randomUUID()
       val desiredOutcomeId2 = UUID.randomUUID()
@@ -457,10 +457,15 @@ internal class ReferralControllerTest {
 
       whenever(serviceCategoryService.getServiceCategoryByID(serviceCategoryId)).thenReturn(serviceCategory)
       val response = referralController.getServiceCategoryByID(serviceCategoryId)
-      val expectedResponse = listOf(DesiredOutcomeDTO(desiredOutcomeId3, "description 3"), DesiredOutcomeDTO(desiredOutcomeId4, "description 4"))
+      val expectedResponse = listOf(
+        DesiredOutcomeDTO(desiredOutcomeId1, "description 1"),
+        DesiredOutcomeDTO(desiredOutcomeId2, "description 2"),
+        DesiredOutcomeDTO(desiredOutcomeId3, "description 3"),
+        DesiredOutcomeDTO(desiredOutcomeId4, "description 4"),
+      )
 
       assertThat(response.id).isEqualTo(serviceCategoryId)
-      assertThat(response.desiredOutcomes.size).isEqualTo(2)
+      assertThat(response.desiredOutcomes.size).isEqualTo(4)
       assertThat(response.desiredOutcomes).isEqualTo(expectedResponse)
     }
   }


### PR DESCRIPTION
## What does this pull request do?

Reverts back to no longer filtering out deprecated desired outcomes for GET service-category

## What is the intent behind these changes?

Allows deprecated desired outcomes to be returned, to be used in older referrals.
