### PR TITLE
IPB-1544: Upgraded gradle-spring-boot pluging to fix vulnerablities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("plugin.spring") version "2.1.20"
   id("org.jetbrains.kotlin.plugin.jpa") version "2.1.20"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.1"
   id("jacoco")
   id("project-report")
 }


### PR DESCRIPTION
## What does this pull request do?

Upgrades gradle-spring-boot plugin to 9.0.1 which has netty latest version 4.1.125 which fixes vulnerability CVE-2025-58056

## What is the intent behind these changes?

To unblock the pipeline by removing a security vulnerability
