### PR TITLE
Fixing when eosr is not generated for attended but cancelled session

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DeliverySessionRepository.kt
@@ -43,4 +43,11 @@ interface DeliverySessionRepository : JpaRepository<DeliverySession, UUID> {
       "and appt.appointmentFeedbackSubmittedAt is not null and appt.superseded = false and appt.stale = false",
   )
   fun countNumberOfNotAttendedSessions(referralId: UUID): Int
+
+  @Query(
+    "select count(sesh) from DeliverySession sesh join sesh.appointments appt " +
+      "where sesh.referral.id = :referralId and appt.attended in ('YES', 'LATE') " +
+      "and appt.appointmentFeedbackSubmittedAt is not null and appt.stale = false",
+  )
+  fun countNumberOfAttendedSessionsIncludingRescheduledSessions(referralId: UUID): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluder.kt
@@ -128,7 +128,5 @@ class ReferralConcluder(
 
   private fun countSessionsWithAttendanceRecord(referral: Referral): Int = deliverySessionRepository.countNumberOfSessionsWithAttendanceRecord(referral.id)
 
-  private fun countSessionsAttended(referral: Referral): Int = deliverySessionRepository.countNumberOfAttendedSessions(referral.id)
-
-  private fun deliveredFirstSubstantiveAppointment(referral: Referral): Boolean = countSessionsAttended(referral) > 0
+  private fun deliveredFirstSubstantiveAppointment(referral: Referral): Boolean = deliverySessionRepository.countNumberOfAttendedSessionsIncludingRescheduledSessions(referral.id) > 0
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/ReferralConcluderTest.kt
@@ -140,7 +140,7 @@ internal class ReferralConcluderTest {
 
     val actionPlan = actionPlanFactory.createApproved(numberOfSessions = totalSessions)
     val referral = referralFactory.createSent(actionPlans = mutableListOf(actionPlan))
-    whenever(deliverySessionRepository.countNumberOfAttendedSessions(referral.id))
+    whenever(deliverySessionRepository.countNumberOfAttendedSessionsIncludingRescheduledSessions(referral.id))
       .thenReturn(state.attendedOrLate)
     whenever(deliverySessionRepository.countNumberOfSessionsWithAttendanceRecord(referral.id))
       .thenReturn(state.attendedOrLate + state.notAttended)


### PR DESCRIPTION
## What does this pull request do?

- fixes the query where a session is attended by referral but cancelled by SP is not triggering EoSR
- changed the query to include superseded appointments

## What is the intent behind these changes?

- To fix the issue where a session is attended by referral but cancelled by SP is not triggering EoSR
