### PR TITLE
fixing vulnerability issue. upgrading org.postgresql:postgresql library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,7 @@ dependencies {
   implementation("org.hibernate:hibernate-core:6.6.13.Final")
   implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.9.10")
 
-  runtimeOnly("org.postgresql:postgresql:42.7.5")
+  runtimeOnly("org.postgresql:postgresql:42.7.7")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
 
   // json and csv


### PR DESCRIPTION
## What does this pull request do?

- trivy and owasp dependency fails with current version postgres library.  This PR fixes by upgrading to the version of postgres library which fixes it.

## What is the intent behind these changes?

- trivy and owasp dependency fails with current version postgres library. The latest version 42.7.7 is fixing it. 
