### PR TITLE
fix the issue where expired contracts is shown

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.User
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.dto.InterventionDTO
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PCCRegionID
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.InterventionService
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @RestController
@@ -23,9 +24,17 @@ class InterventionController(
   private val serviceProviderAccessScopeMapper: ServiceProviderAccessScopeMapper,
 ) {
   @GetMapping("/intervention/{id}")
-  fun getInterventionByID(@PathVariable id: UUID): InterventionDTO = interventionService.getIntervention(id)?.let {
-    InterventionDTO.from(it, interventionService.getPCCRegions(it))
-  } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "intervention not found [id=$id]")
+  fun getInterventionByID(@PathVariable id: UUID): InterventionDTO {
+    val intervention = interventionService.getIntervention(id)
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "intervention not found [id=$id]")
+
+    val referralEndAt = intervention.dynamicFrameworkContract.referralEndAt
+    if (referralEndAt != null && referralEndAt.isBefore(OffsetDateTime.now())) {
+      throw ResponseStatusException(HttpStatus.GONE, "intervention contract has expired [id=$id]")
+    }
+
+    return InterventionDTO.from(intervention, interventionService.getPCCRegions(intervention))
+  }
 
   @GetMapping("/my-interventions")
   fun getInterventionsForUser(authenticationToken: JwtAuthenticationToken): List<InterventionDTO> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/controller/InterventionControllerTest.kt
@@ -1,14 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsinterventionsservice.controller
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.ServiceProviderAccessScopeMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.authorization.UserMapper
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.Intervention
+import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.SampleData
 import uk.gov.justice.digital.hmpps.hmppsinterventionsservice.service.InterventionService
+import java.time.OffsetDateTime
+import java.util.UUID
 
 internal class InterventionControllerTest {
   private val interventionService = mock<InterventionService>()
@@ -16,6 +23,72 @@ internal class InterventionControllerTest {
   private val serviceProviderAccessScopeMapper = mock<ServiceProviderAccessScopeMapper>()
   private val interventionController =
     InterventionController(interventionService, userMapper, serviceProviderAccessScopeMapper)
+
+  @Test
+  fun `getInterventionByID throws 404 when intervention does not exist`() {
+    val id = UUID.randomUUID()
+    whenever(interventionService.getIntervention(id)).thenReturn(null)
+
+    val exception = assertThrows<ResponseStatusException> {
+      interventionController.getInterventionByID(id)
+    }
+
+    assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+  }
+
+  @Test
+  fun `getInterventionByID throws 410 when intervention contract has expired`() {
+    val id = UUID.randomUUID()
+    val expiredContract = SampleData.sampleContract(
+      primeProvider = SampleData.sampleServiceProvider(),
+      npsRegion = SampleData.sampleNPSRegion(),
+      referralEndAt = OffsetDateTime.now().minusDays(1),
+    )
+    val intervention = SampleData.sampleIntervention(id = id, dynamicFrameworkContract = expiredContract)
+    whenever(interventionService.getIntervention(id)).thenReturn(intervention)
+
+    val exception = assertThrows<ResponseStatusException> {
+      interventionController.getInterventionByID(id)
+    }
+
+    assertThat(exception.statusCode).isEqualTo(HttpStatus.GONE)
+  }
+
+  @Test
+  fun `getInterventionByID returns intervention when referralEndAt is null`() {
+    val id = UUID.randomUUID()
+    val contract = SampleData.sampleContract(
+      primeProvider = SampleData.sampleServiceProvider(),
+      npsRegion = SampleData.sampleNPSRegion(),
+      referralEndAt = null,
+    )
+    val intervention = SampleData.sampleIntervention(id = id, dynamicFrameworkContract = contract)
+    val pccRegions = emptyList<uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PCCRegion>()
+    whenever(interventionService.getIntervention(id)).thenReturn(intervention)
+    whenever(interventionService.getPCCRegions(intervention)).thenReturn(pccRegions)
+
+    val result = interventionController.getInterventionByID(id)
+
+    assertThat(result.id).isEqualTo(id)
+  }
+
+  @Test
+  fun `getInterventionByID returns intervention when referralEndAt is in the future`() {
+    val id = UUID.randomUUID()
+    val contract = SampleData.sampleContract(
+      primeProvider = SampleData.sampleServiceProvider(),
+      npsRegion = SampleData.sampleNPSRegion(),
+      referralEndAt = OffsetDateTime.now().plusDays(1),
+    )
+    val intervention = SampleData.sampleIntervention(id = id, dynamicFrameworkContract = contract)
+    val pccRegions = emptyList<uk.gov.justice.digital.hmpps.hmppsinterventionsservice.jpa.entity.PCCRegion>()
+    whenever(interventionService.getIntervention(id)).thenReturn(intervention)
+    whenever(interventionService.getPCCRegions(intervention)).thenReturn(pccRegions)
+
+    val result = interventionController.getInterventionByID(id)
+
+    assertThat(result.id).isEqualTo(id)
+  }
 
   @Test
   fun `getInterventions returns interventions based on filtering`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/SampleData.kt
@@ -168,6 +168,7 @@ class SampleData {
       pccRegion: PCCRegion? = null,
       contractReference: String = RandomStringUtils.randomAlphanumeric(8),
       referralStartDate: LocalDate = LocalDate.of(2020, 12, 1),
+      referralEndAt: OffsetDateTime? = null,
     ): DynamicFrameworkContract = DynamicFrameworkContract(
       id = id ?: UUID.randomUUID(),
       contractType = contractType ?: sampleContractType(),
@@ -182,6 +183,7 @@ class SampleData {
       pccRegion = pccRegion,
       contractReference = contractReference,
       referralStartDate = referralStartDate,
+      referralEndAt = referralEndAt,
     )
 
     fun sampleContractType(


### PR DESCRIPTION
## What does this pull request do?

- fixes the issue where the api throws error when the intervention is expired

## What is the intent behind these changes?

- The user were able to access the expired contracts from the interventions page
