### PR TITLE
upgrade the spring security crypto to resolve the vulnerability issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("plugin.spring") version "2.1.20"
@@ -26,8 +27,8 @@ java {
 
 tasks {
   withType<KotlinCompile> {
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_21)
     }
   }
   test {
@@ -115,6 +116,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux:3.4.4")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server:3.4.4")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client:3.4.4")
+  // Override vulnerable dependency. Remove it when we upgrade org.springframework.boot:spring-boot-starter-oauth2-resource-server:3.4.4
+  implementation("org.springframework.security:spring-security-crypto:6.4.5")
   implementation("com.nimbusds:oauth2-oidc-sdk:11.23.1")
 
   // database


### PR DESCRIPTION
## What does this pull request do?

- upgrade spring-security-crypto version to resolve vulnerability issue. The new version is 6.4.5

## What is the intent behind these changes?

- Vulnerability issue is thrown as part of the nightly build (https://output.circle-artifacts.com/output/job/41142c9c-9e47-4658-8e1f-539e1c0b8b89/artifacts/0/Reports/OWASP/dependency-check-report.html). So this PR is done to fix that
