### PR TITLE
Excluded EOSR Outcomes API from Ingress rule

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
@@ -18,7 +18,7 @@ metadata:
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
       # Condition Check if the request URI matches any of the specified patterns and remove the rule if it does
-      SecRule REQUEST_URI "@rx /(draft-action-plan|oasys-risk-information|case-note|action-plan|post-assessment-feedback)" "id:1005,phase:1,nolog,pass,ctl:ruleRemoveById=949110"
+      SecRule REQUEST_URI "@rx /(draft-action-plan|oasys-risk-information|case-note|action-plan|post-assessment-feedback|end-of-service-report/[^/]+/outcomes/[^/]+)" "id:1005,phase:1,nolog,pass,ctl:ruleRemoveById=949110"
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-interventions-dev"
     {{- else }}
     nginx.ingress.kubernetes.io/modsecurity-snippet: |


### PR DESCRIPTION
## What does this pull request do?

Relaxes ingress rule around End Of Service Report Outcomes API

## What is the intent behind these changes?

To enable more flexibility around notes provided when submitting End Of Service Report
