### PR TITLE
Update data extractor to latest

### DIFF
--- a/helm_deploy/hmpps-interventions-service/Chart.yaml
+++ b/helm_deploy/hmpps-interventions-service/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 
 dependencies:
   - name: generic-data-analytics-extractor
-    version: 1.0.1
+    version: 1.3.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
We had a critical alert from dependabot in the data extractor repository which required us to bump a few dependencies and create a new release. This PR bumps the data extractor to the latest release. We've tested this with the calculate-release-dates service and it worked without issue. Hope this is ok - happy to discuss. Thanks!

## What does this pull request do?

_Required._

## What is the intent behind these changes?

_Required._
