### PR TITLE
Added netty 4.1.124 vulnerability to trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,3 +13,5 @@ CVE-2022-45868
 # Suppression for tomcat vulnerability affecting jsp compilation in the default servlet
 #   can be suppressed as we do not use the default servlet and haven't configured it for write either
 CVE-2024-50379
+# Suppression for netty 4.1.124 vulnerability until migration to github actions and upgrade to gradle-spring-boot v9
+CVE-2025-58056


### PR DESCRIPTION
## What does this pull request do?

Enables builds to temporarily ignore netty 4.1.124 due to security vulnerability CVE-2025-58056

## What is the intent behind these changes?

To provide a less evasive quick fix to unblock the pipeline
