### PR TITLE
fixing the vulnerability issue https://avd.aquasec.com/nvd/cve-2025-4…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("plugin.spring") version "2.1.20"
   id("org.jetbrains.kotlin.plugin.jpa") version "2.1.20"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.7"
   id("jacoco")
   id("project-report")
 }


### PR DESCRIPTION
…8989

## What does this pull request do?

- Upgrades hmpps gradle spring boot to 8.3.7

## What is the intent behind these changes?

- The new version of hmpps gradle spring boot fixes the vulnerability issue  https://avd.aquasec.com/nvd/cve-2025-48989
