### PR TITLE
not including draft referrals as part of SAS api response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/jpa/repository/ReferralSummaryRepositoryImpl.kt
@@ -24,7 +24,6 @@ import kotlin.contracts.contract
 
 data class SASReferralNativeData(
   val referralId: String,
-  val isDraft: Boolean,
   val sentAt: Instant?,
   val concludedAt: Instant?,
   val withdrawalReasonCode: String?,
@@ -530,10 +529,9 @@ WHERE  assigned_at_desc_seq = 1
     val sentQuery = entityManager.createNativeQuery(sentSql)
     sentQuery.setParameter("crn", crn)
     val sentResults = sentQuery.resultList as List<Array<Any>>
-    val sentRows = sentResults.map { row ->
+    return sentResults.map { row ->
       SASReferralNativeData(
         referralId = row[0] as String,
-        isDraft = false,
         sentAt = row[1] as Instant?,
         concludedAt = row[2] as Instant?,
         withdrawalReasonCode = row[3] as String?,
@@ -549,54 +547,6 @@ WHERE  assigned_at_desc_seq = 1
         subProviderName = row[13] as String?,
       )
     }
-
-    val draftSql = """
-      SELECT
-        cast(dr.id as varchar)                            AS referralId,
-        cast(dr.created_at as TIMESTAMP WITH TIME ZONE)   AS createdAt,
-        sp.id                                             AS primeProviderId,
-        sp.name                                           AS primeProviderName,
-        sp_sub.id                                         AS subProviderId,
-        sp_sub.name                                       AS subProviderName
-      FROM draft_referral dr
-        INNER JOIN intervention i          ON i.id = dr.intervention_id
-        INNER JOIN dynamic_framework_contract dfc
-                                           ON dfc.id = i.dynamic_framework_contract_id
-        INNER JOIN service_provider sp     ON sp.id = dfc.prime_provider_id
-        LEFT  JOIN dynamic_framework_contract_sub_contractor dfcsc
-                                           ON dfcsc.dynamic_framework_contract_id = dfc.id
-        LEFT  JOIN service_provider sp_sub ON sp_sub.id = dfcsc.subcontractor_provider_id
-        INNER JOIN referral_selected_service_category rssc ON rssc.referral_id = dr.id
-        INNER JOIN service_category sc     ON sc.id = rssc.service_category_id
-      WHERE dr.service_usercrn = :crn
-        AND NOT EXISTS (SELECT 1 FROM referral r WHERE r.id = dr.id)
-        AND sc.name = 'Accommodation'
-    """.trimIndent()
-
-    val draftQuery = entityManager.createNativeQuery(draftSql)
-    draftQuery.setParameter("crn", crn)
-    val draftResults = draftQuery.resultList as List<Array<Any>>
-    val draftRows = draftResults.map { row ->
-      SASReferralNativeData(
-        referralId = row[0] as String,
-        isDraft = true,
-        sentAt = null,
-        concludedAt = null,
-        withdrawalReasonCode = null,
-        withdrawalComments = null,
-        createdAt = row[1] as Instant,
-        sentByUserId = null,
-        sentByAuthSource = null,
-        sentByUserName = null,
-        endOfServiceReportId = null,
-        primeProviderId = row[2] as String,
-        primeProviderName = row[3] as String,
-        subProviderId = row[4] as String?,
-        subProviderName = row[5] as String?,
-      )
-    }
-
-    return sentRows + draftRows
   }
 
   private fun instantToOffsetNotNull(instant: Instant?): OffsetDateTime {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralService.kt
@@ -33,13 +33,12 @@ class SASReferralService(
       }
 
       val status = when {
-        first.isDraft -> SASReferralStatus.DRAFT
         first.withdrawalReasonCode != null && first.withdrawalComments != null -> SASReferralStatus.WITHDRAWN
         first.concludedAt != null && first.endOfServiceReportId != null -> SASReferralStatus.COMPLETED
         else -> SASReferralStatus.LIVE
       }
 
-      val sentBy = if (!first.isDraft && first.sentByUserId != null) {
+      val sentBy = if (first.sentByUserId != null) {
         AuthUserDTO(
           username = first.sentByUserName ?: "",
           authSource = first.sentByAuthSource ?: "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SASReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/integration/SASReferralControllerIntegrationTest.kt
@@ -54,7 +54,7 @@ class SASReferralControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `returns 200 with DRAFT status for a draft-only referral with Accommodation category`() {
+  fun `returns 404 for a draft-only referral with Accommodation category`() {
     val token = createTokenWithRole("ROLE_SAS_RM__REFERRAL_RO")
     val accommodationCategory = setupAssistant.serviceCategories["Accommodation"]!!
     setupAssistant.createDraftReferral(
@@ -66,12 +66,7 @@ class SASReferralControllerIntegrationTest : IntegrationTestBase() {
       .uri("/sas-referral-details/X100002")
       .headers { it.setBearerAuth(token) }
       .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .jsonPath("$[0].status").isEqualTo("DRAFT")
-      .jsonPath("$[0].sentAt").doesNotExist()
-      .jsonPath("$[0].sentBy").doesNotExist()
-      .jsonPath("$[0].referral.createdAt").isNotEmpty
+      .expectStatus().isNotFound
   }
 
   @Test
@@ -127,14 +122,8 @@ class SASReferralControllerIntegrationTest : IntegrationTestBase() {
   @Test
   fun `returns multiple Accommodation referrals for the same CRN`() {
     val token = createTokenWithRole("ROLE_SAS_RM__REFERRAL_RO")
-    val accommodationCategory = setupAssistant.serviceCategories["Accommodation"]!!
-    // Sent referral – set Accommodation category
     withAccommodationCategory(setupAssistant.createSentReferral(serviceUserCRN = "X100005"))
-    // Draft-only referral (different UUID) – pass Accommodation category directly
-    setupAssistant.createDraftReferral(
-      serviceUserCRN = "X100005",
-      selectedServiceCategories = mutableSetOf(accommodationCategory),
-    )
+    withAccommodationCategory(setupAssistant.createSentReferral(serviceUserCRN = "X100005"))
 
     webTestClient.get()
       .uri("/sas-referral-details/X100005")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsinterventionsservice/service/SASReferralServiceTest.kt
@@ -35,7 +35,6 @@ internal class SASReferralServiceTest {
     subProviderName: String? = null,
   ) = SASReferralNativeData(
     referralId = referralId,
-    isDraft = false,
     sentAt = sentAt,
     concludedAt = concludedAt,
     withdrawalReasonCode = withdrawalReasonCode,
@@ -45,30 +44,6 @@ internal class SASReferralServiceTest {
     sentByAuthSource = sentByAuthSource,
     sentByUserName = sentByUserName,
     endOfServiceReportId = endOfServiceReportId,
-    primeProviderId = primeProviderId,
-    primeProviderName = primeProviderName,
-    subProviderId = subProviderId,
-    subProviderName = subProviderName,
-  )
-
-  private fun draftRow(
-    referralId: String = UUID.randomUUID().toString(),
-    primeProviderId: String = this.primeProviderId,
-    primeProviderName: String = this.primeProviderName,
-    subProviderId: String? = null,
-    subProviderName: String? = null,
-  ) = SASReferralNativeData(
-    referralId = referralId,
-    isDraft = true,
-    sentAt = null,
-    concludedAt = null,
-    withdrawalReasonCode = null,
-    withdrawalComments = null,
-    createdAt = Instant.now(),
-    sentByUserId = null,
-    sentByAuthSource = null,
-    sentByUserName = null,
-    endOfServiceReportId = null,
     primeProviderId = primeProviderId,
     primeProviderName = primeProviderName,
     subProviderId = subProviderId,
@@ -94,18 +69,6 @@ internal class SASReferralServiceTest {
     val result = sasReferralService.getReferralsByCrn(crn)
 
     assertThat(result).isEmpty()
-  }
-
-  @Test
-  fun `returns DRAFT status for a draft referral`() {
-    whenever(referralRepository.getSASReferralsByCrn(crn)).thenReturn(listOf(draftRow()))
-
-    val result = sasReferralService.getReferralsByCrn(crn)
-
-    assertThat(result).hasSize(1)
-    assertThat(result[0].status).isEqualTo(SASReferralStatus.DRAFT)
-    assertThat(result[0].sentAt).isNull()
-    assertThat(result[0].sentBy).isNull()
   }
 
   @Test
@@ -195,17 +158,5 @@ internal class SASReferralServiceTest {
 
     assertThat(result).hasSize(2)
     assertThat(result.map { it.status }).containsExactlyInAnyOrder(SASReferralStatus.LIVE, SASReferralStatus.COMPLETED)
-  }
-
-  @Test
-  fun `returns both sent and draft referrals for the same CRN`() {
-    val sentRow = sentRow()
-    val draftRow = draftRow()
-    whenever(referralRepository.getSASReferralsByCrn(crn)).thenReturn(listOf(sentRow, draftRow))
-
-    val result = sasReferralService.getReferralsByCrn(crn)
-
-    assertThat(result).hasSize(2)
-    assertThat(result.map { it.status }).containsExactlyInAnyOrder(SASReferralStatus.LIVE, SASReferralStatus.DRAFT)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

- not including draft referrals as part of SAS api response

## What is the intent behind these changes?

- This is done to resolve timeout issues and exposing Draft referrals is not of much value to the client
