### PR TITLE
enabling modsec ingress logs by adding the git hub teams

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
@@ -17,6 +17,7 @@ metadata:
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-interventions-dev"
     {{- end }}
 spec:
   {{- if .Values.env_details.contains_live_data }}


### PR DESCRIPTION
## What does this pull request do?

- adding git hub teams to enable debugging

## What is the intent behind these changes?

- git hub teams needs to be added so that it can allow access to modsec ingress
