### PR TITLE
Add draft-end-of-service-report url in ingress (modsec) exclude list

### DIFF
--- a/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
+++ b/helm_deploy/hmpps-interventions-service/templates/ingress-new.yaml
@@ -18,7 +18,7 @@ metadata:
       SecRuleUpdateActionById 959100 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50,setvar:tx.outbound_anomaly_score_threshold=50"
       # Condition Check if the request URI matches any of the specified patterns and remove the rule if it does
-      SecRule REQUEST_URI "@rx /(draft-action-plan|oasys-risk-information|case-note|action-plan|post-assessment-feedback|end-of-service-report/[^/]+/outcomes/[^/]+)" "id:1005,phase:1,nolog,pass,ctl:ruleRemoveById=949110"
+      SecRule REQUEST_URI "@rx /(draft-action-plan|oasys-risk-information|case-note|action-plan|post-assessment-feedback|end-of-service-report/[^/]+/outcomes/[^/]+|draft-end-of-service-report/[^/]+)" "id:1005,phase:1,nolog,pass,ctl:ruleRemoveById=949110"
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-interventions-dev"
     {{- else }}
     nginx.ingress.kubernetes.io/modsecurity-snippet: |


### PR DESCRIPTION
## What does this pull request do?

Update the Ingress / ModSecurity configuration to exclude the following URL from ModSecurity rules

/draft-end-of-service-report/{reportId}

## What is the intent behind these changes?

When user submitting a update for a EOSR with additional task comment to the application, the request is being blocked by ModSecurity at the Ingress layer and returns a 423 Locked status. The request never reaches the application. This is currently preventing users from completing the form submission.
After investigation, the block is caused by ModSecurity input validation rules incorrectly flagging the request payload for this particular endpoint.