### PR TITLE
Fixing slow queries in SAS referral endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/entity/DynamicFrameworkContract.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.NamedAttributeNode
 import jakarta.persistence.NamedEntityGraph
 import jakarta.persistence.NamedSubgraph
 import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.BatchSize
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -79,6 +80,7 @@ data class DynamicFrameworkContract(
     joinColumns = [JoinColumn(name = "dynamic_framework_contract_id")],
     inverseJoinColumns = [JoinColumn(name = "subcontractor_provider_id")],
   )
+  @BatchSize(size = 50)
   val subcontractorProviders: MutableSet<ServiceProvider> = mutableSetOf(),
 
   @NotNull

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DraftReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/DraftReferralRepository.kt
@@ -32,4 +32,22 @@ interface DraftReferralRepository : JpaRepository<DraftReferral, UUID> {
       and dr.id not in (select r.id from Referral r where r.serviceUserCRN = :serviceUserCRN)""",
   )
   fun findDraftOnlyByServiceUserCRN(serviceUserCRN: String): List<DraftReferral>
+
+  /**
+   * SAS-specific query: uses NOT EXISTS (faster than NOT IN on large tables), eagerly fetches
+   * selectedServiceCategories and the intervention → dynamicFrameworkContract → primeProvider
+   * chain in a single query to avoid N+1 lazy-load round-trips.
+   * subcontractorProviders is left for BatchSize-based batch loading.
+   */
+  @Query(
+    value =
+    """select distinct dr from DraftReferral dr
+      left join fetch dr.selectedServiceCategories
+      join fetch dr.intervention i
+      join fetch i.dynamicFrameworkContract dc
+      join fetch dc.primeProvider
+      where dr.serviceUserCRN = :serviceUserCRN
+        and not exists (select r from Referral r where r.id = dr.id)""",
+  )
+  fun findDraftOnlyByServiceUserCRNForSAS(serviceUserCRN: String): List<DraftReferral>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralRepository.kt
@@ -26,4 +26,19 @@ interface ReferralRepository :
   fun referralForSar(serviceUserCRN: String, from: OffsetDateTime, to: OffsetDateTime): List<Referral>
 
   fun findByServiceUserCRN(crn: String): List<Referral>
+
+  /**
+   * SAS-specific query: eagerly fetches selectedServiceCategories and the intervention →
+   * dynamicFrameworkContract → primeProvider chain in a single query to avoid N+1 lazy-load
+   * round-trips.  subcontractorProviders is left for BatchSize-based batch loading.
+   */
+  @Query(
+    """select distinct r from Referral r
+      left join fetch r.selectedServiceCategories
+      join fetch r.intervention i
+      join fetch i.dynamicFrameworkContract dc
+      join fetch dc.primeProvider
+      where r.serviceUserCRN = :crn""",
+  )
+  fun findByServiceUserCRNForSAS(crn: String): List<Referral>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralService.kt
@@ -21,13 +21,13 @@ class SASReferralService(
   fun getReferralsByCrn(crn: String): List<SASReferralDTO> {
     val results = mutableListOf<SASReferralDTO>()
 
-    referralRepository.findByServiceUserCRN(crn)
+    referralRepository.findByServiceUserCRNForSAS(crn)
       .filter { it.hasAccommodationServiceCategory() }
       .forEach { referral ->
         results.add(SASReferralDTO.from(referral, determineStatus(referral)))
       }
 
-    draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)
+    draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)
       .filter { it.hasAccommodationServiceCategory() }
       .forEach { draftReferral ->
         results.add(SASReferralDTO.fromDraft(draftReferral))

--- a/src/main/resources/db/migration/V1_233__add_index_draft_referral_service_usercrn.sql
+++ b/src/main/resources/db/migration/V1_233__add_index_draft_referral_service_usercrn.sql
@@ -1,0 +1,6 @@
+-- draft_referral was created via 'CREATE TABLE AS SELECT * FROM referral' (V1_108),
+-- which copies rows but NOT indexes. The referral table has IX_referral_service_usercrn
+-- (V1_57), but draft_referral never got the equivalent index.
+-- Without this index the findDraftOnlyByServiceUserCRN query does a full table scan.
+create index concurrently if not exists IX_draft_referral_service_usercrn
+    on draft_referral (service_usercrn);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralServiceTest.kt
@@ -62,8 +62,8 @@ internal class SASReferralServiceTest {
   @Test
   fun `returns LIVE status for a sent referral with Accommodation service category`() {
     val referral = accommodationReferral()
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -76,8 +76,8 @@ internal class SASReferralServiceTest {
   @Test
   fun `excludes sent referrals that do not have Accommodation service category`() {
     val referral = nonAccommodationReferral()
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -88,8 +88,8 @@ internal class SASReferralServiceTest {
   fun `excludes sent referrals with null selectedServiceCategories`() {
     val referral = accommodationReferral()
     referral.selectedServiceCategories = null
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -114,8 +114,8 @@ internal class SASReferralServiceTest {
         ),
       ),
     )
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(emptyList())
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(listOf(draftReferral))
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(listOf(draftReferral))
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -125,8 +125,8 @@ internal class SASReferralServiceTest {
   @Test
   fun `includes draft referrals with Accommodation service category`() {
     val draftReferral = SampleData.sampleDraftReferral(crn = crn, serviceProviderName = "TestProvider")
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(emptyList())
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(listOf(draftReferral))
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(listOf(draftReferral))
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -138,8 +138,8 @@ internal class SASReferralServiceTest {
   fun `filters mixed referrals keeping only Accommodation ones`() {
     val accommodationRef = accommodationReferral(id = UUID.randomUUID())
     val nonAccommodationRef = nonAccommodationReferral(id = UUID.randomUUID())
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(accommodationRef, nonAccommodationRef))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(accommodationRef, nonAccommodationRef))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -153,8 +153,8 @@ internal class SASReferralServiceTest {
       concludedAt = OffsetDateTime.now(),
       endOfServiceReport = endOfServiceReportFactory.create(),
     )
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -167,8 +167,8 @@ internal class SASReferralServiceTest {
     val referral = accommodationReferral()
     referral.withdrawalReasonCode = "MIS"
     referral.withdrawalComments = "No longer required"
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -179,8 +179,8 @@ internal class SASReferralServiceTest {
   @Test
   fun `returns LIVE not COMPLETED when concludedAt set but no end-of-service report`() {
     val referral = accommodationReferral(concludedAt = OffsetDateTime.now(), endOfServiceReport = null)
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -199,8 +199,8 @@ internal class SASReferralServiceTest {
         userName = "john.smith",
       ),
     )
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -219,8 +219,8 @@ internal class SASReferralServiceTest {
       id = UUID.randomUUID(),
       sentAt = OffsetDateTime.now(),
     )
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -230,8 +230,8 @@ internal class SASReferralServiceTest {
 
   @Test
   fun `returns empty list when no referrals found`() {
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(emptyList())
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 
@@ -246,8 +246,8 @@ internal class SASReferralServiceTest {
       concludedAt = OffsetDateTime.now(),
       endOfServiceReport = endOfServiceReportFactory.create(),
     )
-    whenever(referralRepository.findByServiceUserCRN(crn)).thenReturn(listOf(referral1, referral2))
-    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRN(crn)).thenReturn(emptyList())
+    whenever(referralRepository.findByServiceUserCRNForSAS(crn)).thenReturn(listOf(referral1, referral2))
+    whenever(draftReferralRepository.findDraftOnlyByServiceUserCRNForSAS(crn)).thenReturn(emptyList())
 
     val result = sasReferralService.getReferralsByCrn(crn)
 


### PR DESCRIPTION
## What does this pull request do?

- Instead of using lazy fetch referral, use join eager fetch to avoid n+1 queries
- Doing this for both referral and draft referral
- adding a new index for service_usercrn in the draft referral

## What is the intent behind these changes?

- This is to fix slow queries for the sas referral endpoint
