### PR TITLE
disable ingress rule 949110 for some POST request

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
@@ -17,6 +17,20 @@ metadata:
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
+      # Condition 1: Check if the request method is POST
+      SecRule REQUEST_METHOD "@streq POST" \
+        "id:1004,\
+        phase:1,\
+        pass,\
+        nolog,\
+        chain"
+      # Condition 3: Check if the request URI matches any of the specified patterns and remove the rule if it does
+      SecRule REQUEST_URI "@rx (/draft-action-plan|/oasys-risk-information|/case-note|/action-plan)" \
+        "id:1005,\
+        phase:1,\
+        pass,\
+        nolog,\
+        ctl:ruleRemoveById=949110"
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-interventions-dev"
     {{- end }}
 spec:


### PR DESCRIPTION
## What does this pull request do?

- Configures a rule to disable 949110

## What is the intent behind these changes?

- Disables the rule 949110 for some of the POST requests
